### PR TITLE
Add vara-skills to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [mcp-builder/](./mcp-builder/) - Build and evaluate MCP servers with best practices and an evaluation harness.
 - [webapp-testing/](./webapp-testing/) - Run targeted web app tests and summarize results.
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
+- [vara-skills](https://github.com/gear-foundation/vara-skills) - 21 skills for shipping Rust smart contracts on Vara Network with the Gear/Sails framework. Full pipeline: spec → Sails impl → gtest → on-chain deploy via `vara-wallet`. Covers IDL codegen, React frontend, and event-driven indexer. Ships as Codex install script via `bash scripts/install-codex-skills.sh`.
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
Adds [vara-skills](https://github.com/gear-foundation/vara-skills) to the Development & Code Tools section.

**What it is:** 21 skills teaching Codex how to build and ship Rust smart contracts on Vara Network with the Gear/Sails framework. Covers spec → architecture → Rust implementation → IDL/client codegen → deterministic gtest → React frontend → event-driven indexer → on-chain deploy via `vara-wallet`.

**Codex install:**
```bash
git clone git@github.com:gear-foundation/vara-skills.git
cd vara-skills
bash scripts/install-codex-skills.sh
```

This installs into `$CODEX_HOME/skills/vara-skills` (router) plus one directory per skill.

**Why it fits here:** Same profile as `brooks-lint` and `AuraKit` — a framework-specific skill pack with an included installer. MIT licensed. Published by Gear Foundation.