### PR TITLE
Add agent-deep-links skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 ### Meta & Utilities
 
 - [brand-guidelines/](./brand-guidelines/) - Apply OpenAI/Codex brand colors and typography to artifacts.
+- [agent-deep-links/](./agent-deep-links/) - Build and validate deep links for Codex, Cursor, and VS Code with Slack-safe formatting and fallback guidance.
 - [canvas-design/](./canvas-design/) - Generate structured canvas layouts and design artifacts.
 - [image-enhancer/](./image-enhancer/) - Upscale and refine images with configurable presets.
 - [slack-gif-creator/](./slack-gif-creator/) - Generate GIFs for Slack with captions and styling.

--- a/agent-deep-links/SKILL.md
+++ b/agent-deep-links/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: agent-deep-links
+description: Build, validate, and troubleshoot deep links for Codex, Cursor, VS Code, Visual Studio, and similar tools. Use when users ask for clickable links (especially in Slack) that open threads, files, folders, or app settings.
+---
+
+# Agent Deep Links
+
+## Overview
+
+Use this skill when a user asks for clickable links that should open directly in an app (usually from Slack). This includes verifying whether a target app supports deep links at all, selecting the right URL shape, and providing fallbacks when deep links are unsupported.
+
+## Workflow
+
+1. Identify target app + target object:
+   - Thread/conversation
+   - File/folder
+   - Settings/new window
+2. Read `references/deep-link-matrix.md` for known-good link formats and support level.
+3. If support is unknown, verify locally before sending:
+   - Check URL schemes in the app bundle:
+     ```bash
+     /usr/libexec/PlistBuddy -c 'Print :CFBundleURLTypes' /Applications/<App>.app/Contents/Info.plist
+     ```
+   - Smoke test launch behavior:
+     ```bash
+     open '<scheme>://...'
+     ```
+4. Construct Slack-safe link syntax:
+   - `<url|label>`
+5. If unsupported or uncertain, send a fallback:
+   - Plain path + command
+   - Documented CLI open command
+   - Statement that no official deep-link format is known
+
+## Output Rules
+
+- Prefer absolute paths for file/folder links.
+- Keep labels short and action-oriented (`Open in Cursor`, `Open in Codex`).
+- Do not claim deep-link support unless it is in the matrix or just verified.
+- For uncertain app routes, clearly mark as inferred/experimental.
+
+## Common Templates
+
+- Codex thread:
+  - `<codex://threads/<thread-uuid>|Open in Codex>`
+- Cursor file:
+  - `<cursor://file/<absolute-path>:<line>:<column>|Open in Cursor>`
+- VS Code file:
+  - `<vscode://file/<absolute-path>:<line>:<column>|Open in VS Code>`
+- VS Code Insiders file:
+  - `<vscode-insiders://file/<absolute-path>:<line>:<column>|Open in VS Code Insiders>`
+
+Use `references/deep-link-matrix.md` for the full cross-app matrix and support notes.

--- a/agent-deep-links/agents/openai.yaml
+++ b/agent-deep-links/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Agent Deep Links"
+  short_description: "Build and verify app deep links for Slack and handoffs."
+  default_prompt: "Create or validate deep links for Codex/Cursor/VS Code and provide fallbacks for unsupported apps."

--- a/agent-deep-links/references/deep-link-matrix.md
+++ b/agent-deep-links/references/deep-link-matrix.md
@@ -1,0 +1,66 @@
+# Deep Link Matrix
+
+Last updated: 2026-02-10
+Scope: practical deep links for agent workflows, especially Slack handoff links.
+
+## Support Levels
+
+- `Supported`: Officially documented and/or repeatedly verified.
+- `Partial`: Works for some routes, but route coverage is incomplete.
+- `Unknown`: Scheme exists, but route behavior is not clearly documented.
+- `Not available`: No known official deep-link format.
+
+## Matrix
+
+| App | Scheme | Support | Known Link Patterns | Notes |
+| --- | --- | --- | --- | --- |
+| Codex Desktop | `codex://` | Supported | `codex://threads/<thread-uuid>`, `codex://threads/new`, `codex://settings` | Good for thread handoff links. |
+| Cursor | `cursor://` | Supported | `cursor://file/<absolute-path>:<line>:<column>`, `cursor://file/<absolute-folder-path>/` | Works well for file/folder open links. |
+| VS Code | `vscode://` | Supported | `vscode://file/<absolute-path>:<line>:<column>`, `vscode://file/<absolute-folder-path>/` | Requires VS Code installed on clicker machine. |
+| VS Code Insiders | `vscode-insiders://` | Supported | `vscode-insiders://file/<absolute-path>:<line>:<column>` | Insiders-specific scheme. |
+| Visual Studio (Windows IDE) | n/a | Not available | n/a | Use CLI fallback (`devenv /edit <path>`). |
+| Claude Desktop | `claude://` | Unknown | `claude://...` | Scheme registration exists, but stable public route list is unclear. |
+| Xcode | `xcode://` | Partial | `xcode://...` | Scheme exists; file-open route details are not well documented. |
+| CLI-only agents | n/a | Not available | n/a | No standard clickable deep-link protocol without custom handlers. |
+
+## Slack Format
+
+Slack clickable links must be formatted as:
+
+```text
+<url|label>
+```
+
+Examples:
+
+- `<codex://threads/123e4567-e89b-12d3-a456-426614174000|Open in Codex>`
+- `<cursor://file/<absolute-path>:<line>:<column>|Open in Cursor>`
+- `<vscode://file/<absolute-path>:<line>:<column>|Open in VS Code>`
+
+## Verification Commands
+
+Check app schemes:
+
+```bash
+/usr/libexec/PlistBuddy -c 'Print :CFBundleURLTypes' /Applications/<App>.app/Contents/Info.plist
+```
+
+Smoke test a deep link:
+
+```bash
+open '<scheme>://...'
+```
+
+## Fallback Patterns
+
+When no deep link exists:
+
+1. Provide the file path and app command (`devenv /edit`, `code`, etc.).
+2. State that no official deep-link format is known.
+3. Offer a supported alternative app link when possible.
+
+## Sources
+
+- Cursor deeplinks docs: https://cursor.com/docs/deeplinks
+- VS Code URL docs: https://code.visualstudio.com/docs/editor/command-line#_opening-vs-code-with-urls
+- Visual Studio CLI docs: https://learn.microsoft.com/en-us/visualstudio/ide/reference/devenv-command-line-switches?view=vs-2022


### PR DESCRIPTION
Adds a new Codex skill for cross-agent deep linking (Codex/Cursor/VS Code), Slack-safe link formatting, and support/fallback matrix guidance.

> Recreated from https://github.com/ComposioHQ/awesome-codex-skills/pull/2 (originally submitted from wrong account)