### PR TITLE
Add paperjsx skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [notion-spec-to-implementation/](./notion-spec-to-implementation/) - Turn Notion specs into implementation plans, tasks, and progress tracking.
 - [support-ticket-triage/](./support-ticket-triage/) - Triage customer support tickets with categories, priority, next actions, and draft replies.
 - [file-organizer/](./file-organizer/) - Organize, rename, and tidy files to keep workspaces clean.
+- [paperjsx/](./paperjsx/) - Generate PPTX presentations, DOCX documents, XLSX spreadsheets, and PDF invoices/reports/charts from structured JSON. Runs locally via `@paperjsx/mcp-server` — no API key, no network calls.
 - [skill-share/](./skill-share/) - Share skills and reusable instructions across teammates.
 
 ### Communication & Writing

--- a/paperjsx/LICENSE.txt
+++ b/paperjsx/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/paperjsx/SKILL.md
+++ b/paperjsx/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: paperjsx
+description: Generate PPTX presentations, DOCX documents, XLSX spreadsheets, and PDF reports from structured JSON input using PaperJSX.
+---
+
+# PaperJSX Document Generation
+
+Generate professional documents from JSON layout specs. PaperJSX is generation-only — it creates new files, it does not edit existing ones.
+
+## Triggers
+
+Use this skill when the user asks to:
+- Create a presentation or generate slides
+- Make a PPTX or PowerPoint file
+- Create a Word document or DOCX
+- Generate an Excel spreadsheet with charts
+- Create a JSON to PPTX, JSON to DOCX, or JSON to XLSX file
+- Generate a PDF invoice, report, or chart document
+
+## Install
+
+Install the format-appropriate package:
+
+```bash
+# Presentations
+npm install @paperjsx/json-to-pptx
+
+# Word documents
+npm install @paperjsx/json-to-docx
+
+# Spreadsheets
+npm install @paperjsx/json-to-xlsx
+
+# PDF documents
+npm install @paperjsx/json-to-pdf
+```
+
+## How it works
+
+1. Build a JSON layout spec matching the schema in `references/json-schema.md`
+2. Write a Node.js script that passes the JSON to the PaperJSX engine
+3. Run the script to generate the output file
+4. Validate the output file exists and is non-zero bytes
+
+Do **not** write imperative PaperJSX API code. The execution model is always: JSON spec in, document file out.
+
+## Example: PPTX generation
+
+```javascript
+import { PaperEngine } from "@paperjsx/json-to-pptx";
+import fs from "node:fs";
+
+const spec = {
+  type: "Document",
+  meta: { title: "Q4 Review" },
+  slides: [
+    {
+      type: "Slide",
+      children: [
+        { type: "Text", content: "Q4 2025 Business Review", style: { fontSize: 36, bold: true } }
+      ]
+    }
+  ]
+};
+
+const buffer = await PaperEngine.render(spec);
+fs.writeFileSync("presentation.pptx", buffer);
+console.log("Generated presentation.pptx");
+```
+
+## Example: DOCX generation
+
+```javascript
+import { renderToDocx } from "@paperjsx/json-to-docx";
+import fs from "node:fs";
+
+const result = await renderToDocx({
+  type: "DocxDocument",
+  pageSize: "a4",
+  orientation: "portrait",
+  pages: [
+    {
+      elements: [
+        { type: "heading", level: 1, text: "Quarterly Report" },
+        { type: "paragraph", text: "Section content here." }
+      ]
+    }
+  ]
+});
+
+fs.writeFileSync("report.docx", result.buffer);
+console.log("Generated report.docx");
+```
+
+## Example: XLSX generation
+
+```javascript
+import { SpreadsheetEngine } from "@paperjsx/json-to-xlsx";
+import fs from "node:fs";
+
+const spec = {
+  meta: { title: "Revenue Data", creator: "PaperJSX" },
+  sheets: [{
+    name: "Revenue",
+    rows: [
+      { cells: [{ value: "Quarter" }, { value: "Revenue" }] },
+      { cells: [{ value: "Q1 2026" }, { value: 420000 }] },
+      { cells: [{ value: "Q2 2026" }, { value: 510000 }] }
+    ]
+  }]
+};
+
+const buffer = await SpreadsheetEngine.render(spec);
+fs.writeFileSync("revenue.xlsx", buffer);
+console.log("Generated revenue.xlsx");
+```
+
+## Validation
+
+After generating any file, always verify:
+
+```javascript
+import fs from "node:fs";
+
+const stats = fs.statSync("output.pptx");
+if (stats.size === 0) {
+  throw new Error("Generated file is empty");
+}
+console.log(`Output file: ${stats.size} bytes`);
+```
+
+If the engine throws an error, surface the full error message to the user.
+
+## Schema reference
+
+See `references/json-schema.md` for the complete JSON layout spec schema for all supported formats.

