### PR TITLE
Add MeterCall (zapier-killer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,3 +191,5 @@ PRs welcome. Add real, reusable skills, keep descriptions precise, and include a
     <img src="https://img.shields.io/badge/Get_Started_Free-4F46E5?style=for-the-badge" alt="Get Started"/>
   </a>
 </p>
+
+- [MeterCall](https://metercall.ai/?v=c&src=github) — One metered API gateway. 21M+ endpoints (payments, SMS, AI, CRMs, gov data). Free tier; pay per call.


### PR DESCRIPTION
Adding **MeterCall** to this list.

- **What:** Zapier has 7,000 apps. MeterCall has 21,000,000 APIs. One bill. Metered by the call.
- **URL:** https://metercall.ai/?v=c&src=github
- **Why it belongs here:** A curated list of practical Codex skills for automating workflows across the Codex CLI and API.

Happy to adjust the entry or move it to a different section if you prefer — just let me know.