### PR TITLE
Add agentskill.sh to meta & utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [template-skill/](./template-skill/) - Starter template for building new skills.
 - [skill-installer/](./skill-installer/) - Helper scripts to install skills from curated lists or GitHub paths.
 - [skill-creator/](./skill-creator/) - Guidance for building effective Codex skills with progressive disclosure.
+- [agentskill.sh](https://agentskill.sh) - Browse and install 69,000+ AI agent skills for Codex, Claude Code, Cursor, Copilot, Windsurf, and 20+ AI tools.
 
 ## Using Skills in Codex
 


### PR DESCRIPTION
Adds [agentskill.sh](https://agentskill.sh) to the Meta & Utilities section.

agentskill.sh is a directory of 69,000+ AI agent skills with one-click install for Codex, Claude Code, Cursor, Copilot, Windsurf, and 20+ AI tools.