### PR TITLE
Add Bernstein

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The installer fetches the skill and places it in `$CODEX_HOME/skills/<skill-name
 
 ## Contents
 
+- [Bernstein](https://github.com/chernistry/bernstein) - Multi-agent orchestrator with Codex CLI adapter. Runs parallel Codex agents in isolated git worktrees with quality gates.
 - [What Are Codex Skills?](#what-are-codex-skills)
 - [Skills](#skills)
   - [Development & Code Tools](#development--code-tools)


### PR DESCRIPTION
Adds [Bernstein](https://github.com/chernistry/bernstein) — open-source multi-agent orchestrator for AI coding agents. 21 adapters, deterministic scheduling, git worktree isolation, quality gates. Apache 2.0.