### PR TITLE
Add SwarmVault skill

### DIFF
--- a/swarmvault/README.md
+++ b/swarmvault/README.md
@@ -1,0 +1,174 @@
+# SwarmVault Skill
+
+Use the SwarmVault skill when you want a local-first knowledge vault that compiles books, articles, notes, transcripts, chat exports, emails, calendars, datasets, spreadsheets, slide decks, screenshots, URLs, code, and research captures into durable markdown pages, a searchable graph, dashboards, and reviewable outputs on disk.
+
+SwarmVault is built on the [LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) pattern: keep a durable wiki between you and raw sources using a three-layer architecture (raw sources, wiki, schema). The LLM does the bookkeeping — cross-referencing, consistency, updating — while you curate sources and think about what they mean. SwarmVault turns that pattern into a local toolchain with graph navigation, search, review flows, automation, and optional provider-backed synthesis.
+
+## Install
+
+Install the skill from ClawHub:
+
+```bash
+clawhub install swarmvault
+```
+
+Install the CLI it depends on:
+
+```bash
+npm install -g @swarmvaultai/cli
+swarmvault --version
+swarmvault demo --no-serve
+swarmvault source add https://github.com/karpathy/micrograd
+swarmvault ingest ./meeting.srt --guide
+swarmvault ingest ./customer-call.mp3
+swarmvault ingest https://www.youtube.com/watch?v=dQw4w9WgXcQ
+swarmvault source session transcript-or-session-id
+```
+
+Requirements:
+
+- Node `>=24`
+- A working `swarmvault` or `vault` binary on `PATH`
+
+Update paths:
+
+```bash
+clawhub update swarmvault
+npm install -g @swarmvaultai/cli@latest
+```
+
+## When To Use This Skill
+
+- You want knowledge work to stay on disk instead of disappearing into chat history.
+- The repo already contains `swarmvault.config.json` or `swarmvault.schema.md`.
+- You want markdown wiki pages, graph artifacts, local search, approvals, candidates, and MCP exposure from the same workspace.
+- You want a save-first compile/query/review loop for source collections, codebases, or research material.
+- You want one workflow for mixed non-code material such as EPUBs, CSV/TSV files, XLSX workbooks, PPTX decks, transcripts, Slack exports, mailbox files, and calendar exports.
+
+## Quickstart
+
+```bash
+swarmvault init --obsidian --profile personal-research
+swarmvault init --obsidian --profile reader,timeline
+swarmvault demo --no-serve
+swarmvault source add ./exports/customer-call.srt --guide
+swarmvault source session file-customer-call-srt-12345678
+swarmvault source add https://github.com/karpathy/micrograd
+swarmvault ingest ./src --repo-root .
+swarmvault ingest ./customer-call.mp3
+swarmvault ingest https://www.youtube.com/watch?v=dQw4w9WgXcQ
+swarmvault add https://arxiv.org/abs/2401.12345
+swarmvault compile --max-tokens 120000
+swarmvault diff
+swarmvault query "What is the auth flow?"
+swarmvault graph blast ./src/index.ts
+swarmvault graph serve
+swarmvault graph export --report ./exports/report.html
+swarmvault graph export --obsidian ./exports/graph-vault
+swarmvault mcp
+```
+
+For the fastest scratch walkthrough of a local repo or docs tree, run `swarmvault scan ./path --no-serve`. It initializes the current directory as a vault, ingests that directory, compiles immediately, and leaves the graph viewer closed when you only need the generated artifacts.
+
+If you want the same zero-config walkthrough without supplying your own inputs first, run `swarmvault demo --no-serve`. It creates a temporary demo vault with bundled sources and compiles it immediately.
+
+For very large graphs, `swarmvault graph serve` and `swarmvault graph export --html` automatically start in overview mode. Add `--full` when you explicitly want the full canvas rendered. `graph export` also supports `--html-standalone`, `--json`, `--obsidian`, and `--canvas` when you need lighter sharing or Obsidian-native artifacts. `swarmvault diff` compares the current graph against the last committed graph so you can inspect graph-level changes after a compile.
+
+The default `heuristic` provider is a valid local/offline starting point. Add a model provider in `swarmvault.config.json` when you want richer synthesis quality or optional capabilities such as embeddings, vision, or image generation. The recommended fully-local setup is `ollama pull gemma4` wired up as the `compileProvider` and `queryProvider` (see the root README for the exact config block). Any supported provider works - OpenAI, Anthropic, Gemini, OpenRouter, Groq, Together, xAI, Cerebras, openai-compatible, or custom. Code files are always parsed locally via tree-sitter; only non-code text or image sources go to configured model providers.
+
+`swarmvault init --profile` accepts `default`, `personal-research`, or a comma-separated preset list such as `reader,timeline`. For a custom vault style, edit the `profile` block in `swarmvault.config.json` directly; `swarmvault.schema.md` stays the human-written intent layer. The `personal-research` preset also enables `profile.guidedIngestDefault` and `profile.deepLintDefault`, so guided ingest/source and lint flows are on by default until you opt out with `--no-guide` or `--no-deep`.
+
+For local semantic graph query without API keys, point `tasks.embeddingProvider` at an embedding-capable local backend such as Ollama, not `heuristic`.
+
+With an embedding-capable provider available, SwarmVault can also merge semantic page matches into local search by default. `tasks.embeddingProvider` is the explicit way to choose that backend, but SwarmVault can also fall back to a `queryProvider` with embeddings support. Set `search.rerank: true` when you want the configured `queryProvider` to rerank the merged top hits before answering.
+
+Audio file ingest uses `tasks.audioProvider` when you configure a provider with `audio` capability. YouTube transcript ingest works without a model provider. If you want to pin graph clustering instead of using the adaptive default, set `graph.communityResolution` in `swarmvault.config.json`.
+
+`swarmvault lint --deep --web` augments deep-lint findings with external evidence from a configured `webSearch` adapter. Web search is currently scoped to deep lint; compile, query, and explore stay on local vault state plus your configured LLM providers.
+
+When the vault lives inside a git repo, `ingest`, `compile`, and `query` also accept `--commit` so generated `wiki/` and `state/` changes can be committed immediately. `compile --max-tokens <n>` trims lower-priority pages when you need bounded wiki output for a tighter context window.
+
+Source-scoped artifacts are intentionally split by role:
+
+| Artifact | Created by | Purpose |
+|----------|-----------|---------|
+| Source brief | `source add`, `ingest` (always) | Auto summary written to `wiki/outputs/source-briefs/` |
+| Source review | `source review`, `source add --guide`, `ingest --review`, `ingest --guide` | Lighter staged assessment in `wiki/outputs/source-reviews/` |
+| Source guide | `source guide`, `source add --guide`, `ingest --guide` | Guided walkthrough with approval-bundled updates in `wiki/outputs/source-guides/` |
+| Source session | `source session`, `source add --guide`, `ingest --guide` | Resumable workflow state in `wiki/outputs/source-sessions/` and `state/source-sessions/` |
+
+Supported non-code ingest includes `.pdf`, the full Word family (`.docx`, `.docm`, `.dotx`, `.dotm`), `.rtf`, `.odt`, `.odp`, `.ods`, `.epub`, `.csv`, `.tsv`, the full Excel family (`.xlsx`, `.xlsm`, `.xlsb`, `.xls`, `.xltx`, `.xltm`), the full PowerPoint family (`.pptx`, `.pptm`, `.potx`, `.potm`), `.ipynb` (Jupyter notebooks), `.bib` (BibTeX), `.org` (Org-mode), `.adoc`/`.asciidoc`, `.srt`, `.vtt`, Slack exports, `.eml`, `.mbox`, `.ics`, audio files (`.mp3`, `.wav`, `.m4a`, `.aac`, `.ogg`, `.webm`, and other `audio/*` inputs) through `tasks.audioProvider`, direct YouTube transcript URLs, images (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.bmp`, `.tif`, `.tiff`, `.svg`, `.ico`, `.heic`, `.heif`, `.avif`, `.jxl`), markdown/MDX/text notes, structured config/data (`.json`, `.jsonc`, `.json5`, `.yaml`, `.toml`, `.xml`, `.ini`, `.conf`, `.cfg`, `.env`, `.properties`) with schema hints, common developer manifests (`package.json`, `tsconfig.json`, `Cargo.toml`, `pyproject.toml`, `go.mod`, `go.sum`, `Dockerfile`, `Makefile`, `LICENSE`, `.gitignore`, `.editorconfig`, and similar) via content-sniffed text ingest so they are never silently dropped, browser clips, and research URLs captured through `swarmvault add`.
+
+Supported code ingest covers `.js`, `.mjs`, `.cjs`, `.jsx`, `.ts`, `.mts`, `.cts`, `.tsx`, `.sh`, `.bash`, `.zsh`, `.py`, `.go`, `.rs`, `.java`, `.kt`, `.kts`, `.scala`, `.sc`, `.dart`, `.lua`, `.zig`, `.cs`, `.c`, `.cc`, `.cpp`, `.cxx`, `.h`, `.hh`, `.hpp`, `.hxx`, `.php`, `.rb`, `.ps1`, `.psm1`, `.psd1`, `.ex`, `.exs`, `.ml`, `.mli`, `.m`, `.mm`, `.res`, `.resi`, `.sol`, `.vue`, `.css`, `.html`, `.htm`, plus extensionless executable scripts with `#!/usr/bin/env node|python|ruby|bash|zsh` shebangs. Each language goes through a tree-sitter AST walk to extract symbols, imports, and local module references.
+
+## What The Skill Package Includes
+
+- `SKILL.md` - operational instructions for the model
+- [`examples/quickstart.md`](examples/quickstart.md) - first-run setup flow
+- [`examples/repo-workflow.md`](examples/repo-workflow.md) - repo ingest, compile, review, and graph workflow
+- [`examples/research-workflow.md`](examples/research-workflow.md) - research capture and query workflow
+- [`references/commands.md`](references/commands.md) - high-signal command cheat sheet
+- [`references/artifacts.md`](references/artifacts.md) - what shows up under `raw/`, `wiki/`, and `state/`
+- [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md) - common setup and runtime fixes
+- [`validation/smoke-prompts.md`](validation/smoke-prompts.md) - release-validation prompts and expected outcomes
+
+The published ClawHub package is intentionally text-only in this release.
+
+## Core Workflow
+
+1. Initialize the vault with `swarmvault init`.
+2. Treat `swarmvault.schema.md` as the vault contract before serious compile or query work.
+3. Use `swarmvault source add` when the input is a recurring local file, local directory, public GitHub repo root, or docs hub that should stay registered.
+4. Add one-off material with `swarmvault ingest`, `swarmvault add`, or `swarmvault inbox import`.
+5. Use `swarmvault ingest --guide`, `swarmvault source add --guide`, `swarmvault source reload --guide`, `swarmvault source guide <id>`, or `swarmvault source session <id>` when you want the stronger guided-session workflow. Set `profile.guidedIngestDefault: true` when guided mode should be the default for ingest/source commands, and use `--no-guide` to force the lighter path for a specific run. Profiles using `guidedSessionMode: "canonical_review"` stage approval-queued canonical page edits; `insights_only` profiles keep exploratory synthesis under `wiki/insights/`.
+6. Compile with `swarmvault compile`, use `compile --max-tokens <n>` when the generated wiki must fit a bounded context window, or use `compile --approve` when the change should land in the approval queue first.
+7. Inspect `wiki/`, `wiki/dashboards/`, and `state/` artifacts before broad re-search. When the vault lives inside git, `ingest|compile|query --commit` can commit those artifacts immediately after the run.
+8. Use `swarmvault query`, `swarmvault explore`, `swarmvault review`, `swarmvault candidate`, and `swarmvault lint` to keep the vault current and reviewable. Set `profile.deepLintDefault: true` when `lint` should run the advisory deep pass by default, and use `--no-deep` to force a structural-only run.
+9. Use `swarmvault graph blast` for reverse-import impact checks, `swarmvault graph serve` for the live workspace plus bookmarklet clipper, `swarmvault graph export --report` for a self-contained HTML report, `swarmvault graph export` for other shareable formats, `swarmvault graph push neo4j`, or `swarmvault mcp` when the vault needs to be explored or shared elsewhere.
+
+## What SwarmVault Writes
+
+- `raw/sources/` and `raw/assets/` for canonical input storage
+- `wiki/` for compiled source, concept, entity, code, graph, and output pages
+- `wiki/outputs/source-briefs/` for recurring-source onboarding briefs
+- `wiki/outputs/source-sessions/` for resumable guided session anchors
+- `wiki/outputs/source-reviews/` for staged source-scoped review artifacts
+- `wiki/outputs/source-guides/` for guided source integration artifacts
+- `wiki/dashboards/` for recent sources, reading log, timeline, source sessions, source guides, research map, contradictions, and open questions
+- `wiki/candidates/` for staged concept/entity pages
+- `state/graph.json` for the compiled graph
+- `state/search.sqlite` for local search
+- `state/sources.json` plus `state/sources/<id>/` for managed-source registry state and working sync data
+- `state/approvals/` for compile approval bundles
+- `state/sessions/` and `state/jobs.ndjson` for saved run history
+
+Generated guided artifacts and dashboards also carry Dataview-friendly fields such as `profile_presets`, `session_status`, `question_state`, `canonical_targets`, and `evidence_state` when you enable `profile.dataviewBlocks`.
+
+## Agent And MCP Integration
+
+Supported agent installs:
+
+- `swarmvault install --agent codex`
+- `swarmvault install --agent claude --hook`
+- `swarmvault install --agent cursor`
+- `swarmvault install --agent gemini --hook`
+- `swarmvault install --agent opencode --hook`
+- `swarmvault install --agent aider`
+- `swarmvault install --agent copilot --hook`
+- `swarmvault install --agent trae`
+- `swarmvault install --agent claw`
+- `swarmvault install --agent droid`
+
+Expose the vault over MCP with:
+
+```bash
+swarmvault mcp
+```
+
+## Links
+
+- Docs: https://www.swarmvault.ai/docs
+- Providers: https://www.swarmvault.ai/docs/providers
+- Troubleshooting: https://www.swarmvault.ai/docs/getting-started/troubleshooting
+- npm: https://www.npmjs.com/package/@swarmvaultai/cli
+- GitHub: https://github.com/swarmclawai/swarmvault

--- a/swarmvault/SKILL.md
+++ b/swarmvault/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: swarmvault
+description: "Use SwarmVault when the user needs a local-first knowledge vault that writes durable markdown, graph, search, dashboard, review, and MCP artifacts to disk from books, notes, transcripts, exports, datasets, slide decks, files, URLs, code, and recurring source workflows."
+version: "0.7.30"
+metadata: '{"openclaw":{"requires":{"anyBins":["swarmvault","vault"]},"install":[{"id":"node","kind":"node","package":"@swarmvaultai/cli","bins":["swarmvault","vault"],"label":"Install SwarmVault CLI (npm)"}],"emoji":"🗃️","homepage":"https://www.swarmvault.ai/docs"}}'
+---
+
+# SwarmVault
+
+Use this skill when the user wants a local-first knowledge vault built on the [LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) pattern — three layers (raw sources, wiki, schema) where the LLM maintains a durable wiki between you and raw sources. Also use it when the project already contains `swarmvault.config.json` or `swarmvault.schema.md`.
+
+For onboarding, examples, command references, or troubleshooting, read the bundled `README.md`, `examples/`, `references/`, and `TROUBLESHOOTING.md` before improvising workflow advice.
+
+## Quick checks
+
+- Work from the vault root.
+- If the vault does not exist yet, run `swarmvault init`.
+- Use `swarmvault demo --no-serve` when the user wants the fastest zero-config walkthrough before pointing SwarmVault at their own sources.
+- Use `swarmvault scan <directory> --no-serve` when the user wants the fastest scratch pass over a local repo or docs tree without manually stepping through init + ingest + compile first.
+- Read `swarmvault.schema.md` before compile or query work. It is the vault's operating contract.
+- If `wiki/graph/report.md` exists, use it before broad repo search.
+
+## Core loop
+
+1. Initialize a vault with `swarmvault init` when needed.
+2. Update `swarmvault.schema.md` before a serious compile. Use it for naming rules, categories, grounding, freshness expectations, and exclusions.
+3. Use `swarmvault source add <input>` when the input is a recurring local file, local directory, public GitHub repo root, or docs hub that should stay registered.
+4. Ingest one-off inputs with `swarmvault ingest <path-or-url>`, or ingest a whole repo tree with `swarmvault ingest <directory>`. Audio files use `tasks.audioProvider` when configured, and supported YouTube URLs go through direct transcript capture instead of generic URL ingest.
+5. Use `swarmvault ingest --guide`, `swarmvault source add --guide`, `swarmvault source reload --guide`, `swarmvault source guide <id>`, or `swarmvault source session <id>` when the human should integrate one source at a time before canonical pages change. Set `profile.guidedIngestDefault: true` in `swarmvault.config.json` to make guided mode the default; use `--no-guide` to override. Profiles using `guidedSessionMode: "canonical_review"` stage approval-queued canonical edits; `insights_only` profiles keep exploratory synthesis in `wiki/insights/`. Use `--review` only for the lighter review-only path.
+6. Use `swarmvault inbox import` for capture-style batches, then `swarmvault watch --lint --repo` when the workflow should stay automated. Add `--code-only` when the refresh should stay AST-only and defer non-code semantic re-analysis to a later `compile`. On tracked repos, code-only changes take that faster compile path automatically. Install `swarmvault hook install` when git checkouts and commits should trigger the same repo-aware code-only refresh automatically.
+7. Compile with `swarmvault compile`, use `compile --max-tokens <n>` when the generated wiki must stay inside a bounded context budget, or use `compile --approve` when changes should go through the local review queue first.
+8. Resolve staged work with `swarmvault review list|show|accept|reject` and `swarmvault candidate list|promote|archive`.
+9. Ask questions with `swarmvault query "<question>"`. It saves durable answers into `wiki/outputs/` by default; add `--no-save` only for ephemeral checks. When an embedding provider is configured, query can merge semantic page matches into local search; `search.rerank: true` lets the current `queryProvider` rerank the merged top hits before answering.
+10. Use `swarmvault explore "<question>" --steps <n>` for save-first multi-step research loops, or `--format report|slides|chart|image` when the artifact should be presentation-oriented.
+11. Run `swarmvault lint` whenever the schema changed, artifacts look stale, or compile/query results drift. Set `profile.deepLintDefault: true` in `swarmvault.config.json` when the advisory deep-lint pass should be the default, and use `--no-deep` when you need a structural-only run. Add `--web` only when deep lint is enabled and a `webSearch.tasks.deepLintProvider` adapter is configured; web evidence is scoped to deep lint and does not change compile or query behavior.
+12. Use `swarmvault mcp` when another agent or tool should browse, search, and query the vault through MCP.
+13. Use `swarmvault graph blast <target>` when the user wants reverse-import impact analysis, `swarmvault graph serve` when the live workspace or bookmarklet clipper will help, `swarmvault diff` when they need a graph-level change summary against the last committed baseline, or `swarmvault graph export --html <output>` / `graph export --report <output>` when sharing will help. `graph export` also supports `--html-standalone`, `--json`, `--obsidian`, and `--canvas` for lighter or Obsidian-native sharing.
+
+## Working rules
+
+- Prefer changing the schema before re-running compile when organization or grounding is wrong.
+- Treat `wiki/` and `state/` as first-class outputs. Inspect them instead of trusting a single chat answer.
+- Prefer `wiki/graph/report.md`, `state/graph.json`, and saved wiki pages over ad hoc broad search when they already exist.
+- Use `source add` for recurring files, directories, public GitHub repo roots, and docs hubs. Use `ingest` and `add` for deliberate one-off inputs.
+- When the vault lives in a git repo, `ingest|compile|query --commit` can commit `wiki/` and `state/` changes immediately after the run.
+- The default heuristic provider is a valid local/offline starting point. Add a model provider only when the user wants richer synthesis quality or optional capabilities such as embeddings, vision, image generation, or audio transcription. The recommended fully-local setup is Ollama + Gemma: `ollama pull gemma4` then set `providers.llm` to `{ type: "ollama", model: "gemma4" }` and point `tasks.compileProvider`, `tasks.queryProvider`, and `tasks.lintProvider` at it.
+- Audio ingest needs `tasks.audioProvider` to resolve to a provider that exposes `audio` capability. YouTube transcript ingest does not need a provider. Set `graph.communityResolution` when the user wants to pin community clustering instead of using the adaptive default.
+- If an OpenAI-compatible backend cannot satisfy structured generation, reduce its declared capabilities instead of forcing every task through it.
+- Keep raw sources immutable. Put corrections in schema, new sources, or saved outputs rather than manually rewriting generated provenance.
+
+## Files and artifacts
+
+- `swarmvault.schema.md`: vault-specific compile and query rules.
+- `raw/sources/` and `raw/assets/`: canonical source storage.
+- `wiki/`: generated pages plus saved outputs.
+- `wiki/outputs/source-briefs/`: saved onboarding briefs for managed sources.
+- `wiki/outputs/source-sessions/`: resumable guided-session anchors plus question/answer history for one-source-at-a-time integration.
+- `wiki/outputs/source-reviews/`: staged source-scoped review pages.
+- `wiki/outputs/source-guides/`: staged source-integration guides for one-source-at-a-time workflows.
+- `wiki/dashboards/`: recent sources, reading log, timeline, source sessions, source guides, research map, contradiction, and open-question dashboards.
+- `wiki/code/`: module pages for ingested JavaScript, JSX, TypeScript (including `.mts`/`.cts`), TSX, Bash/shell script (with shebang-based detection for extensionless scripts), Python, Go, Rust, Java, Kotlin, Scala, Dart, Lua, Zig, C#, C, C++ (including `.c`/`.cc`/`.cpp`/`.cxx` and `.h`/`.hh`/`.hpp`/`.hxx`), PHP, Ruby, PowerShell (`.ps1`/`.psm1`/`.psd1`), Elixir (`.ex`/`.exs`), OCaml (`.ml`/`.mli`), Objective-C (`.m`/`.mm`), ReScript (`.res`/`.resi`), Solidity (`.sol`), Vue single-file components (`.vue`), HTML (`.html`/`.htm`), and CSS sources.
+- `state/extracts/`: extracted markdown and JSON sidecars for PDF, the full Word family (`.docx`/`.docm`/`.dotx`/`.dotm`), RTF (`.rtf`), OpenDocument (ODT/ODP/ODS), EPUB, CSV/TSV, the full Excel family (`.xlsx`/`.xlsm`/`.xlsb`/`.xls`/`.xltx`/`.xltm`), the full PowerPoint family (`.pptx`/`.pptm`/`.potx`/`.potm`), Jupyter notebooks (`.ipynb`), BibTeX (`.bib`), Org-mode (`.org`), AsciiDoc (`.adoc`/`.asciidoc`), transcripts, Slack exports, email, calendar, audio transcripts, YouTube transcript captures, and image sources (`.png`/`.jpg`/`.jpeg`/`.gif`/`.webp`/`.bmp`/`.tif`/`.tiff`/`.svg`/`.ico`/`.heic`/`.heif`/`.avif`/`.jxl`), plus structured previews for config/data files (JSON/JSONC/JSON5/TOML/YAML/XML/INI/ENV/PROPERTIES/CFG/CONF) and content-sniffed text ingest for developer manifests (`package.json`, `Cargo.toml`, `go.mod`, `LICENSE`, `.gitignore`, `Dockerfile`, `Makefile`, and similar plaintext files).
+- `state/code-index.json`: repo-aware code aliases and local import resolution data.
+- `wiki/projects/`: project rollups over canonical pages.
+- `wiki/candidates/`: staged concept and entity pages awaiting promotion.
+- `state/graph.json`: compiled graph.
+- `state/search.sqlite`: local search index.
+- `state/sources.json` and `state/sources/<id>/`: managed-source registry entries plus working sync state.
+- `state/approvals/`: staged review bundles from `compile --approve`.
+- `state/sessions/`: canonical session artifacts for compile, query, explore, lint, watch, review, and candidate actions.
+- `state/jobs.ndjson`: watch-mode run log.
+
+## Agent integration
+
+- `swarmvault install --agent codex|claude|cursor|goose|pi|gemini|opencode|aider|copilot|trae|claw|droid` installs agent-specific rules into the current project.
+- `swarmvault install --agent claude|opencode|gemini|copilot --hook` installs graph-first hook or plugin support for the agents that expose project hook APIs.
+- `swarmvault install --agent aider` installs `CONVENTIONS.md` and wires `.aider.conf.yml` to read it when that config is valid YAML.
+- `swarmvault mcp` exposes tools and resources for page search, page reads, source listing, query, ingest, compile, and lint.
+
+## Defaults to preserve
+
+- Keep raw source material immutable under `raw/`.
+- Save useful answers unless the user explicitly wants ephemeral output.
+- Prefer reviewable flows such as `compile --approve`, `review`, and `candidate` when a change should not activate silently.
+- Treat provider setup as part of serious vault operation. If only `heuristic` is configured, say so clearly.
+- When a vault uses the `profile` block in `swarmvault.config.json`, respect it as the deterministic behavior layer. `swarmvault.schema.md` still defines the human intent layer.

--- a/swarmvault/TROUBLESHOOTING.md
+++ b/swarmvault/TROUBLESHOOTING.md
@@ -1,0 +1,109 @@
+# Troubleshooting
+
+## `swarmvault` command not found
+
+The ClawHub skill does not bundle the CLI binary by itself. Install the published package and verify it:
+
+```bash
+npm install -g @swarmvaultai/cli
+swarmvault --version
+```
+
+If the binary still is not found, check that npm's global bin directory is on `PATH`.
+
+## Node version too old
+
+SwarmVault requires Node `>=24`.
+
+```bash
+node --version
+```
+
+Upgrade Node before troubleshooting provider or compile behavior.
+
+## The vault compiles, but quality is weak
+
+Check whether the vault is still using the built-in `heuristic` provider. That is a valid local/offline default, but its synthesis is intentionally lighter. Add a model provider in `swarmvault.config.json` when you want richer synthesis quality or optional capabilities such as embeddings, vision, or image generation.
+
+For local semantic graph query, `embeddingProvider` must point at an embedding-capable backend such as `ollama` or another OpenAI-compatible embeddings service. The built-in `heuristic` provider does not generate embeddings.
+
+## Audio files ingest, but no transcript appears
+
+Audio ingest needs `tasks.audioProvider` to point at a provider with `audio` capability. Without that, SwarmVault still ingests the source and records an extraction warning instead of failing the whole run.
+
+YouTube transcript ingest does not need a model provider, but it can still fail when the video has no accessible captions or the upstream transcript fetch path is unavailable.
+
+## Source reviews or dashboards did not appear
+
+If you expected a source-scoped guide or review page, use one of these flows:
+
+```bash
+swarmvault ingest <input> --guide
+swarmvault source add <input> --guide
+swarmvault source session <source-id-or-session-id>
+```
+
+Then verify:
+
+- `wiki/outputs/source-briefs/`
+- `wiki/outputs/source-sessions/`
+- `wiki/outputs/source-guides/`
+- `wiki/dashboards/index.md`
+- `wiki/dashboards/timeline.md`
+- `wiki/dashboards/source-sessions.md`
+- `wiki/dashboards/source-guides.md`
+- `state/approvals/`
+
+## `wiki/graph/report.md` or search artifacts are missing
+
+Run:
+
+```bash
+swarmvault compile
+```
+
+Then verify:
+
+- `wiki/graph/report.md`
+- `state/graph.json`
+- `state/search.sqlite`
+
+If the vault lives inside git and you want a quick graph-level delta, run `swarmvault diff`.
+
+## Agent install or hooks seem stale
+
+Re-run the relevant install command in the project root:
+
+```bash
+swarmvault install --agent claude --hook
+swarmvault install --agent gemini --hook
+swarmvault install --agent opencode --hook
+swarmvault install --agent copilot --hook
+```
+
+For Aider:
+
+```bash
+swarmvault install --agent aider
+```
+
+## Update paths
+
+Update the skill:
+
+```bash
+clawhub update swarmvault
+```
+
+Update the CLI:
+
+```bash
+npm install -g @swarmvaultai/cli@latest
+```
+
+## More Help
+
+- Docs: https://www.swarmvault.ai/docs
+- Providers: https://www.swarmvault.ai/docs/providers
+- Web troubleshooting: https://www.swarmvault.ai/docs/getting-started/troubleshooting
+- GitHub issues: https://github.com/swarmclawai/swarmvault/issues

--- a/swarmvault/examples/quickstart.md
+++ b/swarmvault/examples/quickstart.md
@@ -1,0 +1,36 @@
+# Quickstart Example
+
+Use this when the user needs the shortest path from install to a working vault.
+
+## Commands
+
+```bash
+npm install -g @swarmvaultai/cli
+swarmvault demo --no-serve
+swarmvault init --obsidian
+swarmvault scan ./repo --no-serve
+swarmvault source add https://github.com/karpathy/micrograd
+swarmvault diff
+swarmvault graph blast ./src/index.ts
+swarmvault query "What are the key concepts?"
+swarmvault graph serve
+swarmvault graph export --report ./graph-report.html
+```
+
+## What To Check
+
+- `swarmvault.schema.md` exists and reflects the vault contract
+- `demo --no-serve` leaves a temporary compiled vault behind even on a clean machine
+- `scan --no-serve` leaves a compiled vault behind even when the viewer is not launched
+- `state/sources.json` contains the managed source registry entry
+- `wiki/graph/report.md` exists after compile
+- `graph export --report` writes a shareable HTML report when the user wants a lighter artifact than the full workspace
+- `wiki/outputs/source-briefs/` contains a source brief
+- `wiki/outputs/` contains the saved query answer
+- `state/graph.json` and `state/search.sqlite` exist
+
+## Guidance
+
+- If the answer quality is weak, check whether the vault is still on the `heuristic` provider.
+- If the user is unsure what changed, point them at `wiki/` and `state/` before suggesting another compile.
+- When the vault lives in git, `swarmvault diff` is the quickest graph-level summary of what the last compile changed.

--- a/swarmvault/examples/repo-workflow.md
+++ b/swarmvault/examples/repo-workflow.md
@@ -1,0 +1,32 @@
+# Repo Workflow Example
+
+Use this when the user wants to compile a codebase into durable module pages, graph artifacts, and reviewable outputs.
+
+## Commands
+
+```bash
+swarmvault init --obsidian
+swarmvault source add https://github.com/karpathy/micrograd
+swarmvault compile --approve
+swarmvault diff
+swarmvault review list
+swarmvault review show <approval-id> --diff
+swarmvault review accept <approval-id>
+swarmvault query "What is the auth flow?"
+swarmvault graph serve
+```
+
+## What To Check
+
+- `wiki/code/` contains module pages
+- `wiki/outputs/source-briefs/` contains a repo onboarding brief
+- `state/code-index.json` exists for repo-aware symbol/import resolution
+- `swarmvault diff` reflects the graph-level additions and removals when the vault is inside git
+- `state/approvals/` contains staged review bundles when `--approve` is used
+- `wiki/graph/report.md` highlights the important modules, bridge nodes, and contradictions
+
+## Guidance
+
+- Prefer reading `wiki/graph/report.md` and the relevant `wiki/code/*.md` pages before broad grep.
+- If organization is wrong, update `swarmvault.schema.md` first instead of hand-editing generated pages.
+- Use `swarmvault watch --lint --repo` plus `swarmvault hook install` when the repo should stay current automatically.

--- a/swarmvault/examples/research-workflow.md
+++ b/swarmvault/examples/research-workflow.md
@@ -1,0 +1,36 @@
+# Research Workflow Example
+
+Use this when the user is collecting papers, articles, books, datasets, slide decks, screenshots, or other mixed research sources into one vault.
+
+## Commands
+
+```bash
+swarmvault init
+swarmvault add https://arxiv.org/abs/2401.12345
+swarmvault add 10.1145/1234567.1234568
+swarmvault ingest ./paper.pdf
+swarmvault ingest ./interview.mp3
+swarmvault ingest https://www.youtube.com/watch?v=dQw4w9WgXcQ
+swarmvault ingest ./book.epub
+swarmvault ingest ./results.csv
+swarmvault ingest ./analysis.xlsx
+swarmvault ingest ./deck.pptx
+swarmvault inbox import ./capture-bundle
+swarmvault compile
+swarmvault query "What are the main claims and conflicts?"
+swarmvault explore "What should I read next?" --steps 3
+```
+
+## What To Check
+
+- `raw/sources/` contains normalized markdown captures for `add`
+- `state/extracts/` contains PDF, DOCX, EPUB, CSV/TSV, XLSX, PPTX, audio, YouTube, or image extraction sidecars when relevant
+- `wiki/graph/report.md` surfaces contradictions, surprise links, and benchmark data
+- `wiki/outputs/` contains saved query and explore outputs
+
+## Guidance
+
+- Use `swarmvault add` for research URLs and `swarmvault ingest` for direct local files.
+- If image extraction is weak, verify that a real `visionProvider` is configured.
+- If audio extraction is missing, verify that `tasks.audioProvider` points at a provider with `audio` capability.
+- Use `lint --conflicts` when the user specifically wants contradiction review.

--- a/swarmvault/references/artifacts.md
+++ b/swarmvault/references/artifacts.md
@@ -1,0 +1,44 @@
+# Artifact Reference
+
+SwarmVault is save-first. The files on disk are the product.
+
+## Canonical Inputs
+
+- `swarmvault.schema.md` - vault instructions, naming rules, exclusions, freshness rules
+- `raw/sources/` - immutable canonical sources
+- `raw/assets/` - localized remote or imported assets
+- `state/sources.json` - managed-source registry for recurring directories, public repos, and docs hubs
+- `state/sources/<id>/` - managed-source working state such as shallow checkouts and crawl metadata
+
+## Compiled Knowledge
+
+- `wiki/sources/` - source pages
+- `wiki/concepts/` and `wiki/entities/` - promoted canonical pages
+- `wiki/code/` - parser-backed module pages
+- `wiki/projects/` - project rollups
+- `wiki/outputs/` - saved query and explore outputs
+- `wiki/outputs/source-briefs/` - source-scoped onboarding briefs for managed sources
+- `wiki/outputs/source-reviews/` - source-scoped review pages staged through approvals
+- `wiki/outputs/source-guides/` - guided source-integration pages that stage broader wiki updates for review
+- `wiki/outputs/source-sessions/` - resumable guided-session anchors plus question and answer state
+- `wiki/dashboards/` - recent sources, timeline, contradiction, and open-question dashboards
+- `wiki/candidates/` - staged concept/entity pages
+- `wiki/graph/report.md` - trust and orientation report
+
+## State And Review
+
+- `state/graph.json` - compiled graph artifact
+- `state/search.sqlite` - local full-text index
+- `state/code-index.json` - repo-aware symbol/import index
+- `state/extracts/` - extraction markdown and JSON sidecars for PDF, the full Word family, RTF, OpenDocument, EPUB, CSV/TSV, the full Excel family, the full PowerPoint family, Jupyter notebooks, BibTeX, Org-mode, AsciiDoc, transcript, Slack export, email, calendar, audio transcripts, YouTube transcript captures, structured config/data previews, and image sources
+- `state/approvals/` - review bundles from `compile --approve`
+- `state/benchmark.json` - latest benchmark/trust artifact
+- `state/watch/` - pending semantic refresh and watch status artifacts
+- `state/sessions/` - saved compile/query/explore/lint/watch history
+- `state/jobs.ndjson` - watch run log
+
+## How To Use These
+
+- Read generated pages before re-asking the same question.
+- Use report and approval artifacts to explain what changed.
+- Prefer schema edits or new sources over editing generated provenance directly.

--- a/swarmvault/references/commands.md
+++ b/swarmvault/references/commands.md
@@ -1,0 +1,92 @@
+# Command Reference
+
+## Setup
+
+```bash
+swarmvault demo --no-serve
+swarmvault init
+swarmvault init --obsidian --profile personal-research
+swarmvault init --obsidian --profile reader,timeline
+swarmvault scan ./apps/api --no-serve
+swarmvault --version
+```
+
+## Ingest and Capture
+
+```bash
+swarmvault source add https://github.com/karpathy/micrograd
+swarmvault source add ./exports/customer-call.srt --guide
+swarmvault source session <source-id-or-session-id>
+swarmvault source list
+swarmvault source reload --all
+swarmvault source review <source-id>
+swarmvault source guide <source-id>
+swarmvault source delete <source-id>
+swarmvault ingest <path-or-url>
+swarmvault ingest ./customer-call.mp3
+swarmvault ingest https://www.youtube.com/watch?v=dQw4w9WgXcQ
+swarmvault ingest <path-or-url> --commit
+swarmvault ingest <path-or-url> --guide
+swarmvault ingest <directory> --repo-root .
+swarmvault add <url-or-doi-or-arxiv-id>
+swarmvault inbox import <path>
+```
+
+## Compile, Query, Review
+
+```bash
+swarmvault compile
+swarmvault compile --max-tokens 120000
+swarmvault compile --approve
+swarmvault diff
+swarmvault query "<question>"
+swarmvault query "<question>" --commit
+swarmvault explore "<question>" --steps 3
+swarmvault lint
+swarmvault lint --conflicts
+swarmvault review list
+swarmvault review show <approval-id> --diff
+swarmvault review accept <approval-id>
+swarmvault candidate list
+```
+
+## Graph and Sharing
+
+```bash
+swarmvault graph serve
+swarmvault graph serve --full
+swarmvault graph blast ./src/index.ts
+swarmvault graph export --html ./graph.html
+swarmvault graph export --report ./graph-report.html
+swarmvault graph export --html ./graph.html --full
+swarmvault graph export --html-standalone ./graph-standalone.html
+swarmvault graph export --json ./graph.json --canvas ./graph.canvas
+swarmvault graph export --obsidian ./graph-vault
+swarmvault graph push neo4j --dry-run
+swarmvault mcp
+```
+
+## Automation
+
+```bash
+swarmvault watch --lint --repo
+swarmvault watch --repo --code-only --once
+swarmvault watch status
+swarmvault hook install
+swarmvault schedule list
+swarmvault schedule run <job-id>
+```
+
+## Agent Installs
+
+```bash
+swarmvault install --agent codex
+swarmvault install --agent claude --hook
+swarmvault install --agent gemini --hook
+swarmvault install --agent opencode --hook
+swarmvault install --agent aider
+swarmvault install --agent copilot --hook
+swarmvault install --agent trae
+swarmvault install --agent claw
+swarmvault install --agent droid
+```

--- a/swarmvault/validation/smoke-prompts.md
+++ b/swarmvault/validation/smoke-prompts.md
@@ -1,0 +1,84 @@
+# Smoke Prompts
+
+These prompts are the human-readable validation set for the ClawHub skill and the installed-package release flow.
+
+## First-run prompt
+
+Prompt:
+
+> Set up a SwarmVault workspace for this repo and explain what files I should inspect first.
+
+Expected shape:
+
+- initializes or confirms the vault
+- may use `swarmvault demo --no-serve` for the fastest zero-config walkthrough
+- may use `swarmvault scan <directory> --no-serve` when the task is a quick local repo walkthrough
+- points at `swarmvault.schema.md`
+- mentions `wiki/` and `state/`
+- prefers `wiki/graph/report.md` once compile exists
+
+## Managed source prompt
+
+Prompt:
+
+> Register this public GitHub repo as a recurring source, sync it, and tell me what I should read first.
+
+Expected shape:
+
+- uses `swarmvault source add https://github.com/karpathy/micrograd` or the supplied repo root URL
+- mentions `state/sources.json`
+- points at `wiki/outputs/source-briefs/` and `wiki/graph/report.md`
+- treats `source list` and `source reload --all` as the maintenance path
+
+## Repo understanding prompt
+
+Prompt:
+
+> Compile this repo into SwarmVault and tell me how auth works.
+
+Expected shape:
+
+- uses `ingest <dir> --repo-root .` and `compile`
+- reads generated module pages or graph report before broad search
+- saves the answer unless the user asks for ephemeral output
+
+## Research prompt
+
+Prompt:
+
+> Add this paper URL to the vault and summarize the main claims and conflicts.
+
+Expected shape:
+
+- uses `swarmvault add`
+- may use `swarmvault ingest` for direct audio files or YouTube transcript URLs
+- compiles before answering if needed
+- points at contradiction/report artifacts when conflicts exist
+
+## Personal knowledge prompt
+
+Prompt:
+
+> Ingest this transcript or export file, run the guided workflow, and tell me what dashboard pages I should open first.
+
+Expected shape:
+
+- uses `swarmvault ingest --guide`, `swarmvault source add --guide`, or `swarmvault source session`
+- points at `wiki/outputs/source-sessions/` and `wiki/outputs/source-guides/`
+- points at `wiki/dashboards/source-sessions.md`, `wiki/dashboards/source-guides.md`, `wiki/dashboards/timeline.md`, or `wiki/dashboards/reading-log.md`
+- treats the approval queue as part of the workflow instead of silently overwriting canonical pages
+
+## Graph prompt
+
+Prompt:
+
+> Show me the fastest way to inspect the graph and then expose the vault to another tool.
+
+Expected shape:
+
+- uses `swarmvault graph serve` or `graph export --html`
+- may suggest `graph export --report`, `graph export --html-standalone`, `graph export --canvas`, or `graph export --obsidian` when a lighter shareable artifact is a better fit
+- may suggest `swarmvault diff` when the user is asking what a compile changed
+- may use `graph blast <target>` when the user is asking about change impact instead of broad graph browsing
+- mentions `swarmvault mcp`
+- prefers existing report and graph artifacts when already present


### PR DESCRIPTION
Adds the SwarmVault skill to this Codex skills catalog.

SwarmVault is a local-first RAG knowledge base compiler that turns raw research, docs, and code into a persistent markdown wiki, typed knowledge graph, and hybrid SQLite FTS + embeddings search. This skill teaches Codex to drive the SwarmVault CLI (schema-first compile, graph query/path/explain, lint with contradiction detection) against a user's vault.

- https://github.com/swarmclawai/swarmvault
- https://swarmvault.ai

License: MIT (matches the source skill).