### PR TITLE
Add unslop to Communication & Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [content-research-writer/](./content-research-writer/) - Research and draft content with sourced citations.
 - [novel-writing](https://github.com/wgwtest/novel-writing) - External repo: public Codex skill for fiction planning, chapter drafting, scene continuation, and revision.
 - [tailored-resume-generator/](./tailored-resume-generator/) - Tailor resumes to job descriptions with quantified impact.
+- [unslop](https://github.com/MohamedAbdallah-14/unslop) - External repo: CLI and MCP server that removes AI writing patterns from text: tricolons, em-dash overuse, hedging stacks, and sycophancy openers. Works with Codex, Claude Code, Gemini CLI, and Cursor. Five intensity levels and a lint-only audit mode.
 
 ### Data & Analysis
 


### PR DESCRIPTION
## Add unslop to Communication & Writing

**unslop** — https://github.com/MohamedAbdallah-14/unslop

A CLI and MCP server that removes AI writing patterns from text: tricolons, em-dash overuse, hedging stacks, sycophancy openers, and overused vocabulary. Works with Codex, Claude Code, Gemini CLI, and Cursor. Five intensity levels and a lint-only audit mode that checks without modifying.

Added to Communication & Writing section as an external repo skill reference.
