### PR TITLE
Add VirtualSMS — real-SIM SMS verification skill for Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [skill-share/](./skill-share/) - Share skills and reusable instructions across teammates.
 
 ### Communication & Writing
+- [codex-sms-verification](https://github.com/virtualsms-io/codex-sms-verification) - External repo: real-SIM SMS verification for AI agents via VirtualSMS MCP. 145+ countries, 2000+ services, both hosted (mcp.virtualsms.io) and local stdio transports.
 
 - [email-draft-polish/](./email-draft-polish/) - Draft, rewrite, or condense emails for the right tone and audience.
 - [changelog-generator/](./changelog-generator/) - Create clear changelogs from commits or summaries.


### PR DESCRIPTION
## Summary

Adds VirtualSMS to **Communication & Writing** — a Codex CLI skill for real-SIM SMS verification across 2000+ services and 145+ countries.

## Why this fits

- Production MCP server (`virtualsms-mcp` on npm, v1.2.0)
- Two transports: hosted StreamableHTTP at `https://mcp.virtualsms.io/mcp` (zero install) and local stdio via npm
- 18 tools across discovery, account, and order management
- Real physical SIMs survive carrier_lookup checks where VoIP/eSIM-based services fail
- Listed on the official MCP registry: `io.github.virtualsms-io/sms`

## Repo

https://github.com/virtualsms-io/codex-sms-verification

Includes `.codex/config.toml` example for both hosted and local install paths.
