### PR TITLE
Add feishu-inout: Lark/Feishu docs, messaging, calendar & bitable skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [meeting-notes-and-actions/](./meeting-notes-and-actions/) - Turn meeting transcripts into summaries with decisions and owner-tagged action items.
 - [internal-comms/](./internal-comms/) - Craft internal announcements, updates, and stakeholder messaging.
 - [invoice-organizer/](./invoice-organizer/) - Normalize and extract invoice data for tracking and reporting.
+- [feishu-inout](https://github.com/joe960913/feishu-inout) - Lark/Feishu docs, messaging, calendar & bitable integration for AI coding agents. Zero dependencies, official MCP.
 - [notion-knowledge-capture/](./notion-knowledge-capture/) - Convert chats or notes into structured Notion pages with proper linking.
 - [notion-meeting-intelligence/](./notion-meeting-intelligence/) - Prepare meeting materials with Notion context plus Codex research.
 - [notion-research-documentation/](./notion-research-documentation/) - Synthesize multiple Notion sources into briefs, comparisons, or reports with citations.


### PR DESCRIPTION
## feishu-inout

One command to connect AI coding agents to Lark (Feishu) — docs, messaging, calendar, bitable.

- 📄 Read/write/search cloud documents (7 edit modes)
- 💬 Send/read/search messages (user identity, no bot needed)
- 📅 Create calendar events with auto video meeting
- 📊 CRUD bitable records
- 👥 Create groups and add members
- Zero dependencies, official MCP + Open API

**Repo:** https://github.com/joe960913/feishu-inout
**Install:** `npx skills add joe960913/feishu-inout`