--- a/paperjsx/references/json-schema.md
+++ b/paperjsx/references/json-schema.md
@@ -1,0 +1,330 @@
+# PaperJSX JSON Layout Spec — Schema Reference
+
+This document contains the complete input schemas for all PaperJSX document generation tools. Use these schemas to produce valid JSON input.
+
+---
+
+## PPTX Presentation
+
+**Tool:** `generate_presentation`
+**Package:** `@paperjsx/json-to-pptx`
+
+### Top-level fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `title` | string | yes | — | Presentation title |
+| `author` | string | no | — | Author/presenter name |
+| `company` | string | no | — | Company name |
+| `date` | string | no | — | Presentation date |
+| `slides` | SlideContent[] | yes | — | Array of slides (1–50) |
+| `theme` | enum | no | `"corporate"` | `"corporate"`, `"modern"`, `"minimal"`, `"dark"`, `"gradient"` |
+| `primary_color` | string | no | — | Primary brand color (hex) |
+| `secondary_color` | string | no | — | Secondary accent color (hex) |
+| `logo_url` | string (URL) | no | — | Company logo URL |
+| `format` | enum | no | `"pptx"` | `"pptx"` or `"pdf"` |
+| `aspect_ratio` | enum | no | `"16:9"` | `"16:9"` or `"4:3"` |
+| `include_slide_numbers` | boolean | no | `true` | Show slide numbers |
+| `include_footer` | boolean | no | `true` | Show footer |
+
+### Slide types
+
+Each slide has a `type` field that determines its structure.
+
+#### `"title"` — Title slide
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `"title"` | yes | — |
+| `title` | string | yes | Main title text |
+| `subtitle` | string | no | Subtitle text |
+| `background_image_url` | string (URL) | no | Background image |
+
+#### `"content"` — Bullet content slide
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `type` | `"content"` | yes | — | — |
+| `heading` | string | yes | — | Slide heading |
+| `bullets` | string[] | yes | — | Bullet points |
+| `image_url` | string (URL) | no | — | Optional image |
+| `image_position` | enum | no | `"right"` | `"left"` or `"right"` |
+
+#### `"chart"` — Chart slide
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `"chart"` | yes | — |
+| `heading` | string | yes | Slide heading |
+| `chart` | ChartConfig | yes | Chart configuration (see below) |
+| `caption` | string | no | Chart caption or source |
+
+**ChartConfig:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | enum | yes | `"line"`, `"bar"`, `"pie"`, `"area"` |
+| `data` | object[] | yes | Array of data points (key-value records) |
+| `x_key` | string | yes | Key for X-axis |
+| `y_keys` | string[] | yes | Keys for Y-axis series |
+| `colors` | string[] | no | Hex colors for each series |
+
+#### `"two_column"` — Two-column layout
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `"two_column"` | yes | — |
+| `heading` | string | yes | Slide heading |
+| `left` | string[] | yes | Left column bullet points |
+| `right` | string[] | yes | Right column bullet points |
+| `left_heading` | string | no | Left column sub-heading |
+| `right_heading` | string | no | Right column sub-heading |
+
+#### `"quote"` — Quote slide
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `"quote"` | yes | — |
+| `quote` | string | yes | Quote text |
+| `attribution` | string | no | Quote source |
+| `background_color` | string | no | Background color (hex) |
+
+#### `"image"` — Image slide
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `type` | `"image"` | yes | — | — |
+| `heading` | string | no | — | Optional heading |
+| `image_url` | string (URL) | yes | — | Main image URL |
+| `caption` | string | no | — | Image caption |
+| `fit` | enum | no | `"contain"` | `"contain"`, `"cover"`, `"fill"` |
+
+#### `"comparison"` — Comparison slide
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `"comparison"` | yes | — |
+| `heading` | string | yes | Slide heading |
+| `items` | ComparisonItem[] | yes | 2–4 comparison items |
+
+**ComparisonItem:** `{ label: string, value: string, highlight?: boolean }`
+
+#### `"stats"` — Stats/metrics slide
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `"stats"` | yes | — |
+| `heading` | string | yes | Slide heading |
+| `stats` | StatItem[] | yes | 1–4 stat items |
+
+**StatItem:** `{ label: string, value: string, change?: string, trend?: "up" | "down" | "neutral" }`
+
+---
+
+## PDF Invoice
+
+**Tool:** `generate_invoice`
+**Package:** `@paperjsx/json-to-pdf`
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `invoice_number` | string | yes | — | Unique invoice ID |
+| `issue_date` | string | yes | — | ISO 8601 (YYYY-MM-DD) |
+| `due_date` | string | yes | — | ISO 8601 (YYYY-MM-DD) |
+| `from` | InvoiceSender | yes | — | Sender info (see below) |
+| `to` | Address | yes | — | Recipient info |
+| `items` | LineItem[] | yes | — | Line items (min: 1) |
+| `currency` | enum | no | `"USD"` | ISO 4217 code: USD, EUR, GBP, INR, BRL, AUD, CAD, JPY, CNY, CHF, SGD, HKD |
+| `tax_rate` | number | no | `0` | Default tax rate (0–100) |
+| `discount_total` | number | no | — | Discount amount |
+| `shipping` | number | no | — | Shipping cost |
+| `notes` | string | no | — | Additional notes/terms |
+| `payment_instructions` | string | no | — | Payment instructions |
+| `purchase_order` | string | no | — | PO number |
+| `theme` | enum | no | — | `"corporate"`, `"modern"`, `"minimal"`, `"academic"`, `"legal"` |
+
+**InvoiceSender** extends Address with: `logo_url?: string (URL)`
+
+**Address:** `{ name, address_line_1, address_line_2?, city, state?, postal_code, country, email?, phone?, tax_id? }`
+
+**LineItem:** `{ description: string, quantity: number, unit_price: number, tax_rate?: number (0–100), discount?: number (0–100) }`
+
+---
+
+## PDF Report
+
+**Tool:** `generate_report`
+**Package:** `@paperjsx/json-to-pdf`
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `title` | string | yes | — | Report title |
+| `subtitle` | string | no | — | Subtitle |
+| `author` | string | no | — | Author name |
+| `date` | string | no | — | ISO 8601 (YYYY-MM-DD) |
+| `version` | string | no | — | e.g. "v1.0", "Draft" |
+| `content` | string | yes | — | Full markdown content |
+| `include_toc` | boolean | no | `true` | Auto-generate table of contents |
+| `include_cover` | boolean | no | `true` | Generate cover page |
+| `page_numbers` | boolean | no | `true` | Show page numbers |
+| `toc_depth` | number | no | `3` | Max heading level in TOC (1–6) |
+| `theme` | enum | no | — | `"corporate"`, `"modern"`, `"minimal"`, `"academic"`, `"legal"` |
+| `primary_color` | string | no | — | Hex color for headings |
+| `font_family` | enum | no | `"sans"` | `"sans"`, `"serif"`, `"mono"` |
+| `page_format` | enum | no | `"a4"` | `"a4"`, `"letter"`, `"legal"` |
+| `orientation` | enum | no | `"portrait"` | `"portrait"`, `"landscape"` |
+| `header_logo_url` | string (URL) | no | — | Logo for header |
+| `footer_text` | string | no | — | Footer text |
+
+**Markdown content supports:** headings (#–######), GFM tables, fenced code blocks, images via URL, bullet/numbered lists, blockquotes, bold/italic/strikethrough, horizontal rules, links.
+
+---
+
+## PDF Chart Document
+
+**Tool:** `generate_chart_document`
+**Package:** `@paperjsx/json-to-pdf`
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `title` | string | yes | — | Document title |
+| `subtitle` | string | no | — | Subtitle |
+| `author` | string | no | — | Author name |
+| `date` | string | no | — | ISO 8601 |
+| `charts` | ChartConfig[] | yes | — | 1–4 chart configurations |
+| `analysis_text` | string | no | — | Markdown analysis/commentary |
+| `key_insights` | string[] | no | — | Bullet points of insights |
+| `include_data_table` | boolean | no | `false` | Include raw data as table |
+| `theme` | enum | no | — | `"corporate"`, `"modern"`, `"minimal"`, `"academic"`, `"legal"` |
+| `page_format` | enum | no | `"a4"` | `"a4"`, `"letter"`, `"legal"` |
+| `primary_color` | string | no | — | Hex color for accents |
+
+**ChartConfig:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `type` | enum | yes | — | `"line"`, `"bar"`, `"pie"`, `"area"`, `"scatter"`, `"composed"` |
+| `title` | string | no | — | Chart title |
+| `data` | object[] | yes | — | Array of data points (key-value records) |
+| `x_key` | string | yes | — | Key for X-axis |
+| `y_keys` | string[] | yes | — | Keys for Y-axis series |
+| `colors` | string[] | no | — | Hex colors for each series |
+| `show_legend` | boolean | no | `true` | Show legend |
+| `show_grid` | boolean | no | `true` | Show grid lines |
+| `y_axis_label` | string | no | — | Y-axis label |
+| `x_axis_label` | string | no | — | X-axis label |
+| `stacked` | boolean | no | — | Stack bars/areas |
+
+---
+
+## XLSX Spreadsheet
+
+**Tool:** `generate_spreadsheet`
+**Package:** `@paperjsx/json-to-xlsx`
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `document` | SpreadsheetDoc | yes | — | Spreadsheet document JSON |
+| `output_filename` | string | no | — | Safe .xlsx filename (alphanumeric, dots, hyphens, underscores) |
+| `render_options` | object | no | — | `{ deterministic?, large_dataset?, row_chunk_size? (max 100K), string_strategy?: "auto"|"sharedStrings"|"inlineStrings" }` |
+| `validate_after_render` | boolean | no | `true` | Validate output after generation |
+| `attempt_repair_if_needed` | boolean | no | `true` | Auto-repair if validation finds issues |
+
+**SpreadsheetDoc:**
+
+```json
+{
+  "meta": {
+    "title": "string",
+    "creator": "string"
+  },
+  "sheets": [
+    {
+      "name": "Sheet1",
+      "rows": [
+        {
+          "cells": [
+            { "value": "string or number or boolean" }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## DOCX Report
+
+**Tool:** `generate_report_docx`
+**Package:** `@paperjsx/json-to-docx`
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `title` | string | yes | — | Report title |
+| `subtitle` | string | no | — | Subtitle |
+| `author` | string | no | — | Author name |
+| `date` | string | no | — | YYYY-MM-DD format |
+| `sections` | Section[] | yes | — | Report sections (min: 1) |
+| `include_toc` | boolean | no | `true` | Table of contents |
+| `theme` | enum | no | `"corporate"` | `"corporate"`, `"modern"`, `"classic"`, `"academic"`, `"minimal"` |
+| `page_size` | enum | no | `"a4"` | `"a4"`, `"letter"`, `"legal"` |
+| `orientation` | enum | no | `"portrait"` | `"portrait"`, `"landscape"` |
+| `header_text` | string | no | — | Header text |
+| `footer_text` | string | no | — | Footer text |
+| `include_page_numbers` | boolean | no | `true` | Show page numbers |
+
+**Section:** `{ heading: string, level?: number (1–4, default 1), content: string, bullets?: string[] }`
+
+Content paragraphs are separated by double newlines.
+
+---
+
+## DOCX Contract
+
+**Tool:** `generate_contract_docx`
+**Package:** `@paperjsx/json-to-docx`
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `title` | string | yes | — | Contract title |
+| `effective_date` | string | yes | — | Effective date |
+| `parties` | Party[] | yes | — | Contracting parties (min: 2) |
+| `recitals` | string[] | no | — | WHEREAS clauses/preamble |
+| `clauses` | Clause[] | yes | — | Contract clauses (min: 1) |
+| `signatures` | Signature[] | no | — | Signature blocks |
+| `theme` | enum | no | `"classic"` | `"corporate"`, `"classic"`, `"academic"` |
+| `page_size` | enum | no | `"letter"` | `"a4"`, `"letter"`, `"legal"` |
+
+**Party:** `{ name: string, address: string, role: string }`
+
+**Clause:** `{ number: string, title: string, content: string, subclauses?: [{ label: string, content: string }] }`
+
+**Signature:** `{ name: string, title: string, party: string }`
+
+---
+
+## DOCX Invoice
+
+**Tool:** `generate_invoice_docx`
+**Package:** `@paperjsx/json-to-docx`
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `invoice_number` | string | yes | — | Invoice ID |
+| `date` | string | yes | — | Invoice date |
+| `due_date` | string | yes | — | Payment due date |
+| `sender` | object | yes | — | `{ name, address, email?, phone?, tax_id? }` |
+| `recipient` | object | yes | — | `{ name, address, email?, tax_id? }` |
+| `items` | InvoiceItem[] | yes | — | Line items (min: 1) |
+| `subtotal` | number | yes | — | Subtotal amount |
+| `tax_rate` | number | no | — | Tax rate (decimal, e.g. 0.1 = 10%) |
+| `tax_amount` | number | yes | — | Tax amount |
+| `total` | number | yes | — | Total amount |
+| `currency` | string | no | `"USD"` | ISO 4217 code |
+| `notes` | string | no | — | Additional notes |
+| `theme` | enum | no | `"corporate"` | `"corporate"`, `"modern"`, `"minimal"` |
+| `page_size` | enum | no | `"a4"` | `"a4"`, `"letter"` |
+
+**InvoiceItem:** `{ description: string, quantity: number, unit_price: number, amount: number }`


### PR DESCRIPTION
Adds the **paperjsx** skill under Productivity & Collaboration.

PaperJSX generates PPTX presentations, DOCX documents, XLSX spreadsheets, and PDF invoices/reports/charts from structured JSON input. It runs locally via the `@paperjsx/mcp-server` MCP server — no API key, no network calls — wrapping free-tier `@paperjsx/json-to-*` npm packages.

## Files added

```
paperjsx/
├── SKILL.md
├── LICENSE.txt            # Apache-2.0
└── references/
    └── json-schema.md     # Document spec JSON schema reference
```

## Usage

After install, ask Codex things like:
- "Generate a 3-slide PPTX about Q4 results with a bar chart"
- "Create a PDF invoice for client X with 3 line items"
- "Generate an XLSX with a pivot table and chart from this CSV data"

## References

- Skill source: https://github.com/paperjsx/agent-skill
- npm package: https://www.npmjs.com/package/@paperjsx/mcp-server (v0.2.0)
- License: Apache-2.0