### PR TITLE
Add Emdash Skills -- autonomous product-building OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [codebase-migrate/](./codebase-migrate/) - Run large codebase migrations and multi-file refactors in reviewable batches with CI verification.
 - [create-plan/](./create-plan/) - Quickly draft concise execution plans for coding tasks.
 - [deploy-pipeline/](./deploy-pipeline/) - End-to-end Stripe → Supabase → Vercel release pipelines with verify and rollback.
+- [Emdash Skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS: CF Workers + Hono + Angular + D1 + Stripe. One-line prompts to deployed SaaS with 94 reference docs, 18 agents, and Codex-native `.agents/skills/` support.
 - [gh-address-comments/](./gh-address-comments/) - Address review or issue comments on the open GitHub PR for the current branch using `gh`.
 - [gh-fix-ci/](./gh-fix-ci/) - Inspect failing GitHub Actions checks, summarize failures, and propose fixes.
 - [mcp-builder/](./mcp-builder/) - Build and evaluate MCP servers with best practices and an evaluation harness.


### PR DESCRIPTION
Adds [Emdash Skills](https://github.com/megabytespace/claude-skills) to the **Development & Code Tools** section.

**What it is:** A 14-category autonomous product-building OS for AI coding tools. Ships with 94 reference docs, 18 agents, and Codex-native `.agents/skills/` support. Stack: CF Workers + Hono + Angular + D1 + Stripe. One-line prompts produce deployed SaaS.

**Entry added:** External repo link in alphabetical position within Development & Code Tools, matching the format of existing external entries (brooks-lint, AuraKit, Bernstein).

No other files modified.