### PR TITLE
Add novel-writing as a community skill link

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [email-draft-polish/](./email-draft-polish/) - Draft, rewrite, or condense emails for the right tone and audience.
 - [changelog-generator/](./changelog-generator/) - Create clear changelogs from commits or summaries.
 - [content-research-writer/](./content-research-writer/) - Research and draft content with sourced citations.
+- [novel-writing](https://github.com/wgwtest/novel-writing) - External repo: public Codex skill for fiction planning, chapter drafting, scene continuation, and revision.
 - [tailored-resume-generator/](./tailored-resume-generator/) - Tailor resumes to job descriptions with quantified impact.
 
 ### Data & Analysis


### PR DESCRIPTION
## Summary
- add a link to `wgwtest/novel-writing` under Communication & Writing
- surface a public Codex skill for fiction planning, chapter drafting, scene continuation, and revision

## Why
The current list has writing-adjacent skills but no dedicated fiction-writing skill. `novel-writing` fills that gap and is already published as a public MIT-licensed repo with releases and install instructions.