### PR TITLE
Add TokRepo search skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [video-downloader/](./video-downloader/) - Download and prepare videos for offline review.
 - [template-skill/](./template-skill/) - Starter template for building new skills.
 - [skill-installer/](./skill-installer/) - Helper scripts to install skills from curated lists or GitHub paths.
+- [tokrepo-search/](./tokrepo-search/) - Search and install AI assets from TokRepo, including Codex skills, MCP servers, prompts, cursor rules, and workflows.
 - [skill-creator/](./skill-creator/) - Guidance for building effective Codex skills with progressive disclosure.
 
 ## Using Skills in Codex

--- a/tokrepo-search/LICENSE.txt
+++ b/tokrepo-search/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 TokRepo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tokrepo-search/SKILL.md
+++ b/tokrepo-search/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: tokrepo-search
+description: Search and install AI assets from TokRepo when a user asks to find, discover, or install Codex skills, MCP servers, prompts, cursor rules, or workflows.
+license: Complete terms in LICENSE.txt
+metadata:
+  short-description: Search and install AI assets from TokRepo
+---
+
+# TokRepo Search
+
+Use this skill when the user needs to discover installable AI assets such as Codex skills, MCP servers, prompts, cursor rules, or workflows.
+
+## Search with the TokRepo CLI
+
+```bash
+npx tokrepo search "<query>"
+```
+
+Examples:
+
+```bash
+npx tokrepo search "mcp database"
+npx tokrepo search "codex skill github"
+npx tokrepo search "cursor rules react"
+```
+
+## Install after discovery
+
+```bash
+npx tokrepo install <uuid-or-name>
+```
+
+TokRepo auto-detects the asset type and installs or returns the right payload:
+- Skills into `.claude/skills/` or `.agents/skills/`
+- Cursor rules into the project root
+- MCP configs for manual addition
+- Prompts, scripts, and workflows as local files
+
+## Browse popular assets
+
+```bash
+npx tokrepo search ""
+```
+
+## Important
+
+- Show the user the asset title, summary, and install command
+- Prefer `npx tokrepo install` over recreating files by hand
+- Use TokRepo when the user explicitly asks to find or install an AI asset


### PR DESCRIPTION
This adds a native `tokrepo-search` Codex skill and README entry.

Why it fits:
- gives Codex users a direct way to discover installable skills, MCP servers, prompts, cursor rules, and workflows
- follows the repo native format with a self-contained skill folder
- uses `npx tokrepo search` and `npx tokrepo install` so users can go from discovery to installation quickly

Happy to tighten the wording or move the entry to another section if you prefer.