### PR TITLE
Add harness to Development & Code Tools

### DIFF
--- a/harness/SKILL.md
+++ b/harness/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: harness
-description: "A meta-skill for designing a specialized subagent team in the Codex CLI environment. Domain analysis → Agent TOML definitions (.codex/agents/) → Skill creation (.agents/skills/) → AGENTS.md initialization. Triggers: 'set up codex harness', 'create codex agent team', 'build codex harness', '{domain} codex automation'. Also use this skill for follow-up tasks (modification/refinement/re-execution/expansion)."
+name: codex-harness
+description: "A meta-skill for designing a specialized subagent team in the Codex CLI environment. Domain analysis → Agent TOML definitions (.codex/agents/) → Skill creation (.codex/skills/) → AGENTS.md initialization. Triggers: 'set up codex harness', 'create codex agent team', 'build codex harness', '{domain} codex automation'. Also use this skill for follow-up tasks (modification/refinement/re-execution/expansion)."
 ---
 
 # Skill: Codex Harness Orchestrator
@@ -11,7 +11,7 @@ description: "A meta-skill for designing a specialized subagent team in the Code
 
 1. **7 Architecture Patterns:** Pipeline · Fan-out/Fan-in · Expert Pool · Producer-Reviewer · Supervisor · Hierarchical · Handoff
 2. **Agent Definition:** TOML format — `.codex/agents/{name}.toml`
-3. **Skill Format:** SKILL.md — `.agents/skills/{name}/SKILL.md`
+3. **Skill Format:** SKILL.md — `.codex/skills/{name}/SKILL.md`
 4. **Project Context:** `AGENTS.md` — Path hierarchy: global `~/.codex/AGENTS.md` → repo `AGENTS.md` → subdirectory (more specific file takes precedence). Short and precise files are better than long and vague ones.
 5. **State Persistence:** `_workspace/` file-based brokering
 6. **Permission Control:** TOML `sandbox_mode` field — `read-only | workspace-write | danger-full-access`
@@ -70,7 +70,7 @@ PROCEDURE plan_mode(user_request):
 
 ### Phase 0: Status Audit (Mode Branching)
 
-Check for the existence of `.codex/agents/`, `.agents/skills/`, `AGENTS.md`, `_workspace/checkpoint.json`:
+Check for the existence of `.codex/agents/`, `.codex/skills/`, `AGENTS.md`, `_workspace/checkpoint.json`:
 
 | State                         | Mode          | Entry Phase                              |
 | ----------------------------- | ------------- | ---------------------------------------- |
@@ -91,14 +91,17 @@ Check for the existence of `.codex/agents/`, `.agents/skills/`, `AGENTS.md`, `_w
 2. Select pattern (see `references/agent-design-patterns.md`).
 3. Determine `sandbox_mode` for each agent:
 
-   | Agent Type              | sandbox_mode         | Rationale                                                               |
-   | ----------------------- | -------------------- | ----------------------------------------------------------------------- |
-   | Researcher / Analyst    | `read-only`          | File reading and web research only, no writes                           |
-   | Architect / Planner     | `read-only`          | Reports design output to findings.md only (orchestrator writes for it)  |
-   | Coder / Developer       | `workspace-write`    | Directly creates and modifies code and documentation files              |
-   | Reviewer / QA Inspector | `workspace-write`    | Creates report files + runs tests                                       |
-   | State Manager           | `workspace-write`    | CRUD on checkpoint, task, and findings files                            |
-   | Operator / Deployer     | `danger-full-access` | Executes external processes such as kubectl, terraform, etc.            |
+   | Agent Type                              | sandbox_mode         | Rationale                                                                                         |
+   | --------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------- |
+   | Researcher / Analyst                    | `read-only`          | File reading and web research only, no writes                                                     |
+   | Architect / Planner *(consultative)*    | `read-only`          | Returns analysis/opinion as text only — orchestrator captures output and writes to findings.md    |
+   | Architect / Planner *(document-producing)* | `workspace-write` | Directly writes design docs (architecture.md, plan.md, etc.) to `_workspace/{plan_name}/`        |
+   | Coder / Developer                       | `workspace-write`    | Directly creates and modifies code and documentation files                                        |
+   | Reviewer / QA Inspector                 | `workspace-write`    | Creates report files + runs tests                                                                 |
+   | State Manager                           | `workspace-write`    | CRUD on checkpoint, task, and findings files                                                      |
+   | Operator / Deployer                     | `danger-full-access` | Executes external processes such as kubectl, terraform, etc.                                      |
+
+   > **Architect/Planner mode selection:** Use `read-only` (consultative) when the orchestrator instructs "analyze and return opinion." Use `workspace-write` (document-producing) when the orchestrator instructs "write the design doc to `_workspace/`." **Never assign `read-only` to an agent whose prompt says to write files** — this will silently fail.
 
 4. **Subagent constraint check:** Agents other than the orchestrator must not spawn subagents.
 
@@ -114,14 +117,14 @@ Required fields: `name`, `description`, `developer_instructions`, `model`, `sand
 
 ### Phase 4: Procedure Skill Creation
 
-Write `.agents/skills/{orchestrator-name}/SKILL.md`. Reference: `references/schemas/agent-orchestrator.template.md`.
+Write `.codex/skills/{orchestrator-name}/SKILL.md`. Reference: `references/schemas/agent-orchestrator.template.md`.
 
-Bundle schema files: Copy all 9 schemas from `references/schemas/` → `.agents/skills/{name}/references/schemas/`.
+Bundle schema files: Copy all 10 items from `references/schemas/` → `.codex/skills/{name}/references/schemas/` (9 schemas + `state.py`).
 
 ### Phase 5: Integration and Orchestration
 
 1. Create `_workspace/`, `_workspace/{plan_name}/`, `_workspace/tasks/`, `_workspace/_schemas/`.
-2. Schema sync: Copy all 9 schemas from `references/schemas/` → `_workspace/_schemas/`.
+2. Schema sync: Copy all 9 schemas from `references/schemas/` → `_workspace/_schemas/`. Also copy `references/schemas/state.py` → `_workspace/state.py` (separate destination — callable as `python _workspace/state.py`).
 3. Write `workflow.md` — Stage-Step structure, 6 required fields, verifiable exit conditions.
 4. Initialize `findings.md` (sections by pattern).
 5. Initialize `tasks.md`.
@@ -131,20 +134,23 @@ Bundle schema files: Copy all 9 schemas from `references/schemas/` → `.agents/
    ```markdown
    ## Harness: {plan_name}
 
+   > **Entry point:** Always invoke `@{orchestrator-agent}` first. It loads `.codex/skills/{orchestrator-name}/SKILL.md` and spawns worker subagents per workflow.md. Direct `@worker` calls without the orchestrator are prohibited.
+
+   - Orchestrator: `.codex/agents/{orchestrator-agent}.toml` + `.codex/skills/{orchestrator-name}/SKILL.md`
    - Agents: {agent list + .codex/agents/ paths}
-   - Skills: {skill list + .agents/skills/ paths}
-   - Workflow: \_workspace/workflow.md
-   - Checkpoint: \_workspace/checkpoint.json
+   - Workflow: `_workspace/workflow.md`
+   - Checkpoint: `_workspace/checkpoint.json`
    ```
 
 ### Phase 6: Validation
 
 - [ ] `.codex/agents/*.toml` required fields complete (name, description, developer_instructions, model, sandbox_mode, model_reasoning_effort)
-- [ ] `.agents/skills/*/SKILL.md` frontmatter name and description validated
+- [ ] `.codex/skills/*/SKILL.md` frontmatter name and description validated
 - [ ] workflow.md schema validated (6 required fields + verifiable exit conditions, no natural language)
 - [ ] workflow.md cycle check
 - [ ] `_workspace/_schemas/` all 9 files present
-- [ ] `AGENTS.md` harness section added
+- [ ] `_workspace/state.py` exists and executable (`python _workspace/state.py --help`)
+- [ ] `AGENTS.md` harness section added — includes orchestrator entry point, skill path, agent list, workflow/checkpoint paths
 - [ ] `checkpoint.json` status is `in_progress`
 
 ## Pattern-based Codex Coordination
@@ -166,11 +172,13 @@ Based on Codex subagent spawn. Default parallel execution — sequential executi
 ```
 {project}/
 ├── .codex/
-│   ├── agents/{name}.toml              # Agent definition (TOML)
+│   └── agents/{name}.toml              # Agent definition (TOML)
+├── .agents/
 │   └── skills/{orchestrator}/
 │       ├── SKILL.md
-│       └── references/schemas/         # Schema copies (9 files)
+│       └── references/schemas/         # Schema copies (10 items: 9 schemas + state.py)
 ├── _workspace/
+│   ├── state.py                        # State manager CLI (token-efficient reads/writes)
 │   ├── _schemas/
 │   ├── workflow.md
 │   ├── findings.md
@@ -191,4 +199,5 @@ Zero-Tolerance: Agent failure → maximum 2 retries → if unresolved, set task\
 - `references/orchestrator-template.md` — Step 0~5 pseudocode (Codex version)
 - `references/schemas/models.md` — Model ID source of truth (OpenAI)
 - `references/schemas/agent-worker.template.toml` — Worker agent TOML reference
-- `references/schemas/` — Runtime schema SoT (9 files)
+- `references/schemas/state.py` — State manager CLI source (deployed to `_workspace/state.py` at init)
+- `references/schemas/` — Runtime schema SoT (9 schemas + state.py = 10 items total)

--- a/harness/SKILL.md
+++ b/harness/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: codex-harness
+name: harness
 description: "A meta-skill for designing a specialized subagent team in the Codex CLI environment. Domain analysis → Agent TOML definitions (.codex/agents/) → Skill creation (.codex/skills/) → AGENTS.md initialization. Triggers: 'set up codex harness', 'create codex agent team', 'build codex harness', '{domain} codex automation'. Also use this skill for follow-up tasks (modification/refinement/re-execution/expansion)."
 ---
 

--- a/harness/SKILL.md
+++ b/harness/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: harness
+description: "A meta-skill for designing a specialized subagent team in the Codex CLI environment. Domain analysis → Agent TOML definitions (.codex/agents/) → Skill creation (.agents/skills/) → AGENTS.md initialization. Triggers: 'set up codex harness', 'create codex agent team', 'build codex harness', '{domain} codex automation'. Also use this skill for follow-up tasks (modification/refinement/re-execution/expansion)."
+---
+
+# Skill: Codex Harness Orchestrator
+
+> **Required before starting:** Match the `references/usage-examples.md` scenarios against the user's utterance.
+
+## Core Principles
+
+1. **7 Architecture Patterns:** Pipeline · Fan-out/Fan-in · Expert Pool · Producer-Reviewer · Supervisor · Hierarchical · Handoff
+2. **Agent Definition:** TOML format — `.codex/agents/{name}.toml`
+3. **Skill Format:** SKILL.md — `.agents/skills/{name}/SKILL.md`
+4. **Project Context:** `AGENTS.md` — Path hierarchy: global `~/.codex/AGENTS.md` → repo `AGENTS.md` → subdirectory (more specific file takes precedence). Short and precise files are better than long and vague ones.
+5. **State Persistence:** `_workspace/` file-based brokering
+6. **Permission Control:** TOML `sandbox_mode` field — `read-only | workspace-write | danger-full-access`
+7. **Subagent Constraint:** Only the orchestrator may spawn subagents. `max_depth=1` (default) enforced.
+8. **File I/O:** Prefer `apply_patch` (surgical edits). New files via shell write.
+9. **Zero-Tolerance Failure Protocol:** Arbitrary skipping is strictly prohibited. Maximum 2 retries (3 attempts total) → `Blocked`.
+
+## Plan Mode
+
+**Always run the Plan Mode procedure before building a multi-stage harness.**
+
+- Activation: Collect context via `request_user_input` → clarifying questions → build a solid plan, then implement
+- Required cases: New builds, architecture changes, Stage additions
+- May be skipped: Simple single-item tasks with a clearly scoped change (e.g., minor skill checklist edits)
+
+### Plan Mode Procedure (request_user_input-based)
+
+```
+PROCEDURE plan_mode(user_request):
+    // 1. Context collection
+    questions ← []
+    IF domain/goal is unclear:
+        questions.append("Please describe the goal and domain of the harness you want to build in detail.")
+    IF pattern cannot be determined:
+        questions.append("Do you have a preference for the agent team structure (Pipeline, Fan-out, Supervisor, etc.)?")
+    IF agent count/roles are unclear:
+        questions.append("Please list the agent roles you need.")
+
+    IF questions is not empty:
+        CALL request_user_input(questions)   // Bundle all questions into one call
+        RETURN                               // Re-enter after receiving responses
+
+    // 2. Plan presentation and user approval
+    plan_summary ← Summary of domain, pattern, agent list, Stage/Step structure
+    CALL request_user_input(
+        "We will build the harness with the following plan. Shall we proceed?\n\n{plan_summary}"
+    )
+    RETURN                                   // Enter Phase 1 after approval
+```
+
+> `request_user_input` delivers multiple questions in a single call. Multiple unnecessary calls are prohibited.
+
+## Useful Slash Commands
+
+| Command    | Purpose                                                          |
+| ---------- | ---------------------------------------------------------------- |
+| `/plan`    | Toggle Plan Mode (same as Shift+Tab)                             |
+| `/compact` | Summarize previous context in a long thread — saves context      |
+| `/fork`    | Branch while preserving the current thread — use for experiments |
+| `/resume`  | Resume a saved conversation                                      |
+| `/review`  | Code review — compare base branch, uncommitted changes, specific commit |
+
+> **Thread Strategy:** 1 harness = 1 thread. Use `/compact` when context grows large. Use `/fork` for branching experiments. Start a new thread when the unit of work changes.
+
+## Workflow
+
+### Phase 0: Status Audit (Mode Branching)
+
+Check for the existence of `.codex/agents/`, `.agents/skills/`, `AGENTS.md`, `_workspace/checkpoint.json`:
+
+| State                         | Mode          | Entry Phase                              |
+| ----------------------------- | ------------- | ---------------------------------------- |
+| None exist                    | New build     | Phase 1                                  |
+| Some exist                    | Expansion     | Phase 1 (see expansion-matrix.md)        |
+| checkpoint.json `in_progress` | Resume        | Resume from Phase 5                      |
+| checkpoint.json `blocked`     | Ops/Modify    | Resolve blockage, then resume Phase 5    |
+
+### Phase 1: Domain Analysis + Pattern Matching
+
+1. Analyze user request → Extract domain, goals, and constraints.
+2. Match against `references/usage-examples.md` scenarios → Derive pattern and Stage/Step structure.
+3. Check non-trigger utterances — prevent false positives.
+
+### Phase 2: Virtual Team Design
+
+1. Separate agent responsibilities (single responsibility principle).
+2. Select pattern (see `references/agent-design-patterns.md`).
+3. Determine `sandbox_mode` for each agent:
+
+   | Agent Type              | sandbox_mode         | Rationale                                                               |
+   | ----------------------- | -------------------- | ----------------------------------------------------------------------- |
+   | Researcher / Analyst    | `read-only`          | File reading and web research only, no writes                           |
+   | Architect / Planner     | `read-only`          | Reports design output to findings.md only (orchestrator writes for it)  |
+   | Coder / Developer       | `workspace-write`    | Directly creates and modifies code and documentation files              |
+   | Reviewer / QA Inspector | `workspace-write`    | Creates report files + runs tests                                       |
+   | State Manager           | `workspace-write`    | CRUD on checkpoint, task, and findings files                            |
+   | Operator / Deployer     | `danger-full-access` | Executes external processes such as kubectl, terraform, etc.            |
+
+4. **Subagent constraint check:** Agents other than the orchestrator must not spawn subagents.
+
+### Phase 3: Agent TOML Creation
+
+Create `.codex/agents/{name}.toml`. Reference: `references/schemas/agent-worker.template.toml`.
+
+Required fields: `name`, `description`, `developer_instructions`, `model`, `sandbox_mode`, `model_reasoning_effort`.
+
+> `model_reasoning_effort` guidelines: `low` (StateManager) / `medium` (Analyst, Researcher) / `high` (Coder, QA, Reviewer) / `xhigh` (Orchestrator, Architect). Details: `references/schemas/models.md`.
+
+> **Model ID SoT:** `references/schemas/models.md` — do not guess arbitrary model IDs.
+
+### Phase 4: Procedure Skill Creation
+
+Write `.agents/skills/{orchestrator-name}/SKILL.md`. Reference: `references/schemas/agent-orchestrator.template.md`.
+
+Bundle schema files: Copy all 9 schemas from `references/schemas/` → `.agents/skills/{name}/references/schemas/`.
+
+### Phase 5: Integration and Orchestration
+
+1. Create `_workspace/`, `_workspace/{plan_name}/`, `_workspace/tasks/`, `_workspace/_schemas/`.
+2. Schema sync: Copy all 9 schemas from `references/schemas/` → `_workspace/_schemas/`.
+3. Write `workflow.md` — Stage-Step structure, 6 required fields, verifiable exit conditions.
+4. Initialize `findings.md` (sections by pattern).
+5. Initialize `tasks.md`.
+6. Create `checkpoint.json` (status: `in_progress`).
+7. **Update AGENTS.md** — Add harness pointer:
+
+   ```markdown
+   ## Harness: {plan_name}
+
+   - Agents: {agent list + .codex/agents/ paths}
+   - Skills: {skill list + .agents/skills/ paths}
+   - Workflow: \_workspace/workflow.md
+   - Checkpoint: \_workspace/checkpoint.json
+   ```
+
+### Phase 6: Validation
+
+- [ ] `.codex/agents/*.toml` required fields complete (name, description, developer_instructions, model, sandbox_mode, model_reasoning_effort)
+- [ ] `.agents/skills/*/SKILL.md` frontmatter name and description validated
+- [ ] workflow.md schema validated (6 required fields + verifiable exit conditions, no natural language)
+- [ ] workflow.md cycle check
+- [ ] `_workspace/_schemas/` all 9 files present
+- [ ] `AGENTS.md` harness section added
+- [ ] `checkpoint.json` status is `in_progress`
+
+## Pattern-based Codex Coordination
+
+Based on Codex subagent spawn. Default parallel execution — sequential execution is separated by skill directives per stage:
+
+| Pattern             | Codex Coordination Method                                                                    |
+| ------------------- | -------------------------------------------------------------------------------------------- |
+| `pipeline`          | Sequential spawn per stage — confirm previous stage `task_*.json` status=done before next   |
+| `fan_out_fan_in`    | Parallel spawn → ATOMIC aggregation after all complete                                       |
+| `producer_reviewer` | Spawn producer → check task → spawn reviewer → check verdict                                |
+| `expert_pool`       | Automatic routing based on Codex description                                                 |
+| `supervisor`        | Dynamic spawn based on tasks.md claim                                                        |
+| `hierarchical`      | Spawn team lead → team lead spawns workers (`max_depth=2` required: `.codex/config.toml`)   |
+| `handoff`           | Parse `[NEXT_AGENT:name]` → sequential spawn                                                 |
+
+## Output Artifacts
+
+```
+{project}/
+├── .codex/
+│   ├── agents/{name}.toml              # Agent definition (TOML)
+│   └── skills/{orchestrator}/
+│       ├── SKILL.md
+│       └── references/schemas/         # Schema copies (9 files)
+├── _workspace/
+│   ├── _schemas/
+│   ├── workflow.md
+│   ├── findings.md
+│   ├── tasks.md
+│   ├── checkpoint.json
+│   └── tasks/task_{agent}_{id}.json
+└── AGENTS.md                           # Harness pointer + project context
+```
+
+## Error Handling
+
+Zero-Tolerance: Agent failure → maximum 2 retries → if unresolved, set task\_\*.json status=blocked + HALT.
+
+## Reference Documents
+
+- `references/usage-examples.md` — Trigger utterance scenarios + mode mapping
+- `references/agent-design-patterns.md` — 7 patterns + Codex sandbox permission mapping
+- `references/orchestrator-template.md` — Step 0~5 pseudocode (Codex version)
+- `references/schemas/models.md` — Model ID source of truth (OpenAI)
+- `references/schemas/agent-worker.template.toml` — Worker agent TOML reference
+- `references/schemas/` — Runtime schema SoT (9 files)

--- a/harness/references/agent-design-patterns.md
+++ b/harness/references/agent-design-patterns.md
@@ -249,11 +249,15 @@ Codex CLI controls agent permissions with the single **`sandbox_mode`** field in
 
 ### Available Operations per sandbox_mode
 
-| sandbox_mode         | Available Operations                                                            | Representative Agents          |
-| -------------------- | ------------------------------------------------------------------------------- | ------------------------------ |
-| `read-only`          | shell `cat` · `find` · `grep` · `ls`, web fetch — no file writing              | Analyst, Architect             |
-| `workspace-write`    | + `apply_patch`, shell `tee` · write, subagent spawn, test execution            | Coder, Reviewer, State Manager |
-| `danger-full-access` | + external processes (kubectl, terraform, deploy, etc.)                         | Operator, Deployer             |
+| sandbox_mode         | Available Operations                                                            | Representative Agents                                          |
+| -------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `read-only`          | shell `cat` · `find` · `grep` · `ls`, web fetch — no file writing              | Analyst, Architect *(consultative — returns text, no writes)*  |
+| `workspace-write`    | + `apply_patch`, shell `tee` · write, subagent spawn, test execution            | Coder, Reviewer, State Manager, Architect *(document-producing)* |
+| `danger-full-access` | + external processes (kubectl, terraform, deploy, etc.)                         | Operator, Deployer                                             |
+
+> **Architect/Planner sandbox_mode decision rule:**
+> - Prompted to "analyze and return opinion/checklist" → `read-only` (orchestrator writes to findings.md)
+> - Prompted to "write `_workspace/…/*.md`" → **must be `workspace-write`** — `read-only` will silently block the write
 
 ### Special-purpose Tools
 
@@ -339,7 +343,7 @@ Four criteria for deciding whether to merge into a single agent or separate into
 name = "agent-name"
 description = "1-2 sentence role description. List trigger keywords. Also specify that follow-up tasks (revision/supplementation/re-execution) should use this agent."
 model = "{role tier ID verified from models.md}"  # ← Always refer to _workspace/_schemas/models.md
-sandbox_mode = "{{SANDBOX_MODE}}"              # read-only(Analyst/Architect) | workspace-write(Coder/Reviewer/QA) | danger-full-access(Operator)
+sandbox_mode = "{{SANDBOX_MODE}}"              # read-only(Analyst, consultative-Architect) | workspace-write(Coder/Reviewer/QA, document-producing-Architect) | danger-full-access(Operator)
 model_reasoning_effort = "high"   # low(StateManager) | medium(Analyst/Researcher) | high(Coder/QA) | xhigh(Orchestrator/Architect)
 
 developer_instructions = """
@@ -387,7 +391,7 @@ You are a [role] specialist in [domain].
 | Category       | Skill                                                                | Agent                                              |
 | -------------- | -------------------------------------------------------------------- | -------------------------------------------------- |
 | **Definition** | Procedural knowledge + tool bundle                                   | Expert persona + behavioral principles             |
-| **Location**   | `.agents/skills/{name}/SKILL.md`                                     | `.codex/agents/{name}.toml`                        |
+| **Location**   | `.codex/skills/{name}/SKILL.md`                                     | `.codex/agents/{name}.toml`                        |
 | **Trigger**    | Orchestrator auto-selects via user request keyword matching          | Orchestrator explicitly calls with `@{name}`       |
 | **Size**       | Small to large (workflows)                                           | Small (role definition)                            |
 | **Purpose**    | "**How** to do it"                                                   | "**Who** does it"                                  |
@@ -403,9 +407,9 @@ Three ways agents utilize skills.
 
 | Method                     | Implementation                                                                              | When Suitable                                                             |
 | -------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| **Direct skill file load** | Orchestrator reads via `cat .agents/skills/{name}/SKILL.md` and injects into prompt        | When the skill is an independent workflow and the user can call it directly |
+| **Direct skill file load** | Orchestrator reads via `cat .codex/skills/{name}/SKILL.md` and injects into prompt        | When the skill is an independent workflow and the user can call it directly |
 | **Inline in prompt**       | Skill content is directly included in the agent definition body                             | When the skill is short (50 lines or fewer) and **exclusive** to this agent |
-| **Reference load**         | Load `.agents/skills/{skill}/references/*.md` via shell `cat` as needed                    | When skill content is large and only **conditionally** needed             |
+| **Reference load**         | Load `.codex/skills/{skill}/references/*.md` via shell `cat` as needed                    | When skill content is large and only **conditionally** needed             |
 
 **Recommendation:**
 

--- a/harness/references/agent-design-patterns.md
+++ b/harness/references/agent-design-patterns.md
@@ -1,0 +1,416 @@
+# Subagent Orchestration Design Patterns (Codex CLI)
+
+## Table of Contents
+
+1. [Orchestration Mode Overview](#execution-mode-orchestration)
+2. [Thread-safe Task Board Protocol](#thread-safe-task-board-protocol-preventing-parallel-write-conflicts)
+3. [7 Core Architecture Patterns](#7-core-architecture-patterns)
+4. [Multi-stage Workflow Composition](#multi-stage-workflow-composition)
+5. [Persistence Protocol (Durable Execution)](#persistence-and-durability-protocol-durable-execution)
+6. [Tool Permission Control and Type Mapping](#tool-permission-control-and-type-mapping-guide)
+7. [Data Brokering Protocol](#data-brokering-protocol)
+8. [Subagent Interaction Styles](#subagent-interaction-styles)
+9. [Agent Separation Criteria](#agent-separation-criteria)
+10. [Agent Definition Structure](#agent-definition-structure-codex-cli-official-format)
+11. [Skill vs Agent Distinction](#skill-vs-agent-distinction)
+12. [Skill ↔ Agent Connection Methods](#skill--agent-connection-methods)
+
+---
+
+## Execution Mode: Orchestration
+
+In Codex CLI, the main agent acts as the **orchestrator** to coordinate subagents. Direct communication between subagents is not possible, but highly sophisticated collaboration can be achieved through the main agent's **brokering** and shared files.
+
+```
+[Main Agent (Orchestrator)]
+  ├── Data Brokering (Data Broker / findings.md)
+  ├── State Management (Atomic Task Board / tasks.md)
+  ├── Persistence Management (Persistence / checkpoint.json)
+  └── Shared Workspace (_workspace/{plan_name}/)
+        ├── @subagent-A (specialized toolset + dedicated task_A.json)
+        ├── @subagent-B (specialized toolset + dedicated task_B.json)
+        └── @subagent-C (specialized toolset + dedicated task_C.json)
+```
+
+> **Difference from Claude Code:** Claude Code has an "agent team" mode based on `TeamCreate`/`SendMessage`/`TaskCreate` that allows team members to communicate and broadcast directly to each other, but **Codex CLI does not have this team API**. When inter-member communication is needed, the main agent reads outputs via shell `cat` and injects them into the next agent's prompt — a **file brokering** approach. Subagents are invoked by the orchestrator using `@agent-name` directives, and when parallel execution is required, it is implemented as consecutive calls within a single turn. (Background execution of shell commands themselves is separately supported with `&`.)
+
+### Orchestration Model Selection Decision Tree
+
+```
+Are there 2 or more agents?
+├── Yes → Is information exchange between agents required?
+│         ├── Yes → Fan-out/Fan-in design where the main brokers via findings.md
+│         │         (cross-validation, discovery sharing, real-time feedback quality improvement)
+│         │
+│         └── No → Simple fan-out where the main only collects results
+│                  (one-pass patterns like produce-verify or expert pool)
+│
+└── No (1 agent) → Single subagent call
+              (a single agent does not need orchestration)
+```
+
+> **Core Principle:** In Codex CLI, the premise that "the main agent is the sole broker" underpins all patterns. When selecting a pattern, first design "at what point and what information should the main agent broker?"
+
+---
+
+## Thread-safe Task Board Protocol (Preventing Parallel Write Conflicts)
+
+When multiple agents run in parallel, data can be lost if they attempt to write to the shared file `tasks.md` simultaneously. To prevent this, follow the **Atomic Task Management** principles below.
+
+### 1. Split Task Artifacts
+
+- **Principle:** Subagents must never directly modify the shared `tasks.md`.
+- **Implementation:** Each agent writes its task results to a **dedicated individual file** such as `_workspace/tasks/task_{agent_name}_{task_id}.json`.
+- **Content:** Includes task status (`status`), evidence (`evidence`), and output path (`path`).
+
+### 2. Sole Aggregator
+
+- **Principle:** The sole write authority over `tasks.md` and `checkpoint.json` belongs to the **main agent (orchestrator)**.
+- **Workflow:**
+  1. The main agent calls parallel agents.
+  2. Each agent creates its own individual task file and exits.
+  3. The main agent scans with `shell ls _workspace/tasks/` and reads all individual files.
+  4. The main agent performs an Atomic Update of `tasks.md` at once based on the data it has read.
+
+---
+
+## 7 Core Architecture Patterns
+
+### 1. Pipeline — Sequentially Dependent Tasks
+
+A flow where the output of the previous stage is used as the input of the next stage.
+
+```
+[Analysis] → [Design] → [Implementation] → [Validation]
+```
+
+- **Coordination:** Sequential calls. After the Nth agent completes, the main summarizes results to `findings.md` → injects into the (N+1)th agent's prompt.
+- **Usage Example (Orchestrator's invocation style):**
+  > **Main:** `` `@{analyst}`, please analyze the requirements and save them to `_workspace/{plan_name}/01_reqs.md`. Check the latest specification as needed.
+(After completion)
+**Main:** `` `@{coder}`, read `_workspace/{plan_name}/01_reqs.md` and implement while adhering to the [Key Constraints] in `findings.md`. Save the result to `_workspace/{plan_name}/02_code.md`.
+- **Suitable for:** Novel writing (world-building → characters → plot → writing → editing), design → implementation → validation flows.
+- **Caution:** A bottleneck delays the entire pipeline. Design each stage to be as independent as possible, and verify whether consecutive stages represent a "true dependency" needed at every point. Choosing a pipeline merely out of preference for sequential order means missing parallelization opportunities.
+
+### 2. Fan-out/Fan-in — Parallel Investigation and Integration
+
+Performs independent tasks simultaneously and combines the results into one.
+
+```
+         ┌→ [Expert A] ─┐
+[Distribute] → ├→ [Expert B] ─┼→ [Integrate]
+         └→ [Expert C] ─┘
+```
+
+- **Coordination:** Call `@A`, `@B`, `@C` consecutively in a single response turn → each saves outputs under `_workspace/{plan_name}/` → when the main calls the integration agent, it injects all output paths into the prompt.
+- **Usage Example (Orchestrator's invocation style):**
+  > **Main:** (batch calls within a single turn)
+  >
+  > 1. `` `@{researcher-market}`, research market trends and record them in `\_workspace/{plan_name}/mkt.md`.
+  > 2. `` `@{researcher-tech}`, research technical feasibility and record it in `_workspace/{plan_name}/tech.md`.
+(After all complete)
+**Main:** `` `@{strategist}`, read both `_workspace/{plan_name}/mkt.md` and `_workspace/{plan_name}/tech.md`, resolve any conflicting data noted in the [Data Conflicts] section of `findings.md`, and formulate the final strategy.
+- **Suitable for:** Comprehensive research (simultaneous investigation of official sources/media/community/background → integration), multi-module development.
+- **Caution:** The quality of the integration stage determines overall quality. Since discoveries between experts may **conflict**, the main should include a [Data Conflicts] section in `findings.md` and instruct the integration agent to resolve conflicts without fail.
+
+### 3. Expert Pool — Situational Expert Selection
+
+Selects and calls the most suitable subagent based on the nature of the user's request.
+
+```
+[Router] → { Expert A | Expert B | Expert C }
+```
+
+- **Coordination:** The main agent classifies the input and calls only the agent for that domain.
+- **Invocation style:** Always sequential calls. Do not call multiple experts simultaneously.
+- **Usage Example (Orchestrator's invocation style):**
+  > **Main:** (User request: "Improve React performance")
+  > **Main:** `` `@{perf-expert}`, analyze the current code and find bottlenecks. `@{security-expert}` is excluded from this task.
+- **Suitable for:** Multilingual support (native agents per language), code review (choosing security/performance/architecture experts), stack-specific specialized reviews.
+- **Caution:** The classification accuracy of the router (main) is critical. If classification is ambiguous, clarify by requesting user confirmation, or call two experts simultaneously for cross-validation.
+
+### 4. Producer-Reviewer — Quality Assurance Loop
+
+A producer and reviewer iterate in a loop to refine outputs.
+
+```
+[Produce] → [Review] → (if issues) → [Produce] re-run
+```
+
+- **Coordination:** Main calls the producer → reads output and summarizes to `findings.md` → calls reviewer (injecting output path) → reads review report, and if there are issues, re-calls the producer (injecting the report).
+- **Usage Example (Orchestrator's invocation style):**
+  > **Main:** `` `@{writer}`, draft the document.
+**Main:** `` `@{editor}`, review the draft and leave revision suggestions in `_workspace/{plan_name}/edit_notes.md` according to qa-standard criteria.
+  > (If review result is 'Fail')
+  > **Main:** `` `@{writer}`, revise the draft incorporating the feedback from `\_workspace/{plan_name}/edit_notes.md`. (Maximum 2 retries, 3 total)
+- **Suitable for:** Webtoons (artist → reviewer → regeneration), high-quality code writing, technical document proofreading.
+- **Caution:** **To prevent infinite loops, setting a maximum of 2 retries (3 total) is mandatory.** If still failing after 3 attempts, the main requests user confirmation to transfer decision-making to a human.
+
+### 5. Supervisor — Dynamic Task Assignment
+
+The main agent analyzes workload and dependencies at runtime to distribute tasks.
+
+```
+         ┌→ [Worker A]
+[Supervisor] ─┼→ [Worker B]    ← Supervisor dynamically distributes based on status
+         └→ [Worker C]
+```
+
+- **Coordination:** State management using `tasks.md`. The main splits the `Todo` list and batch-assigns to each worker. After a worker completes, the main **must verify success via `Evidence` or `qa_report.md`** before updating to `Done` and assigning the next batch.
+- **Usage Example (Orchestrator's invocation style):**
+  > **Main:** There are 50 migration tasks in `tasks.md`.
+  >
+  > 1. `` `@{worker-1}`, complete task IDs 1–10.
+  > 2. `` `@{worker-2}`, complete task IDs 11–20.
+(After completion report arrives)
+**Main:** `@{worker-1}`, I have confirmed the outputs and test logs (`Evidence`). Since they passed, mark them as `Done` and now complete tasks 21–30. **If any tasks fail, do not skip them — stop immediately and report a solution.**
+- **Suitable for:** Large-scale file migration, bulk data processing.
+- **Difference from Fan-out:** Fan-out distributes tasks in advance with fixed assignments; Supervisor adjusts dynamically by observing progress.
+- **Caution:** Set delegation units large enough so the supervisor (main) does not become a bottleneck (calling 1 file × 100 times < calling 10 files × 10 times).
+
+### 6. Hierarchical Delegation — Recursive Problem Decomposition
+
+A higher-level agent delegates recursively to lower-level agents. Complex problems are broken down step by step.
+
+```
+[Director] → [Team Lead A] → [Practitioner A1]
+                           → [Practitioner A2]
+           → [Team Lead B] → [Practitioner B1]
+```
+
+- **Coordination:** Nested agent calls with summarized context forwarding. Team lead agents split the instructions they receive and re-invoke practitioner agents.
+- **Usage Example (Orchestrator's invocation style):**
+  > **Main:** `` `@{frontend-lead}`, oversee the UI system construction.
+**@{frontend-lead}:** (within the prompt) I will instruct `` `@{component-coder}` to implement the button component and `` `@{style-coder}` to implement the theme system.
+- **Suitable for:** Full-stack application development (director → frontend lead → UI/logic/tests + backend lead → API/DB/tests), complex system architecture design.
+- **Caution:** **More than 3 levels deep causes significant delays and context loss — 2 levels or fewer is recommended**. Team lead agents should summarize practitioner outputs before forwarding to the director, while preserving originals in `_workspace/{plan_name}/{team}/`.
+
+### 7. Handoff — Agent-driven Delegation
+
+Instead of the main pre-determining all paths, the practitioner agent performs a task and then recommends **"the most suitable expert for the next step"** to the orchestrator, transferring control.
+
+- **Coordination:** When an agent leaves a `[NEXT_AGENT: @expert-name]` keyword and recommendation rationale at the end of its output, the orchestrator parses this and dynamically summons the next agent.
+- **Routing Principle:** Agents consult the list of other agents in the project (based on descriptions) to make recommendations.
+- **Usage Example (Orchestrator's invocation style):**
+  > **Main:** `` `@{log-analyzer}`, analyze the error logs and identify the root cause. If specialized handling is needed, be sure to leave `[NEXT_AGENT: @{agent-name}] Reason: {specific reason}` at the end of your output.
+(log-analyzer completes, end of output: `[NEXT_AGENT: @security-patcher] Reason: Authentication vulnerability found due to missing JWT validation`)
+**Main:** (after parsing the keyword) `` `@{security-patcher}`, read `_workspace/{plan_name}/log_analysis.md` and patch the identified authentication vulnerability.
+- **Suitable for:** Exploratory debugging (log analysis → reproduction attempt → handoff to fix specialist), complex support processes.
+- **Caution:** Preventing circular handoffs (A → B → A) infinite loops is essential — the orchestrator tracks call history and does not re-summon an agent that has already been executed. If a handoff chain occurs 3 or more stages or there is no recommended target agent, transfer decision-making to the user via confirmation request. Detection pseudocode: see `references/orchestrator-procedures.md` — "handle_handoff".
+
+---
+
+## Multi-stage Workflow Composition
+
+The 7 basic patterns are **combined at the Step level**. Declaring them in a Stage-Step structure allows each Step to have an independent pattern, enabling precise multi-stage workflows. Details: `references/stage-step-guide.md`.
+
+| Workflow Type                        | Step Composition                                                                              | Example                                                                       |
+| ------------------------------------ | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| **Parallel Collection → Review Loop** | Stage 1 / Step 1: fan_out_fan_in → Stage 2 / Step 1: producer_reviewer                      | Multilingual translation — parallel translation in 4 languages → native reviewer loop |
+| **Sequential Design → Parallel Validation** | Stage 1 / Step 1-N: pipeline → Stage 2 / Step 1: fan_out_fan_in                      | Requirements · design · API design (sequential) → security · performance · compatibility validation (parallel) |
+| **Classification → Expert Analysis → Review** | Stage 1 / Step 1: expert_pool, Step 2: pipeline → Stage 2 / Step 1: producer_reviewer | Issue classification → expert analysis → report review              |
+
+### Multi-stage Workflow Coordination Points (Codex CLI)
+
+| Scenario                    | Brokering Strategy                                                                                    | Caution                                                                                           |
+| --------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| **Research + Analysis**     | Merge investigator outputs into `findings.md` in real time; log conflicting discoveries in the [Data Conflicts] section | If the integration agent cannot resolve conflicts, call for user confirmation |
+| **Design + Implementation + Validation** | Design output → inject into implementation agent prompt → implementation result → inject into validation agent prompt | Between each stage, do not merely **pass file paths** — also extract **key constraints** into `findings.md` and inject them |
+| **Supervisor + Workers**    | Synchronize state via `tasks.md`; workers read only their assigned tasks                              | Supervisor divides work by file so that multiple concurrently assigned workers do not modify the same file |
+| **Production + Validation** | Produce → validation report (`qa_report.md`) → inject report into prompt on re-production             | Maximum 2 retries (3 total); request user confirmation if exceeded                               |
+
+---
+
+## Persistence and Durability Protocol (Durable Execution)
+
+All orchestration workflows must have **Persistence** to guard against network failures, timeouts, and model errors.
+
+### 1. Checkpoint Protocol (`checkpoint.json`)
+
+The orchestrator creates or updates `_workspace/checkpoint.json` upon every agent task completion.
+
+- **Required data:**
+  - `last_successful_step`: The last successfully completed Step number or agent name.
+  - `tasks_snapshot`: A summary of the current state data in `tasks.md`.
+  - `shared_variables`: Key constants or variable values shared between agents.
+- **Advantage:** Even if execution is interrupted, the checkpoint is detected at Step 0 and **resumption from the point of failure is immediately possible**.
+
+### 2. Idempotency Guarantee Principles
+
+- **Duplicate prevention:** Each agent checks whether its target output file already exists at the start of execution.
+- **State-based skipping:** If the content is up to date and no modification is needed, the task is not performed and a completion signal is sent immediately to prevent token waste.
+- **Atomic writing:** `tasks.md` is not changed to `Done` before file writing is complete.
+
+---
+
+## sandbox_mode Permission Control Guide
+
+Codex CLI controls agent permissions with the single **`sandbox_mode`** field instead of a `tools:` array. Follow the principle of least privilege appropriate to the role.
+
+### Available Operations per sandbox_mode
+
+| sandbox_mode         | Available Operations                                                            | Representative Agents          |
+| -------------------- | ------------------------------------------------------------------------------- | ------------------------------ |
+| `read-only`          | shell `cat` · `find` · `grep` · `ls`, web fetch — no file writing              | Analyst, Architect             |
+| `workspace-write`    | + `apply_patch`, shell `tee` · write, subagent spawn, test execution            | Coder, Reviewer, State Manager |
+| `danger-full-access` | + external processes (kubectl, terraform, deploy, etc.)                         | Operator, Deployer             |
+
+### Special-purpose Tools
+
+Special tools confirmed in Codex CLI. Do not grant to general worker agents; allow only selectively for roles that require them.
+
+| Tool                | Purpose                                              | Recommended Agents                                                                     |
+| ------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `@agent-name` call  | Subagent invocation                                  | Orchestrator, Supervisor, Hierarchical team leads (Mid-level) only — prohibited for general workers |
+| `save_memory`       | Persisting key information across sessions           | Orchestrator (as a supplement to checkpoints)                                          |
+| `write_todos`       | Built-in to-do list management (lightweight alternative to `tasks.md`) | Orchestrator for single-agent tasks                           |
+| `get_internal_docs` | Querying Codex CLI internal documentation            | Analyst, Architect                                                                     |
+
+> **Caution:** `save_memory` does **not replace** file-based persistence via `checkpoint.json`. Files are more reliable when resuming a session. Use `save_memory` only for small amounts of data that are cumbersome to manage as files, such as agent personas or shared constants.
+
+### MCP Tool Mapping Examples
+
+- **GitHub specialist agent:** Assign only `mcp_github_*` tools, dedicated to issue management and PR handling.
+- **Infrastructure specialist:** Restrict permissions with `mcp_kubernetes_*` or `mcp_terraform_*` tools.
+- **Documentation specialist:** Assign mainly shell `curl` · `cat` for building a knowledge base.
+
+### Model Selection Guide
+
+| Agent Role                              | Model Tier                        | Where to Verify Actual IDs                    |
+| --------------------------------------- | --------------------------------- | --------------------------------------------- |
+| Orchestrator, Architect                 | **thinking tier** (`gpt-5.5`)     | `references/schemas/models.md` (SoT)          |
+| Coder, Analyst, Reviewer, Operator      | **codex tier** (`gpt-5.3-codex`)  | `references/schemas/models.md` (SoT)          |
+| State Manager                           | **mini tier** (`gpt-5.4-mini`)    | `references/schemas/models.md` (SoT)          |
+
+> **Important:** Do not hard-code model IDs directly in code. Always verify with `_workspace/_schemas/models.md` via shell `cat` before using. OpenAI model IDs change periodically, and incorrect IDs will cause runtime errors.
+> **Reason:** Workers have a narrow scope and are called repeatedly. The codex tier has speed and cost advantages over thinking. Only the Orchestrator and Architect use thinking.
+
+`model_reasoning_effort` selection criteria and value list: see `references/schemas/models.md` (`low` / `medium` / `high` / `xhigh`).
+
+---
+
+## Data Brokering Protocol
+
+The main agent brokers **Discoveries** between subagents in real time.
+
+1. **Real-time recording:** Every time the main agent reads intermediate results, it summarizes key insights to `_workspace/findings.md`.
+2. **Context injection:** When calling the next subagent, inject "Key discoveries so far: [findings.md content]" into the prompt.
+3. **State synchronization:** Instruct all agents to read `_workspace/tasks.md` every time they are called, to understand the full context.
+4. **Conflict brokering:** If agent outputs conflict, explicitly note in the [Data Conflicts] section of `_workspace/findings.md` → request arbitration from a specialist (typically the Reviewer).
+
+## Subagent Interaction Styles
+
+In addition to structural patterns, the orchestrator can choose the **style** in which it communicates with agents to maximize efficiency.
+
+| Style                         | Invocation Method    | Characteristics                                                                 | When Suitable                                                       |
+| :---------------------------- | :------------------- | :------------------------------------------------------------------------------ | :------------------------------------------------------------------ |
+| **Full Delegation**           | Subagent call        | The subagent completes the task end-to-end (including file creation).           | Independent practical work such as coding, research, test execution. |
+| **Consultative**              | Subagent call        | Returns only **"analysis opinion"** or **"checklist"** instead of deliverables. | Architecture review, security inspection, implementation strategy planning. |
+| **Manual Intervention**       | `@agent_name`        | The user directly summons a specific agent from the terminal.                   | When the user wants to manually re-verify only a specific stage during harness execution. |
+
+### Advanced Tips by Style
+
+- **Using the consultative style:** Before the main agent writes code directly, summon `@architect` and ask only for "an opinion on what structure would be best." The main then records that opinion in `findings.md` and writes the code directly, resulting in less context loss.
+- **Prompting manual intervention:** Guide the orchestrator to suggest to the user: "Would you like to call `@agent-name` directly to review the detailed logs?" when the orchestrator cannot resolve an error.
+- **The power of tool isolation:** Consultative-style agents can be designed without `apply_patch` permission and with only shell `cat`, ensuring they provide only "knowledge" without accidentally touching code.
+
+---
+
+## Agent Separation Criteria
+
+Four criteria for deciding whether to merge into a single agent or separate into distinct agents.
+
+| Criterion         | Separate                                                              | Merge                                        |
+| ----------------- | --------------------------------------------------------------------- | -------------------------------------------- |
+| **Specialization** | Separate if domains (domain · language · stack) differ               | Merge if domains overlap                     |
+| **Parallelism**   | Separate if independently executable (reduces delay via parallel calls) | Consider merging if sequentially dependent  |
+| **Context**       | Separate if context burden is large (each reads only a small scope)  | Merge if lightweight and fast                |
+| **Reusability**   | Separate if used by other teams/scenarios                            | Consider merging if used only by this team   |
+
+**Additional Codex CLI considerations:** Every separation increases the main agent's brokering burden (updating `findings.md` before and after each agent call). Verify whether the benefit of separation outweighs the brokering overhead. When in doubt, start with a unified agent and separate when reuse requirements arise.
+
+---
+
+## Agent Definition Structure (Codex CLI Official Format)
+
+> **When creating agent files:** Do not use inline examples — read **`_workspace/_schemas/agent-worker.template.toml`** (for workers) or **`agent-orchestrator.template.md`** (for orchestrators) via shell `cat`, substitute variables, then create. Model IDs must be verified from **`_workspace/_schemas/models.md`** — never guess arbitrarily.
+
+```toml
+name = "agent-name"
+description = "1-2 sentence role description. List trigger keywords. Also specify that follow-up tasks (revision/supplementation/re-execution) should use this agent."
+model = "{role tier ID verified from models.md}"  # ← Always refer to _workspace/_schemas/models.md
+sandbox_mode = "{{SANDBOX_MODE}}"              # read-only(Analyst/Architect) | workspace-write(Coder/Reviewer/QA) | danger-full-access(Operator)
+model_reasoning_effort = "high"   # low(StateManager) | medium(Analyst/Researcher) | high(Coder/QA) | xhigh(Orchestrator/Architect)
+
+developer_instructions = """
+# Agent Name — One-line Role Summary
+
+You are a [role] specialist in [domain].
+
+## Core Responsibilities
+
+1. Responsibility 1
+2. Responsibility 2
+
+## Operating Principles
+
+- Principle 1
+- Principle 2
+
+## Input/Output Protocol (Data Broker-based)
+
+- **Input briefing:** Read the `findings.md` summary and the assigned task from `tasks.md` injected into the prompt at call time.
+- **Output path:** `_workspace/{plan_name}/{step}/{agent}-result.md` (or the path specified by the orchestrator).
+- **Format:** [File format, section structure, required fields]
+- **Completion signal:** After recording the output, print the "completion keyword" specified in the prompt.
+
+## Error Handling
+
+- Missing required input → request supplementation via user confirmation request.
+- Data conflict discovered → add to [Data Conflicts] in `findings.md` and mark as unable to proceed.
+- Timeout/retry limit reached → report failure to the orchestrator with detailed logs.
+
+## Relationship with Other Agents
+
+- Predecessor: [Which agent's output does this agent depend on?]
+- Successor: [Which agent consumes this agent's output?]
+- Note: Direct communication between subagents is not possible. All collaboration goes through `findings.md`.
+"""
+```
+
+> **Caution:** The "team communication protocol (SendMessage)" section of Claude Code agent definitions does not exist in Codex CLI. Instead, specifying file paths, completion signals, and briefing methods in the "Input/Output Protocol" serves the same role.
+
+---
+
+## Skill vs Agent Distinction
+
+| Category       | Skill                                                                | Agent                                              |
+| -------------- | -------------------------------------------------------------------- | -------------------------------------------------- |
+| **Definition** | Procedural knowledge + tool bundle                                   | Expert persona + behavioral principles             |
+| **Location**   | `.agents/skills/{name}/SKILL.md`                                     | `.codex/agents/{name}.toml`                        |
+| **Trigger**    | Orchestrator auto-selects via user request keyword matching          | Orchestrator explicitly calls with `@{name}`       |
+| **Size**       | Small to large (workflows)                                           | Small (role definition)                            |
+| **Purpose**    | "**How** to do it"                                                   | "**Who** does it"                                  |
+| **Statefulness** | Stateless (procedure re-executed on every call)                    | Persona and principles fixed, context maintained within session |
+
+**Summary:** A skill is a **procedural guide** that an agent references when performing a task, and an agent is a **specialist role definition** that utilizes skills.
+
+---
+
+## Skill ↔ Agent Connection Methods
+
+Three ways agents utilize skills.
+
+| Method                     | Implementation                                                                              | When Suitable                                                             |
+| -------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| **Direct skill file load** | Orchestrator reads via `cat .agents/skills/{name}/SKILL.md` and injects into prompt        | When the skill is an independent workflow and the user can call it directly |
+| **Inline in prompt**       | Skill content is directly included in the agent definition body                             | When the skill is short (50 lines or fewer) and **exclusive** to this agent |
+| **Reference load**         | Load `.agents/skills/{skill}/references/*.md` via shell `cat` as needed                    | When skill content is large and only **conditionally** needed             |
+
+**Recommendation:**
+
+- High reusability → skill
+- Exclusive → inline
+- Large + conditional → shell `cat` reference load
+
+**Principle:** The orchestrator reads the necessary skill files via shell `cat` and injects them into the agent prompt. Behavioral principles, protocols, and checklists should almost always be separated into skills for higher reusability and maintainability.

--- a/harness/references/evolution-protocol.md
+++ b/harness/references/evolution-protocol.md
@@ -71,7 +71,7 @@ Systematically performs inspection, modification, and synchronization of an exis
 ### Step 1: Status Audit
 
 - Compare the file list in `.codex/agents/` against the agent configuration in the orchestrator skill → generate a discrepancy list.
-- Compare the directory list in `.agents/skills/` against the skill configuration in the orchestrator skill → generate a discrepancy list.
+- Compare the directory list in `.codex/skills/` against the skill configuration in the orchestrator skill → generate a discrepancy list.
 - Report audit results to the user.
 
 ### Step 2: Incremental Addition/Modification

--- a/harness/references/evolution-protocol.md
+++ b/harness/references/evolution-protocol.md
@@ -1,0 +1,94 @@
+# Harness Evolution Protocol
+
+The detailed workflow for Step 7 in `SKILL.md`. A harness is not a static artifact built once and finished — it is a system that continuously evolves based on user feedback. Load this file first when entering the "Operations/Maintenance" branch from Step 0, or when a user requests "harness inspection/audit/sync/expansion" or similar.
+
+---
+
+## Table of Contents
+
+1. [Post-Execution Feedback Collection](#1-post-execution-feedback-collection)
+2. [Feedback Incorporation Paths](#2-feedback-incorporation-paths)
+3. [Change History Management](#3-change-history-management)
+4. [Evolution Triggers](#4-evolution-triggers)
+5. [Operations/Maintenance Workflow](#5-operationsmaintenance-workflow)
+
+---
+
+## 1. Post-Execution Feedback Collection
+
+After each harness execution completes, request feedback from the user.
+
+- "Are there any areas in the results you would like to improve?"
+- "Are there any changes you would like to make to the agent configuration or workflow?"
+
+If there is no feedback, move on. Do not pressure the user, but always offer the opportunity.
+
+---
+
+## 2. Feedback Incorporation Paths
+
+The modification target differs depending on the type of feedback.
+
+| Feedback Type       | Modification Target               | Example                                                       |
+| ------------------- | --------------------------------- | ------------------------------------------------------------- |
+| Output quality      | The relevant agent's skill        | "Analysis too superficial" → add depth criteria to skill      |
+| Agent role          | Agent definition `.toml`          | "Security review also needed" → add new agent                 |
+| Workflow order      | Orchestrator skill                | "Validation should come first" → reorder Steps                |
+| Team composition    | Orchestrator + agents             | "These two can be merged" → merge agents                      |
+| Missing trigger     | Skill description                 | "Doesn't work with this phrasing" → expand description        |
+
+---
+
+## 3. Change History Management
+
+All changes are recorded in the **Change History** table in AGENTS.md (same as the history section in the Step 5-4 AGENTS.md template).
+
+```markdown
+**Change History:**
+| Date       | Change           | Target                          | Reason                                  |
+|------------|------------------|---------------------------------|-----------------------------------------|
+| 2026-04-05 | Initial setup    | Entire harness                  | -                                       |
+| 2026-04-07 | Added QA agent   | agents/qa-inspector.toml        | Feedback: insufficient output validation|
+| 2026-04-10 | Added tone guide | skills/content-creator          | Feedback: "too stiff"                   |
+```
+
+---
+
+## 4. Evolution Triggers
+
+Evolution is proposed not only when the user explicitly says "modify the harness," but also in the following situations:
+
+- When the same type of feedback recurs 2 or more times.
+- When a pattern of repeated agent failures is detected.
+- When the user is observed bypassing the orchestrator and working manually.
+
+---
+
+## 5. Operations/Maintenance Workflow
+
+Systematically performs inspection, modification, and synchronization of an existing harness. Follow this workflow when entering the "Operations/Maintenance" branch from Step 0.
+
+### Step 1: Status Audit
+
+- Compare the file list in `.codex/agents/` against the agent configuration in the orchestrator skill → generate a discrepancy list.
+- Compare the directory list in `.agents/skills/` against the skill configuration in the orchestrator skill → generate a discrepancy list.
+- Report audit results to the user.
+
+### Step 2: Incremental Addition/Modification
+
+- Perform agent/skill additions, modifications, or deletions per user request.
+- Classify the change type and determine which Step to execute: see `references/expansion-matrix.md` — `classify_change()`.
+- Make changes one at a time; run Step 3 immediately after each change.
+
+> **In-flight evolution safety:** If skill/agent files are modified while the harness is currently running (`_workspace/checkpoint.json` status: `"in_progress"` or `"partial"`), the orchestrator will restore its position on the next cycle re-entry by reading `current_stage`, `current_step`, and `active_pattern` from checkpoint.json. Therefore, **already-completed Steps are not re-executed**, and execution resumes from the `current_step` restore point when entering the next Step. Modified agent/skill files take effect from the next time the orchestrator calls that agent. However, if the modification affects the agent or exit conditions of the currently running Step, suggest to the user that they either manually re-run that Step (roll back `current_step` in `checkpoint.json`) or restart from the beginning.
+
+### Step 3: Update AGENTS.md Change History
+
+- Record the date, change content, target, and reason in the change history table.
+
+### Step 4: Change Validation
+
+- Validate the structure of modified agents/skills (per Step 6-1 criteria).
+- If the modification scope affects triggers, validate triggers (per Step 6-4 criteria).
+- For large-scale changes (architecture changes, 3+ agents added/removed), also perform Step 6-3 (execution test) and 6-5 (dry run).
+- Final check: confirm AGENTS.md matches the actual files.

--- a/harness/references/examples/full-bundle/sso-style.md
+++ b/harness/references/examples/full-bundle/sso-style.md
@@ -19,7 +19,7 @@
 
 ---
 
-## 2. 오케스트레이터 SKILL.md (`.agents/skills/sso-dev-flow/SKILL.md`)
+## 2. 오케스트레이터 SKILL.md (`.codex/skills/sso-dev-flow/SKILL.md`)
 
 ```markdown
 ---

--- a/harness/references/examples/full-bundle/sso-style.md
+++ b/harness/references/examples/full-bundle/sso-style.md
@@ -1,0 +1,206 @@
+# Full Bundle Example: SSO 개발 하네스 (전체 산출물 패키지)
+
+기존 `examples/step/01~05`는 workflow.md 스니펫만 보여준다. 이 파일은 한 도메인 하네스의 **전체 산출물**(오케스트레이터 SKILL.md + 에이전트 N개 + workflow.md + findings.md 초기화 + checkpoint.json 초기화)을 **통합 패키지**로 시연한다. examples/sso-dev-flow처럼 평면 Step 나열로 도피하는 drift를 막기 위한 정본 예시.
+
+> **사용처:** 새 하네스 구축 시 이 패키지를 참고하여 모든 산출물을 동시에 작성. 하나라도 누락 시 Zero-Tolerance Failure.
+
+---
+
+## 1. 도메인 분해
+
+- **목표:** SSO 인증 기능 구현
+- **작업(Stage) 분해:**
+  - Stage 1: `research-plan` (요구사항 분석 + 설계, 작업 게이트 1회)
+  - Stage 2: `develop-review` (구현 + QA 루프, 마지막 stage)
+- **Step(하위 이슈) 분해:**
+  - research-plan/research = pipeline (분석가 단독)
+  - research-plan/plan = pipeline (설계가 단독)
+  - develop-review/loop = producer_reviewer (개발자 ↔ QA)
+
+---
+
+## 2. 오케스트레이터 SKILL.md (`.agents/skills/sso-dev-flow/SKILL.md`)
+
+```markdown
+---
+name: sso-dev-flow
+description: SSO 인증 기능 구현 하네스. workflow.md 기반 Stage-Step 조율, findings.md·tasks.md·checkpoint.json 영속화. "SSO 구현해줘", "SAML 추가해줘", "로그인 흐름 개선" 트리거. 후속 작업("SSO 결과 수정", "재실행", "보완", "이전 결과 개선") 시에도 반드시 이 스킬 사용.
+---
+
+# Skill: SSO Dev Flow Orchestrator
+
+## 가상 팀
+
+| agent           | 타입   | 역할               | 출력                            |
+| --------------- | ------ | ------------------ | ------------------------------- |
+| @sso-researcher | 커스텀 | 요구사항·코드 분석 | \_workspace/sso/research.md     |
+| @sso-planner    | 커스텀 | 아키텍처 설계      | \_workspace/sso/plan.md         |
+| @go-developer   | 커스텀 | Go 코드 구현       | src/auth/\*.go                  |
+| @qa-reviewer    | 커스텀 | 보안·정합성 검증   | \_workspace/sso/qa_verdict.json |
+
+## 워크플로우
+
+### Step 0: 컨텍스트 확인 (Durable Execution)
+
+표준 절차 적용 — `references/orchestrator-template.md` Step 0 참조. checkpoint.json status별 분기.
+
+### Step 1: 초기화
+
+1. `_workspace/sso/`, `_workspace/tasks/` 디렉터리 생성.
+2. workflow.md 작성 (§3 참조).
+3. findings.md 초기화 (§4 참조).
+4. tasks.md 초기화 (§5 참조).
+5. checkpoint.json 생성 (§6 참조).
+6. **workflow.md 스키마 검증** — 6 필수 필드 + 검증 가능 종료 조건 + 패턴 enum.
+7. workflow.md 사이클 검증.
+
+### Step 2: Step 실행 루프
+
+표준 절차 — `references/orchestrator-template.md` Step 2 참조. 패턴별 호출, 종료 조건 검사, 자동/승인 전환.
+
+### Step 3: producer_reviewer 루프 (develop-review/loop 전용)
+
+1. @go-developer 호출 (구현).
+2. @qa-reviewer 호출 (검증) → qa_verdict.json.
+3. verdict=PASS → step done.
+4. verdict=REJECT → findings.md `[변경 요청]` 갱신 → @go-developer 재호출.
+5. iterations=3 도달 시 `Blocked` + 사용자 확인 요청.
+
+## 에러 핸들링
+
+Zero-Tolerance: 에이전트 실패 → 최대 2회 재시도 → 미해결 시 `task_*.json` status=blocked + 사용자 확인 요청. 임의 Skip 금지.
+```
+
+---
+
+## 3. workflow.md (`_workspace/workflow.md`)
+
+```markdown
+<!-- 참고 패턴: research-plan=pipeline, develop-review=producer_reviewer -->
+<!-- Stage = 상위 이슈(Jira Issue). Step = 하위 이슈(Jira Sub-issue). -->
+
+## Stage 정의
+
+### Stage 1: research-plan
+
+- 종료 조건: 모든 step 완료
+- 다음 stage: develop-review
+- 사용자 승인 게이트: 필요
+
+#### Step 1: research
+
+- 패턴: pipeline
+- 활성 에이전트: [@sso-researcher]
+- 종료 조건: `_workspace/sso/research.md` 존재
+- 다음 step: plan
+- 최대 반복 횟수: 1
+
+#### Step 2: plan
+
+- 패턴: pipeline
+- 활성 에이전트: [@sso-planner]
+- 종료 조건: `_workspace/sso/plan.md` 존재 + `_workspace/sso/tasks_decomposed.json`의 task_count ≥ 1
+- 다음 step: done
+- 최대 반복 횟수: 1
+
+### Stage 2: develop-review
+
+- 종료 조건: 모든 step 완료
+- 다음 stage: done
+- 사용자 승인 게이트: 없음 (마지막 stage)
+
+#### Step 1: loop
+
+- 패턴: producer_reviewer
+- 활성 에이전트: [@go-developer, @qa-reviewer]
+- 종료 조건: `_workspace/sso/qa_verdict.json`의 verdict=PASS
+- 다음 step: done
+- 최대 반복 횟수: 3
+```
+
+**스키마 검증 통과 포인트:**
+
+- 6 필수 필드 모두 존재
+- 종료 조건 모두 검증 가능 술어 (파일 존재 / JSON 필드값)
+- 자연어 표현(`승인`·`충분`·`완료되면`) 0건
+- 패턴 enum 위반 없음
+
+---
+
+## 4. findings.md 초기화 (`_workspace/findings.md`)
+
+```markdown
+# Findings: SSO Dev Flow
+
+## [공유 변수/경로]
+
+- 작업 디렉터리: `_workspace/sso/`
+- 산출물: research.md, plan.md, tasks_decomposed.json, qa_verdict.json
+
+## [다음 단계 지침]
+
+(Stage 1 종료 시 메인이 작성)
+
+## [변경 요청]
+
+(Stage 2 producer_reviewer REJECT 시 메인이 작성)
+```
+
+---
+
+## 5. tasks.md 초기화 (`_workspace/tasks.md`)
+
+```markdown
+| ID  | 에이전트        | 작업 내용            | 상태 | Evidence | 산출물 경로                     |
+| --- | --------------- | -------------------- | ---- | -------- | ------------------------------- |
+| 1   | @sso-researcher | 요구사항·코드 분석   | Todo | -        | \_workspace/sso/research.md     |
+| 2   | @sso-planner    | 아키텍처·태스크 분해 | Todo | -        | \_workspace/sso/plan.md         |
+| 3   | @go-developer   | Go 코드 구현         | Todo | -        | src/auth/\*.go                  |
+| 4   | @qa-reviewer    | 보안·정합성 검증     | Todo | -        | \_workspace/sso/qa_verdict.json |
+```
+
+---
+
+## 6. checkpoint.json 초기화 (`_workspace/checkpoint.json`)
+
+```json
+{
+  "execution_id": "20260427_140000",
+  "plan_name": "sso",
+  "status": "in_progress",
+  "current_stage": "research-plan",
+  "current_step": "research",
+  "active_pattern": "pipeline",
+  "stage_history": [],
+  "step_history": [],
+  "stage_artifacts": {},
+  "handoff_chain": [],
+  "tasks_snapshot": { "done": [], "current": null },
+  "shared_variables": {},
+  "last_updated": "20260427_140000"
+}
+```
+
+---
+
+## 7. examples/sso-dev-flow와의 비교
+
+| 항목                  | examples/skills/sso-dev-flow (drift) | full-bundle/sso-style (정본)             |
+| --------------------- | ------------------------------------ | ---------------------------------------- |
+| Stage 계층            | **없음** (평면 Step 0~4)             | 2 Stage 명시                             |
+| 종료 조건             | "QA 승인 시" (자연어)                | `qa_verdict.json`의 verdict=PASS         |
+| 패턴 명시             | Producer-Reviewer만 한 줄            | 각 Step 블록에 enum 값                   |
+| 사용자 승인 게이트    | 없음                                 | Stage 1 후 명시                          |
+| 최대 반복 횟수        | "최대 3회" 본문 한 줄                | 각 Step 필드                             |
+| findings.md 표준 섹션 | `[Review: 단계]` 임의 형식           | `[공유 변수/경로]`·`[변경 요청]` 등 표준 |
+| task\_\*.json 영속    | 미사용                               | `_workspace/tasks/task_*.json` 표준      |
+
+---
+
+## 핵심 학습 포인트
+
+1. **하나의 산출물만 작성하지 말 것** — 오케스트레이터 SKILL.md + workflow.md + findings.md + tasks.md + checkpoint.json 5종 동시 작성.
+2. **workflow.md 스키마 6 필드 강제** — 누락 시 Zero-Tolerance.
+3. **종료 조건 = 검증 가능 술어** — 자연어 통과 절대 금지.
+4. **표준 findings.md 섹션 사용** — 임의 섹션명 금지.
+5. **Stage·Step 분리 명시** — 평면 Step 1~N 나열 drift 금지.

--- a/harness/references/examples/step/01-blog-post.md
+++ b/harness/references/examples/step/01-blog-post.md
@@ -1,0 +1,45 @@
+# 예시 1: 병렬 수집 후 검토 루프 (블로그 포스트 작성)
+
+작업(Stage) 분해: `gather`(자료 수집 작업) → `write`(작성 작업). Step(=Task) 패턴: gather/research = fan_out_fan_in, write/draft-review = producer_reviewer.
+
+## workflow.md
+
+```markdown
+<!-- 참고 패턴: gather=fan_out_fan_in, write=producer_reviewer -->
+
+## Stage 정의
+
+### Stage 1: gather
+- 종료 조건: 모든 step 완료
+- 다음 stage: write
+- 사용자 승인 게이트: 필요
+
+#### Step 1: research
+- 패턴: fan_out_fan_in
+- 활성 에이전트: [@researcher-trend, @researcher-data, @researcher-case]
+- 종료 조건: `_workspace/research/task_trend.json`, `task_data.json`, `task_case.json` 모두 status=done
+- 다음 step: done
+- 최대 반복 횟수: 1
+
+### Stage 2: write
+- 종료 조건: 모든 step 완료
+- 다음 stage: done
+- 사용자 승인 게이트: 없음 (마지막 stage)
+
+#### Step 1: draft-review
+- 패턴: producer_reviewer
+- 활성 에이전트: [@writer, @editor]
+- 종료 조건: `_workspace/editor_verdict.json`의 verdict=PASS 또는 iterations ≥ 3
+- 다음 step: done
+- 최대 반복 횟수: 3
+```
+
+## 데이터 흐름
+
+```
+gather/research:     @researcher-* → _workspace/research/{topic}.md (병렬)
+write/draft-review:  메인이 research/*.md 요약 → @writer에 주입
+                     @writer → _workspace/draft.md
+                     @editor → _workspace/editor_verdict.json
+                     verdict=REJECT → @writer 재호출 (findings 업데이트 포함)
+```

--- a/harness/references/examples/step/02-issue-triage.md
+++ b/harness/references/examples/step/02-issue-triage.md
@@ -1,0 +1,63 @@
+# 예시 2: 분류 → 전문가 분석 → 검토 (이슈 트리아지)
+
+작업(Stage) 분해: `triage`(분류·분석 작업) → `review`(검토 작업). Step(=Task) 패턴: triage/classification=expert_pool, triage/analysis=pipeline, review/report=producer_reviewer.
+
+## workflow.md
+
+```markdown
+<!-- 참고 패턴: triage=expert_pool+pipeline, review=producer_reviewer -->
+
+## Stage 정의
+
+### Stage 1: triage
+- 종료 조건: 모든 step 완료
+- 다음 stage: review
+- 사용자 승인 게이트: 필요
+
+#### Step 1: classification
+- 패턴: expert_pool
+- 활성 에이전트: [@bug-analyst, @perf-analyst, @security-analyst]
+- 종료 조건: `_workspace/triage/selected_expert.json` 존재
+- 다음 step: analysis
+- 최대 반복 횟수: 1
+
+#### Step 2: analysis
+- 패턴: pipeline
+- 활성 에이전트: [@선택된_전문가]  <!-- 심볼릭 플레이스홀더. Step 진입 시 오케스트레이터가 checkpoint.json의 shared_variables.selected_expert 필드를 읽어 실제 에이전트명으로 치환. workflow.md 수정 없음. -->
+- 종료 조건: `_workspace/triage/analysis.md` 존재
+- 다음 step: done
+- 최대 반복 횟수: 1
+
+### Stage 2: review
+- 종료 조건: 모든 step 완료
+- 다음 stage: done
+- 사용자 승인 게이트: 없음 (마지막 stage)
+
+#### Step 1: report
+- 패턴: producer_reviewer
+- 활성 에이전트: [@report-writer, @tech-lead]
+- 종료 조건: `_workspace/review/final_report.md` 존재 + `_workspace/review/approval.json`의 approved=true
+- 다음 step: done
+- 최대 반복 횟수: 2
+```
+
+## 데이터 흐름
+
+```
+triage/classification: 메인이 이슈 유형 분류 → selected_expert.json 생성
+triage/analysis:       selected_expert.json 기반 적합한 @*-analyst 1개 호출
+                       → _workspace/triage/analysis.md
+review/report:         @report-writer가 analysis.md 읽고 보고서 초안 작성
+                       @tech-lead → 승인 또는 수정 요청
+```
+
+## 심볼릭 플레이스홀더 처리
+
+`[@선택된_전문가]`는 런타임에 오케스트레이터가 치환한다.
+
+```
+Step 2(analysis) 진입 시:
+  1. checkpoint.json의 shared_variables.selected_expert 읽기
+  2. 해당 에이전트명으로 subagent spawn 호출
+  3. workflow.md 파일 자체는 수정하지 않음
+```

--- a/harness/references/examples/step/03-architecture-design.md
+++ b/harness/references/examples/step/03-architecture-design.md
@@ -1,0 +1,63 @@
+# 예시 3: 순차 설계 후 병렬 검증 (아키텍처 설계)
+
+작업(Stage) 분해: `design`(설계 작업, 3 task) → `validate`(검증 작업, 1 task). Step(=Task) 패턴: design Stage 3 Step 모두 pipeline, validate/parallel-review=fan_out_fan_in.
+
+## workflow.md
+
+```markdown
+<!-- 참고 패턴: design=pipeline(다단계), validate=fan_out_fan_in -->
+
+## Stage 정의
+
+### Stage 1: design
+- 종료 조건: 모든 step 완료
+- 다음 stage: validate
+- 사용자 승인 게이트: 필요
+
+#### Step 1: requirements
+- 패턴: pipeline
+- 활성 에이전트: [@requirements-analyst]
+- 종료 조건: `_workspace/design/requirements.md` 존재
+- 다음 step: architecture
+- 최대 반복 횟수: 1
+
+#### Step 2: architecture
+- 패턴: pipeline
+- 활성 에이전트: [@architect]
+- 종료 조건: `_workspace/design/architecture.md` 존재
+- 다음 step: api-design
+- 최대 반복 횟수: 1
+
+#### Step 3: api-design
+- 패턴: pipeline
+- 활성 에이전트: [@api-designer]
+- 종료 조건: `_workspace/design/api_spec.md` 존재
+- 다음 step: done
+- 최대 반복 횟수: 1
+
+### Stage 2: validate
+- 종료 조건: 모든 step 완료
+- 다음 stage: done
+- 사용자 승인 게이트: 없음 (마지막 stage)
+
+#### Step 1: parallel-review
+- 패턴: fan_out_fan_in
+- 활성 에이전트: [@security-reviewer, @perf-reviewer, @compat-reviewer]
+- 종료 조건: `_workspace/validation/task_security.json`, `task_perf.json`, `task_compat.json` 모두 status=done
+- 다음 step: done
+- 최대 반복 횟수: 1
+```
+
+## 데이터 흐름
+
+```
+design/requirements:      @requirements-analyst → requirements.md
+design/architecture:      @architect: requirements.md 읽고 → architecture.md
+design/api-design:        @api-designer: architecture.md 읽고 → api_spec.md
+validate/parallel-review: 세 reviewer가 api_spec.md + architecture.md 병렬 검토
+                          메인이 세 리뷰 결과 통합 → 최종 보고
+```
+
+## 핵심 패턴 포인트
+
+Stage 내 Step 3개(requirements → architecture → api-design)가 모두 **pipeline(순차)**이므로 각 Step 종료 후 자동 전환된다. 사용자 승인 게이트는 `design` → `validate` Stage 전환 시점 1회만 발동.

--- a/harness/references/examples/step/04-single-stage-multi-task.md
+++ b/harness/references/examples/step/04-single-stage-multi-task.md
@@ -1,0 +1,63 @@
+# 예시 4: 단일 Stage(상위 이슈) 다중 Step(하위 이슈) — 조사 → 구현 → 리뷰
+
+상위 이슈(Stage) 1개에 하위 이슈(Step) 3개를 두는 사례. **Jira Issue → Sub-issue** 모델 시연: 하나의 deliverable("기능 구현") 상위 이슈 안에서 하위 이슈별로 서로 다른 패턴 사용.
+
+상위 이슈(Stage) 분해: `feature-build`(기능 구현, 하위 이슈 3개). Step(하위 이슈) 패턴: research=fan_out_fan_in, implement=pipeline, review=producer_reviewer.
+
+## workflow.md
+
+```markdown
+<!-- 참고 패턴: research=fan_out_fan_in, implement=pipeline, review=producer_reviewer -->
+<!-- Stage = 상위 이슈(Jira Issue). Step = 하위 이슈(Jira Sub-issue). -->
+
+## Stage 정의
+
+### Stage 1: feature-build
+- 종료 조건: 모든 step 완료
+- 다음 stage: done
+- 사용자 승인 게이트: 없음 (단일 stage)
+
+#### Step 1: research
+<!-- 하위 이슈: 라이브러리·API 자료 병렬 수집 -->
+- 패턴: fan_out_fan_in
+- 활성 에이전트: [@api-researcher, @lib-researcher, @example-researcher]
+- 종료 조건: `_workspace/research/task_api.json`, `task_lib.json`, `task_example.json` 모두 status=done
+- 다음 step: implement
+- 최대 반복 횟수: 1
+
+#### Step 2: implement
+<!-- 하위 이슈: 조사 결과 기반 코드 구현 -->
+- 패턴: pipeline
+- 활성 에이전트: [@coder]
+- 종료 조건: `_workspace/build/feature.ts` 존재 + `_workspace/build/test.ts` 존재
+- 다음 step: review
+- 최대 반복 횟수: 1
+
+#### Step 3: review
+<!-- 하위 이슈: 코드 리뷰 루프 (PASS 시 종료) -->
+- 패턴: producer_reviewer
+- 활성 에이전트: [@coder, @reviewer]
+- 종료 조건: `_workspace/build/review_verdict.json`의 verdict=PASS
+- 다음 step: done
+- 최대 반복 횟수: 3
+```
+
+## 데이터 흐름
+
+```
+feature-build/research:  @*-researcher 3명 병렬 → _workspace/research/{topic}.md
+                         메인이 task_*.json 모두 done 확인 후 자동 전환
+feature-build/implement: @coder가 research/*.md 읽고 → feature.ts + test.ts 생성
+                         pipeline 단일 task → 자동 전환
+feature-build/review:    @reviewer가 코드·테스트 검토 → review_verdict.json
+                         verdict=REJECT → @coder 재호출 (findings.md의 [변경 요청] 주입)
+                         verdict=PASS → step done → stage done
+```
+
+## 핵심 패턴 포인트
+
+**1 상위 이슈 / 3 하위 이슈**: 하나의 deliverable("기능 구현") 상위 이슈 안에서 하위 이슈가 성격별로 분해된다 — 조사(병렬)·구현(순차)·리뷰(루프). 각 하위 이슈가 독립 패턴을 갖되, Stage 게이트는 1회(전체 상위 이슈 완료 시점)만 발동.
+
+**Step 자동 전환만 발생**: `feature-build` Stage 내 3 Step 모두 종료 조건 충족 시 사용자 개입 없이 자동 전진. Stage 끝(`다음 stage: done`)이라 Stage 승인 게이트도 없음 — 완전 자동 흐름.
+
+**패턴 다양성**: 한 상위 이슈(Stage) 안에서 fan_out_fan_in → pipeline → producer_reviewer가 순차 결합. Jira Issue → Sub-issue 모델의 표현력 시연.

--- a/harness/references/examples/step/05-multi-stage-multi-task.md
+++ b/harness/references/examples/step/05-multi-stage-multi-task.md
@@ -1,0 +1,112 @@
+# 예시 5: 다중 Stage 다중 Step — 제품 개발 라이프사이클 (Jira Story × Sub-issue)
+
+상위 이슈(Stage) 3개, 각 Stage 내 하위 이슈(Step) 2~3개. 풀 라이프사이클 시연 — 발견·구현·검증 상위 이슈가 각자 다중 하위 이슈로 분해되며 Stage 사이에는 사용자 승인 게이트 발동.
+
+작업(Stage) 분해: `discovery`(발견 작업) → `build`(구현 작업) → `validate`(검증 작업).
+Step(하위 이슈) 패턴: market-research=fan_out_fan_in, requirements=pipeline, design=pipeline, implement=supervisor, code-review=producer_reviewer, parallel-qa=fan_out_fan_in, release-notes=pipeline.
+
+## workflow.md
+
+```markdown
+<!-- 참고 패턴: discovery=fan_out+pipeline, build=pipeline+supervisor+producer_reviewer, validate=fan_out+pipeline -->
+<!-- Stage = 상위 이슈(Jira Issue). Step = 하위 이슈(Jira Sub-issue). -->
+
+## Stage 정의
+
+### Stage 1: discovery
+
+- 종료 조건: 모든 step 완료
+- 다음 stage: build
+- 사용자 승인 게이트: 필요
+
+#### Step 1: market-research
+
+- 패턴: fan_out_fan_in
+- 활성 에이전트: [@trend-researcher, @competitor-researcher, @user-researcher]
+- 종료 조건: `_workspace/discovery/task_trend.json`, `task_competitor.json`, `task_user.json` 모두 status=done
+- 다음 step: requirements
+- 최대 반복 횟수: 1
+
+#### Step 2: requirements
+
+- 패턴: pipeline
+- 활성 에이전트: [@requirements-analyst]
+- 종료 조건: `_workspace/discovery/requirements.md` 존재
+- 다음 step: done
+- 최대 반복 횟수: 1
+
+### Stage 2: build
+
+- 종료 조건: 모든 step 완료
+- 다음 stage: validate
+- 사용자 승인 게이트: 필요
+
+#### Step 1: design
+
+- 패턴: pipeline
+- 활성 에이전트: [@architect]
+- 종료 조건: `_workspace/build/architecture.md` 존재
+- 다음 step: implement
+- 최대 반복 횟수: 1
+
+#### Step 2: implement
+
+- 패턴: supervisor
+- 활성 에이전트: [@coder-1, @coder-2, @coder-3]
+- 종료 조건: `_workspace/build/tasks/task_*.json` 모두 status=done (메인이 동적 배치)
+- 다음 step: code-review
+- 최대 반복 횟수: 1
+
+#### Step 3: code-review
+
+- 패턴: producer_reviewer
+- 활성 에이전트: [@reviewer, @coder-1, @coder-2, @coder-3]
+- 종료 조건: `_workspace/build/review_verdict.json`의 verdict=PASS
+- 다음 step: done
+- 최대 반복 횟수: 3
+
+### Stage 3: validate
+
+- 종료 조건: 모든 step 완료
+- 다음 stage: done
+- 사용자 승인 게이트: 없음 (마지막 stage)
+
+#### Step 1: parallel-qa
+
+- 패턴: fan_out_fan_in
+- 활성 에이전트: [@security-reviewer, @perf-reviewer, @compat-reviewer]
+- 종료 조건: `_workspace/validate/task_security.json`, `task_perf.json`, `task_compat.json` 모두 status=done
+- 다음 step: release-notes
+- 최대 반복 횟수: 1
+
+#### Step 2: release-notes
+
+- 패턴: pipeline
+- 활성 에이전트: [@doc-writer]
+- 종료 조건: `_workspace/validate/RELEASE_NOTES.md` 존재
+- 다음 step: done
+- 최대 반복 횟수: 1
+```
+
+## 데이터 흐름
+
+```
+discovery/market-research:  3 researcher 병렬 → research/{topic}.md
+discovery/requirements:     @requirements-analyst → requirements.md
+                            ──[Stage 게이트: 사용자 승인]──
+build/design:               @architect: requirements.md → architecture.md
+build/implement:            메인이 architecture.md → tasks.md(서브태스크 N개) →
+                            @coder-* 3명 동적 배치 (supervisor 패턴)
+build/code-review:          @reviewer 검토 → REJECT 시 해당 @coder-* 재호출 (loop)
+                            ──[Stage 게이트: 사용자 승인]──
+validate/parallel-qa:       3 reviewer 병렬 → 각 task_*.json
+validate/release-notes:     @doc-writer: 모든 산출물 종합 → RELEASE_NOTES.md
+```
+
+## 핵심 패턴 포인트
+
+**3 상위 이슈 × 7 하위 이슈**: 각 상위 이슈(Stage)가 자체 다중 하위 이슈(Step)로 분해. Stage 사이 사용자 승인 게이트 2회(`discovery → build`, `build → validate`) 발동, Stage 내 Step 전환은 자동.
+
+**패턴 7종 중 5종 사용**: fan_out_fan_in / pipeline / supervisor / producer_reviewer 결합 — 한 워크플로우에서 다양한 task 성격 표현. expert_pool·hierarchical·handoff는 미사용 (도메인상 부적합).
+
+**`build/implement` supervisor**: workflow.md 작성 시점에 서브태스크 수 미정 — 메인이 architecture.md 분석 후 런타임에 tasks.md 생성·동적 배치. 활성 에이전트 풀(`@coder-1~3`)만 선언, 실제 할당은 동적.

--- a/harness/references/examples/step/test-scenarios.md
+++ b/harness/references/examples/step/test-scenarios.md
@@ -1,0 +1,122 @@
+# Stage-Step 워크플로우 테스트 시나리오
+
+`stage-step-guide.md` 기반 하네스 검증용 시나리오 6종. 3단계 계층(Stage → Step → Agent) 기준.
+
+## 시나리오 인덱스
+
+| # | 목적 | 핵심 검증 포인트 | 판정 기준 |
+|---|------|----------------|----------|
+| 1 | 단순 workflow.md 구조 검증 | Stage 1개 + Step 1개 생성 여부 | Stage 2 블록 없음 + `main/main` 구조 |
+| 2 | 다단계 워크플로우 트리거 | 발화에서 다단계 자동 선택 | Stage 블록 2개 이상 존재 |
+| 3 | Step 종료 조건 미충족 → 전환 차단 | 미완료 task 있을 때 다음 Step 진입 금지 | Stage 2 에이전트 subagent spawn 미발생 |
+| 4 | Step 자동 전환 (승인 불필요) | 종료 조건 충족 시 사용자 개입 없이 전환 | 승인 요청 없이 다음 Step 에이전트 호출 |
+| 5 | Stage 전환 게이트 (승인 필수) | Stage 완료 시 승인 게이트 발동 | 승인 요청 발생 + 다음 Stage 에이전트 미호출 |
+| 6 | Step별 에이전트 출입 통제 | 현재 Step 목록 외 에이전트 호출 차단 | 비활성 에이전트 subagent spawn 미발생 |
+
+---
+
+## 시나리오 1: 단순 워크플로우 workflow.md 구조 검증
+
+**목적:** 단순 작업 발화 시 `workflow.md`가 Stage 1개 + Step 1개 구조로 생성되며 **deliverable 명사구 명명 규칙**(Jira 제목 컨벤션)을 따르는지 확인. `main`·`step1` 같은 placeholder는 위반.
+
+**테스트 프롬프트:** `"블로그 포스트를 3명이 병렬로 리서치하고 통합해줘"`
+
+**기대 동작:**
+- `_workspace/workflow.md` 생성 — Stage 1개(deliverable 명사구, 예: `blog-post`), Step 1개(deliverable 명사구, 예: `parallel-research`), 패턴 = fan_out_fan_in, 활성 에이전트 목록 포함.
+- Stage 2 블록 없음.
+
+**판정:**
+- `_workspace/workflow.md` 존재 → ✓
+- `### Stage 1: {kebab-name}` 블록 존재 + 이름이 `^[a-z][a-z0-9-]*$` 일치 + placeholder(`main`·`step1`·`task`·`default`) 아님 → ✓
+- `#### Step 1: {kebab-name}` 블록 존재 + 위와 동일 규칙 + 활성 에이전트 목록 → ✓
+- Stage 2 블록 없음 → ✓
+- 넷 다 충족 시 PASS. placeholder 사용 시 FAIL.
+
+---
+
+## 시나리오 2: 다단계 워크플로우 트리거 테스트
+
+**목적:** "병렬 수집 후 검토 루프" 발화에서 다단계 워크플로우가 자동 선택되고 Stage-Step 구조가 올바르게 생성되는지 확인.
+
+**테스트 프롬프트:** `"3명이 병렬로 리서치한 뒤, 작가와 편집자가 루프로 다듬어줘"`
+
+**기대 동작:**
+- 메인이 `stage-step-guide.md` 로드.
+- `_workspace/workflow.md` 생성 — Stage 2개 이상, 각 Stage에 Step 블록 포함.
+- Stage 1 / Step 1 패턴: fan_out_fan_in, Stage 2 / Step 1 패턴: producer_reviewer.
+- 사용자에게 워크플로우 확인 요청.
+
+**판정:** `_workspace/workflow.md` 내 Stage 블록 2개 이상 + 각 Stage 내 Step 블록 (`#### Step`) 존재 시 PASS.
+
+---
+
+## 시나리오 3: Step 종료 조건 미충족 → 자동 전환 차단 테스트
+
+**목적:** Step 종료 조건 미충족 시 다음 Step로 넘어가지 않는지 확인.
+
+**설정:**
+- `workflow.md` Stage 1(gather) / Step 1(research): 종료 조건 = `task_a.json`, `task_b.json` 모두 status=done
+- `task_a.json`: status=done, `task_b.json`: status=in_progress (미완료)
+- `checkpoint.json`: `current_stage: "gather"`, `current_step: "research"`
+
+**기대 동작:**
+- 메인이 Step 종료 조건 검증 → 미충족 감지.
+- Step 2 또는 Stage 2로 전환하지 않고 `gather/research` 패턴에 따라 남은 에이전트 재호출.
+- Stage 2 에이전트(`@writer`, `@editor`)를 이 턴에서 호출하지 않음.
+
+**판정:** 해당 사이클에서 Stage 2 에이전트 `subagent spawn` 미발생 시 PASS.
+
+---
+
+## 시나리오 4: Step 자동 전환 테스트 (사용자 승인 불필요)
+
+**목적:** Step 종료 조건 충족 시 사용자 승인 없이 다음 Step로 자동 전환하는지 확인.
+
+**설정:**
+- `workflow.md` Stage 1(design):
+  - Step 1(requirements): 종료 조건 = `requirements.md` 존재, 다음 step: `architecture`
+  - Step 2(architecture): 종료 조건 = `architecture.md` 존재, 다음 step: `done`
+- `_workspace/design/requirements.md` 존재 (Step 1 완료 상태)
+- `checkpoint.json`: `current_stage: "design"`, `current_step: "requirements"`
+
+**기대 동작:**
+- 메인이 Step 1(requirements) 종료 조건 충족 확인.
+- 사용자 승인 요청 없이 `current_step` → `"architecture"` 갱신.
+- 같은 턴 내 Step 2(architecture) 에이전트(`@architect`) 즉시 호출.
+
+**판정:** 사용자 승인 요청 없이 `@architect` `subagent spawn` 발생 + `checkpoint.json`의 `current_step` = `"architecture"` 시 PASS.
+
+---
+
+## 시나리오 5: Stage 전환 게이트 테스트 (사용자 승인 필수)
+
+**목적:** Stage 내 모든 Step 완료 시 사용자 승인 게이트가 발동하는지 확인.
+
+**설정:**
+- `workflow.md` Stage 1(gather) / Step 1(research): 다음 step = `done`, 다음 stage = `write`
+- `task_trend.json`, `task_data.json`: 모두 status=done
+- `checkpoint.json`: `current_stage: "gather"`, `current_step: "research"`
+
+**기대 동작:**
+- Step 1(research) 종료 조건 충족 + 다음 step = `done`.
+- 메인이 Stage 1 모든 Step 완료 확인 → 사용자에게 Stage 전환 보고.
+- 사용자 승인 전 Stage 2(`write`) 에이전트 미호출.
+
+**판정:** 사용자 승인 요청 발생 + Stage 2 에이전트 미호출 시 PASS.
+
+---
+
+## 시나리오 6: Step별 에이전트 출입 통제 테스트
+
+**목적:** workflow.md의 현재 Step `활성 에이전트` 목록 밖 에이전트를 메인이 호출하지 않는지 확인.
+
+**설정:**
+- `workflow.md` Stage 1(gather) / Step 1(research) 활성 에이전트: `[@researcher-a, @researcher-b]`
+- `checkpoint.json`: `current_stage: "gather"`, `current_step: "research"`
+- `@writer`는 Stage 2(write) / Step 1(draft-review) 소속 — 현재 step 목록에 없음.
+
+**기대 동작:**
+- 메인이 `gather/research` Step 블록 읽기 → `@writer` 목록에 없음 → 호출 보류.
+- `@writer` `subagent spawn` 미발생.
+
+**판정:** 해당 사이클에서 `@writer` `subagent spawn` 미발생 시 PASS.

--- a/harness/references/examples/team/01-fan-out-fan-in.md
+++ b/harness/references/examples/team/01-fan-out-fan-in.md
@@ -1,0 +1,62 @@
+# 예시 1: 리서치 팀 (Fan-out/Fan-in 패턴)
+
+## 팀 아키텍처
+
+주제 하나를 4개 전문 영역으로 팬아웃해 병렬 조사한 뒤, 메인 에이전트가 팬인 통합한다.
+
+## 에이전트 구성
+
+| 에이전트               | 유형    | sandbox_mode  | 산출물                                    |
+| ---------------------- | ------- | ------------- | ----------------------------------------- |
+| @official-researcher   | Analyst | `read-only`   | `_workspace/{plan_name}/01_official.md`   |
+| @media-researcher      | Analyst | `read-only`   | `_workspace/{plan_name}/01_media.md`      |
+| @community-researcher  | Analyst | `read-only`   | `_workspace/{plan_name}/01_community.md`  |
+| @background-researcher | Analyst | `read-only`   | `_workspace/{plan_name}/01_background.md` |
+
+## 오케스트레이터 워크플로우
+
+```
+Phase 0: _workspace/ + checkpoint.json 존재 여부 확인 → 실행 모드 결정:
+         - checkpoint.json 존재 + status: "in_progress" → 중단 지점 재개(Resume)
+           workflow.md 읽기 → current_stage, current_step 복원
+         - checkpoint.json 존재 + status: "completed" → 완료 상태.
+           사용자 요청이 부분 수정이면 부분재실행, 새 입력이면 새 실행으로 분기. Resume 금지.
+         - _workspace/ 미존재 또는 checkpoint.json 미존재 → 신규 실행 (Phase 1로 진행)
+Phase 1: 사용자 입력 분석
+         workflow.md 생성:
+           Stage 1: competitor-research / 사용자 승인 게이트: 없음
+           Step 1: research / 패턴: fan_out_fan_in / 활성 에이전트: [4명] / 다음 step: done
+         checkpoint.json 생성 (current_stage: "competitor-research", current_step: "research",
+                            active_pattern: "fan_out_fan_in", status: "in_progress")
+         tasks.md 4개 조사 작업 등록
+         findings.md 초기화: [핵심 통찰], [핵심 키워드], [공유 변수/경로], [데이터 충돌] 섹션 생성
+Phase 2: [Step 실행 루프 — Stage competitor-research / Step research]
+         단일 응답 턴에서 @official/@media/@community/@background를
+         병렬 배치 호출
+         - 각 에이전트 프롬프트에 findings.md의 [핵심 키워드]·[공유 변수/경로] 주입
+Phase 3: 각 산출물을 `cat`으로 수집
+         - 산출물 파일 미존재(에이전트 실패) → 최대 2회 재시도(총 3회).
+           3회 후에도 미생성 → Blocked, 사용자 확인 요청으로 수동 개입 요청. 임의 Skip 금지.
+         - 수집 성공 → findings.md [데이터 충돌]에 상충 기록
+         - 상충 정보는 교차 영역(예: media 발견 투자 뉴스 ↔ background 경쟁사)을
+           메인 에이전트가 findings.md에 병기하고, 필요 시 해당 에이전트를 재호출
+           (최대 2회 재시도(총 3회). 그래도 상충 미해결 → 출처 병기 후 진행, findings.md [데이터 충돌]에 미해결 표시)
+         Step research 종료 조건 충족 → checkpoint.json 갱신:
+           - step_history에 "research" completed_at 기록
+           - stage_history에 "competitor-research" completed_at 기록
+           - current_stage·current_step: "done", status: "completed", last_updated: 현재 타임스탬프
+         사용자 승인 게이트: 없음 → 워크플로우 자동 완료
+Phase 4: 통합 보고서 _workspace/{plan_name}/final/research_report.md 생성 (상충 정보는 출처 병기)
+Phase 5: 사용자 보고, _workspace/ 보존
+```
+
+## 브로커 중개 패턴 (SendMessage 대체)
+
+Claude Code에서 `official → media → background`로 SendMessage가 오갔던 부분은 Codex CLI에서 다음처럼 변환된다:
+
+```
+@official 산출물(_workspace/{plan_name}/01_official.md) 완료
+  → 메인 에이전트가 `cat`으로 확인
+  → findings.md [공유 변수/경로]에 "official의 공식 발표 X는 media 맥락에서 재검증 필요" 추가
+  → @media 호출 시 프롬프트에 findings.md의 해당 섹션을 요약 주입
+```

--- a/harness/references/examples/team/02-producer-reviewer.md
+++ b/harness/references/examples/team/02-producer-reviewer.md
@@ -1,0 +1,101 @@
+# 예시 2: 웹툰 제작 팀 (Producer-Reviewer 패턴)
+
+## 팀 아키텍처
+
+생성자(artist)와 검증자(reviewer)가 짧은 루프로 산출물을 정제한다. 메인 에이전트가 리뷰 리포트를 해석해 재생성 루프를 제어한다.
+
+## 에이전트 구성
+
+| 에이전트          | 유형     | 역할             | sandbox_mode      | 스킬                                  |
+| ----------------- | -------- | ---------------- | ----------------- | ------------------------------------- |
+| @webtoon-artist   | Coder    | 패널 이미지 생성 | `workspace-write` | `generate-webtoon`                    |
+| @webtoon-reviewer | Reviewer | 품질 검수        | `workspace-write` | `review-webtoon`, `fix-webtoon-panel` |
+
+## 에이전트 파일 전문 예시: `.codex/agents/webtoon-reviewer.toml`
+
+````toml
+name = "webtoon-reviewer"
+description = "웹툰 패널의 품질을 검수하는 전문가. 구도·캐릭터 일관성·텍스트 가독성·연출을 평가. 웹툰 QA·검수·재작업 요청 시 반드시 이 에이전트를 선택."
+model = "gpt-5.3-codex"
+sandbox_mode = "workspace-write"
+model_reasoning_effort = "high"
+
+developer_instructions = """
+
+# Webtoon Reviewer — 웹툰 품질 검수 전문가
+
+웹툰 패널의 품질을 검수하는 전문가. 시각적 완성도·스토리 전달력·캐릭터 일관성을 기준으로 평가한다.
+
+## 핵심 역할
+
+1. 각 패널의 구도와 시각적 완성도 평가
+2. 캐릭터 외형의 패널 간 일관성 검증
+3. 말풍선 텍스트의 가독성과 배치 평가
+4. 전체 에피소드의 연출 흐름과 페이싱 검토
+
+## 작업 원칙
+
+- PASS / FIX / REDO 3단계로 명확히 판정
+- FIX는 부분 수정 가능, REDO는 전면 재생성 필요
+- 주관적 취향이 아닌 객관적 기준(일관성·가독성·구도)으로 판단
+
+## 입력/출력 프로토콜
+
+- 입력: `_workspace/{plan_name}/panels/` 디렉토리의 패널 이미지들
+- 출력: `_workspace/{plan_name}/review_report.md`
+- 형식:
+
+```
+
+## Panel {N}
+
+- 판정: PASS | FIX | REDO
+- 사유: [구체적 이유]
+- 수정 지시: [FIX/REDO인 경우 구체적 수정 방향]
+
+```
+
+## 협업 프로토콜 (Codex CLI)
+
+- @webtoon-artist에게 직접 지시할 수 없다. 모든 수정 요청은
+  `_workspace/{plan_name}/review_report.md`에 기록하며, 메인 에이전트가
+  해당 리포트를 findings.md [변경 요청]으로 요약한 뒤 artist를 재호출한다.
+
+## 에러 핸들링
+
+- 이미지 로드 실패 시 해당 패널을 REDO로 판정
+- 3회 재생성 후에도 REDO인 패널은 **Blocked 처리 후 사용자 확인 요청으로 사용자 개입 요청. 임의 PASS 처리 절대 금지.**
+- 판정 기준이 모호하면 사용자 확인 요청으로 레퍼런스 이미지를 요청
+"""
+````
+
+## 오케스트레이터 워크플로우
+
+```
+Phase 0: (예시 1과 동일 — 상태 확인·Resume·신규 실행 분기)
+Phase 1: 사용자 입력(에피소드 명세) 분석
+         workflow.md 생성:
+           Stage 1: webtoon-episode / 사용자 승인 게이트: 없음
+           Step 1: produce / 패턴: producer_reviewer / 활성 에이전트: [@webtoon-artist, @webtoon-reviewer] / 다음 step: done
+         checkpoint.json 생성 (current_stage: "webtoon-episode", current_step: "produce",
+                            active_pattern: "producer_reviewer", status: "in_progress")
+         tasks.md 패널 작업 등록, findings.md [공유 변수/경로]·[변경 요청] 초기화
+Phase 2: [Step 실행 루프 — Stage webtoon-episode / Step produce]
+         @webtoon-artist 호출 → _workspace/{plan_name}/panels/*.png 생성
+         @webtoon-reviewer 호출 → _workspace/{plan_name}/review_report.md 생성
+         메인 에이전트가 review_report.md 파싱:
+         - FIX/REDO 패널 → 수정 지시를 findings.md [변경 요청]에 기록 → @webtoon-artist 재호출
+           (FIX: 부분 수정, REDO: 전면 재생성)
+         - 1회차 검수 후 REDO 패널이 전체의 50% 이상이면 재호출 전 사용자 확인 요청으로 프롬프트 재조정 제안
+         - FIX+REDO 합산 재호출 최대 2회 재시도(총 3회). 초과 시 Blocked → 사용자 확인 요청
+         루프 탈출 조건: 모든 패널 PASS → Phase 3으로 전환
+Phase 3: 최종 PASS 집계 → step "produce" 종료 조건 충족
+         checkpoint.json 갱신:
+           - step_history에 "produce" completed_at 기록
+           - stage_history에 "webtoon-episode" completed_at 기록
+           - current_stage·current_step: "done", status: "completed", last_updated: 현재 타임스탬프
+         사용자 승인 게이트: 없음 → 워크플로우 자동 완료
+Phase 4: 최종 에피소드 _workspace/{plan_name}/final/episode.md 생성
+         (Blocked 패널은 사용자 확인 요청 승인 후 사용자 결정에 따라 포함·제외 처리)
+Phase 5: 사용자 보고, _workspace/ 보존
+```

--- a/harness/references/examples/team/03-supervisor.md
+++ b/harness/references/examples/team/03-supervisor.md
@@ -1,0 +1,53 @@
+# 예시 3: 코드 마이그레이션 팀 (Supervisor 패턴)
+
+## 팀 아키텍처
+
+감독자가 대상 파일 목록을 배치로 나누어 워커들에게 동적으로 할당한다. Codex CLI에서는 `tasks.md`가 공유 작업 목록 역할을 하며, 메인 에이전트가 배치 할당·재할당을 담당한다.
+
+## 에이전트 구성
+
+| 에이전트              | 유형      | sandbox_mode      | 역할                     |
+| --------------------- | --------- | ----------------- | ------------------------ |
+| @migration-supervisor | Architect | `read-only`       | 파일 분석·배치 분해      |
+| @migrator-1~N         | Coder     | `workspace-write` | 할당된 배치 마이그레이션 |
+
+## 오케스트레이터 워크플로우
+
+```
+Phase 0: (예시 1과 동일 — 상태 확인·Resume·신규 실행 분기)
+Phase 1: ① @migration-supervisor 호출
+           → 대상 파일 목록 수집 + 복잡도 추정 (파일 크기·import 수·의존성)
+           → tasks.md에 N개 배치로 등록 (우선순위·복잡도 필드 포함; 순서는 오케스트레이터가 tasks.md 상태를 읽어 수동 제어)
+         ② supervisor 완료 후 배치 수(N) 확정 → workflow.md 생성:
+           Stage 1: code-migration / 사용자 승인 게이트: 없음
+           Step 1: migrate / 패턴: supervisor / 활성 에이전트: [@migrator-1~N] / 다음 step: test
+           Step 2: test / 패턴: pipeline / 활성 에이전트: [메인] / 다음 step: done
+         ③ checkpoint.json 생성 (current_stage: "code-migration", current_step: "migrate",
+                            active_pattern: "supervisor", status: "in_progress")
+         findings.md [공유 변수/경로]·[데이터 충돌] 초기화
+Phase 2: [Step 실행 루프 — Stage code-migration / Step migrate]
+         메인 에이전트가 tasks.md를 읽어 가용 워커 수만큼 배치 할당
+         - 단일 응답 턴에서 @migrator-1 / @migrator-2 / @migrator-3를
+           병렬 배치 호출
+         - 각 프롬프트에 할당 배치의 파일 목록·성공 기준 명시
+         - 워커 완료 → 산출물 `cat`으로 확인
+           - 성공 → tasks.md 상태 Todo→Done, 남은 배치 중 우선순위 최상을 즉시 재할당
+           - 실패 → findings.md [데이터 충돌]에 원인 기록, 최대 2회 재시도 (총 3회)
+           - 3회 후에도 실패 → Blocked 처리, 사용자 확인 요청으로 대체 경로 질의. 임의 Skip 절대 금지.
+         모든 배치 Done → step "migrate" 종료 조건 충족
+         checkpoint.json 갱신: current_step → "test", active_pattern → "pipeline"
+                            step_history에 "migrate" completed_at 기록, last_updated: 현재 타임스탬프
+Phase 3: [Step 실행 루프 — Stage code-migration / Step test]
+         통합 테스트 실행 (셸)
+         → 실패 시 영향 범위 분석 후 해당 배치만 재실행 (최대 2회 재시도(총 3회))
+         → 3회 후에도 실패 → Blocked 처리, 사용자 확인 요청으로 수동 대응 요청. 임의 완료 처리 금지.
+         step "test" 종료 조건 충족 → stage "code-migration" 완료
+         checkpoint.json 갱신:
+           - step_history에 "test" completed_at 기록
+           - stage_history에 "code-migration" completed_at 기록
+           - current_stage·current_step: "done", status: "completed", last_updated: 현재 타임스탬프
+Phase 4: 마이그레이션 완료 보고서 _workspace/{plan_name}/final/migration_report.md 생성
+Phase 5: 사용자 보고, _workspace/ 보존
+```
+
+**팬아웃과의 차이:** 작업이 사전 고정이 아니라 **런타임에 동적 할당**된다. `tasks.md`의 `[상태]` 필드가 claim 메커니즘을 대신한다.

--- a/harness/references/examples/team/04-hierarchical.md
+++ b/harness/references/examples/team/04-hierarchical.md
@@ -1,0 +1,98 @@
+# 예시 4: 풀스택 앱 개발 (Hierarchical Delegation 패턴)
+
+## 팀 아키텍처
+
+최상위 아키텍트가 프로젝트를 프론트엔드·백엔드 서브 프로젝트로 분해하고, 각 팀 리드가 다시 자신의 서브에이전트를 조율한다.
+
+## 계층 구조
+
+```
+@project-architect (Top)
+  ├── @frontend-team-lead (Mid) — UI/UX, 컴포넌트, 상태 관리
+  │     ├── @ui-designer
+  │     └── @state-engineer
+  └── @backend-team-lead (Mid) — API, DB, 인프라
+        ├── @api-designer
+        └── @db-engineer
+```
+
+## 에이전트 파일 전문 예시: `.codex/agents/frontend-team-lead.toml`
+
+```toml
+name = "frontend-team-lead"
+description = "프론트엔드 아키텍처 및 구현 전문가. UI 컴포넌트 설계와 상태 관리를 전담. 프론트엔드 구조 설계·구현·리팩토링 요청 시 반드시 이 에이전트를 선택."
+model = "gpt-5.3-codex"
+sandbox_mode = "workspace-write"
+model_reasoning_effort = "high"
+
+developer_instructions = """
+
+# Frontend Team Lead
+
+## 핵심 역할
+
+1. 아키텍트의 설계를 기반으로 UI 명세서 작성
+2. React/Next.js 컴포넌트 구조 설계 및 구현
+3. 프론트엔드 테스트 코드 작성
+4. @ui-designer·@state-engineer의 산출물을 통합하는 중간 조율
+
+## 협업 프로토콜 (Codex CLI)
+
+- 상위: @project-architect가 findings.md에 기록한 요구사항을 입력으로 받는다.
+- 하위: @ui-designer·@state-engineer에게 **직접 지시할 수 없다**.
+  필요한 하위 작업은 `task_frontend-team-lead_{id}.json`에 기록하고, 메인 에이전트가 수집·통합 후 해당 에이전트들을 호출하도록 한다.
+- 산출물은 `_workspace/frontend/` 하위에 정리하며,
+  @backend-team-lead와의 API 계약은 findings.md [공유 변수/경로]에 기록한다.
+
+## 에러 핸들링
+
+- 아키텍트 명세 불명확 시 사용자 확인 요청으로 요구사항 재확인. 임의 해석 금지.
+- 하위 에이전트(@ui-designer·@state-engineer) 산출물 검수 실패 시 task*{agent}*{id}.json에 재작업 지시 기록 후 메인 에이전트에 위임.
+- 3회 재작업 후에도 기준 미달 → findings.md [데이터 충돌]에 미달 내용 기록, Blocked 판정. 메인 에이전트가 사용자 확인 요청.
+"""
+```
+
+## 오케스트레이터 워크플로우
+
+```
+Phase 0: (예시 1과 동일 — 상태 확인·Resume·신규 실행 분기)
+Phase 1: findings.md 초기화: [공유 변수/경로]·[변경 요청]·[데이터 충돌] 섹션 생성
+         ① @project-architect 호출 → 전체 설계 _workspace/{plan_name}/00_architecture.md
+           → findings.md [공유 변수/경로]에 프론트/백엔드 API 계약 요약
+         ② architect 완료 후 설계 결과 기반으로 workflow.md 생성:
+           Stage 1: feature-development / 사용자 승인 게이트: 없음
+           Step 1: design / 패턴: hierarchical / 활성 에이전트: [@frontend-team-lead, @backend-team-lead] / 다음 step: implement
+           Step 2: implement / 패턴: hierarchical / 활성 에이전트: [@ui-designer, @state-engineer, @api-designer, @db-engineer] / 다음 step: done
+         ③ checkpoint.json 생성 (current_stage: "feature-development", current_step: "design",
+                            active_pattern: "hierarchical", status: "in_progress")
+         tasks.md 초기화
+Phase 2: [Step 실행 루프 — Stage feature-development / Step design]
+         @frontend-team-lead / @backend-team-lead를
+         병렬 배치 호출
+         - 각 호출 프롬프트에 findings.md [공유 변수/경로]의 프론트/백엔드 API 계약 요약 주입
+         → 각자 자기 영역 설계 완료 + 필요한 하위 작업을 task_{agent}_{id}.json에 기록
+         → 메인 에이전트가 두 파일 수집 후 tasks.md에 원자적 통합 (동시 쓰기 충돌 방지)
+         Step "design" 종료 조건 충족
+         checkpoint.json 갱신: current_step → "implement", active_pattern → "hierarchical" (유지)
+                            step_history에 "design" completed_at 기록, last_updated: 현재 타임스탬프
+Phase 3: [Step 실행 루프 — Stage feature-development / Step implement]
+         메인 에이전트가 tasks.md를 읽어 @ui-designer·@state-engineer·
+         @api-designer·@db-engineer를 subagent spawn으로 순차/병렬 호출
+         (의존관계 없는 작업은 병렬, 의존관계 있으면 순차)
+         → 산출물은 각 팀 리드가 통합 검수
+         → 검수 실패 시 해당 에이전트 재호출 (최대 2회 재시도(총 3회))
+         → 3회 후에도 실패 → Blocked, 사용자 확인 요청으로 수동 개입 요청
+         종료 조건: tasks.md의 모든 항목 상태 = Done + 각 팀 리드 검수 통과 → Step "implement" 충족
+         → stage "feature-development" 완료 (Phase 4 교차 검증 후 최종 확정)
+Phase 4: @project-architect가 최종 산출물을 교차 검증
+         - 검증 통과 → checkpoint.json 갱신:
+           step_history에 "implement" completed_at, stage_history에 "feature-development" completed_at
+           current_stage·current_step: "done", status: "completed", last_updated: 현재 타임스탬프
+         - 검증 실패 → 실패 영역(프론트/백엔드)을 findings.md [변경 요청]에 기록 후 해당 팀 리드 재호출, 최대 2회 재시도(총 3회)
+         - 재검증 후에도 실패 → Blocked, 사용자 확인 요청으로 수동 판단 요청
+Phase 5: 사용자 보고, _workspace/ 보존
+```
+
+계층적 위임에서는 **중간 리드가 직접 하위 호출을 하지 않는다**. 모든 호출은 메인 에이전트가 tasks.md를 통해 트리거한다.
+
+**Supervisor와의 차이:** 단일 계층(감독자→동종 워커)이 아닌 2단계 계층(아키텍트→팀 리드→전문 워커)으로, 도메인이 이질적인 팀에 적합.

--- a/harness/references/examples/team/05-handoff-persistence.md
+++ b/harness/references/examples/team/05-handoff-persistence.md
@@ -1,0 +1,86 @@
+# 예시 5: 시스템 디버깅 및 장애 대응 팀 (Handoff + Persistence 패턴)
+
+## 팀 아키텍처
+
+문제를 분류하는 트리아지 에이전트가 로그를 분석하고, 분석 결과에 따라 가장 적합한 수정 전문가에게 직접 제어권을 넘긴다(Handoff). 대규모 로그 분석 중 중단될 경우에 대비해 체크포인트를 관리한다(Persistence).
+
+## 에이전트 구성
+
+| 에이전트          | 유형    | 핵심 역할                       | sandbox_mode      |
+| ----------------- | ------- | ------------------------------- | ----------------- |
+| @incident-triage  | Analyst | 원인 분석 및 전문가 추천        | `read-only`       |
+| @db-fixer         | Coder   | DB 쿼리 및 스키마 수정          | `workspace-write` |
+| @logic-fixer      | Coder   | 애플리케이션 비즈니스 로직 수정 | `workspace-write` |
+| @security-patcher | Coder   | 취약점 패치 및 보안 설정        | `workspace-write` |
+
+## 오케스트레이터 워크플로우
+
+```
+Phase 0: _workspace/ + checkpoint.json 존재 여부 확인 → 실행 모드 결정:
+         - checkpoint.json 존재 + status: "in_progress" → findings.md의 [공유 변수/경로]에서
+           "마지막 분석 로그 라인" 확인 후 그 지점부터 재개 (Persistence)
+           workflow.md 읽기 → current_stage, current_step 복원
+         - checkpoint.json 존재 + status: "completed" → 이전 분석 완료 상태.
+           사용자 요청이 부분 수정이면 부분 재실행, 새 장애면 새 실행으로 분기. Resume 금지.
+         - _workspace/ 미존재 또는 checkpoint.json 미존재 → 신규 분석 시작 (Phase 1로 진행)
+Phase 1: workflow.md 생성:
+           Stage 1: incident-resolution / 사용자 승인 게이트: 없음
+           Step 1: triage / 패턴: handoff / 활성 에이전트: [@incident-triage] / 다음 step: fix
+           Step 2: fix / 패턴: producer_reviewer / 활성 에이전트: [동적 결정] / 다음 step: done
+         checkpoint.json 생성 (current_stage: "incident-resolution", current_step: "triage",
+                            active_pattern: "handoff", status: "in_progress")
+         tasks.md 초기화 (fix 작업 등록용)
+         findings.md [공유 변수/경로]·[데이터 충돌] 초기화
+Phase 2: [Step 실행 루프 — Stage incident-resolution / Step triage]
+         @incident-triage 호출 → 수 기가바이트의 로그 및 스택 트레이스 스캔
+         - 분석 결과: "DB 연결 타임아웃 발견"
+         - 응답 끝에 핸드오프 신호 삽입:
+           `[NEXT_AGENT: @db-fixer] 사유: Connection Pool 고갈 및 Slow Query 확인됨.`
+         오케스트레이터가 [NEXT_AGENT] 파싱:
+         - 파싱 성공 → handle_handoff(@db-fixer) 호출:
+                        - checkpoint.json의 handoff_chain 확인 (현재: [])
+                        - 순환 없음 + 3단계 미초과 → handoff_chain: ["@db-fixer"] 갱신
+                        - current_step → "fix", active_pattern → "producer_reviewer" 갱신
+                        - step_history에 "triage" completed_at 기록, last_updated: 현재 타임스탬프
+                        - @db-fixer 즉시 호출. 프롬프트에 트리아지 분석 요약 + 로그 위치 주입
+         - 파싱 실패 ([NEXT_AGENT] 미포함) → 사용자 확인 요청으로 전문가 선택 요청
+         - 순환/3단계 초과 → handle_handoff()가 사용자 확인 요청 + HALT (참조: orchestrator-procedures.md)
+Phase 3: [Step 실행 루프 — Stage incident-resolution / Step fix]
+         지정 에이전트(@db-fixer 등)가 수정 수행 후 @incident-triage에게 재검증 요청 (Fix Loop, 최대 2회 재시도(총 3회))
+         - 종료 조건(성공): @incident-triage 응답에 [NEXT_AGENT] 없음 + "이상 없음" 또는 "수정 확인" 명시
+         - 종료 조건(실패): 3회 후에도 [NEXT_AGENT] 재반환 또는 에러 지속
+           → Blocked, 사용자 확인 요청으로 수동 개입 요청. 임의 PASS 절대 금지.
+         step "fix" 종료 조건 충족 → stage "incident-resolution" 완료
+         checkpoint.json 갱신:
+           - step_history에 "fix" completed_at 기록
+           - stage_history에 "incident-resolution" completed_at 기록
+           - current_stage·current_step: "done", status: "completed", last_updated: 현재 타임스탬프
+           - handoff_chain: [] (Step 전환 시 초기화)
+Phase 4: 장애 대응 보고서 _workspace/{plan_name}/final/incident_report.md 생성
+Phase 5: 사용자 보고, _workspace/ 보존
+```
+
+## 협업 프로토콜 예시: `@incident-triage.md`
+
+```markdown
+## 핸드오프 가이드 (Codex CLI)
+
+작업 완료 시 다음 규칙에 따라 전문가를 추천하라.
+
+- SQL/DB 에러·커넥션 타임아웃·슬로우 쿼리 발견 시: `[NEXT_AGENT: @db-fixer]`
+- 403/401/인증·권한 에러 발견 시: `[NEXT_AGENT: @security-patcher]`
+- 성능 이슈(DB 외 애플리케이션 레벨 병목): `[NEXT_AGENT: @logic-fixer]`
+- 그 외 비즈니스 로직 오류: `[NEXT_AGENT: @logic-fixer]`
+- 복수 원인 동시 발견 시: 가장 심각한 원인 기준으로 1개 선택 후 사유에 나머지 원인 병기
+
+## 영속성 가이드
+
+로그 분석 중 컨텍스트 한도에 도달할 경우, 현재까지 읽은 마지막 파일 경로와 라인 번호를
+`_workspace/findings.md`의 [공유 변수/경로] 섹션에 기록하여 다음 턴에서 이어서 읽을 수 있게 하라.
+
+## 에러 핸들링
+
+- 로그 파일 접근 불가(권한·경로 오류) → 사용자 확인 요청으로 올바른 경로 요청. 임의 경로 추측 금지.
+- 원인 특정 불가(에러 패턴 없음) → 분석 불가 사유를 findings.md [데이터 충돌]에 기록 후 사용자 확인 요청으로 추가 컨텍스트 요청.
+- 재검증 시 동일 에러 반복(Fix Loop 3회 초과) → 재반환 없이 Blocked 판정. 메인 에이전트가 사용자 확인 요청 호출.
+```

--- a/harness/references/expansion-matrix.md
+++ b/harness/references/expansion-matrix.md
@@ -1,0 +1,216 @@
+# Phase Selection Matrix for Extending an Existing Harness
+
+Referenced when branching into **existing extension** mode from `SKILL.md` Phase 0. Determines the list of Phases to execute based on the type of change.
+
+---
+
+## Step 1: Change Type Classification Decision Tree
+
+```
+PROCEDURE classify_change(request):
+
+    // ── Step A: Only workflow.md / Step structure changes? ─────────────────
+    IF request affects ONLY ["workflow.md", "checkpoint.json logic"]:
+        IF adds new Stage OR adds new Step:
+            RETURN "Stage/Step Addition"
+        ELSE:                               // exit condition, pattern name, or agent list adjustment
+            RETURN "workflow.md Modification"
+
+    // ── Step B: Only agent/skill files change? ──────────────────────────
+    IF request affects ONLY [".codex/agents/*.toml", "references/skills/"]:
+        IF adds new agent OR renames agent role:
+            RETURN "Agent Addition"
+        ELSE:                               // prompt, checklist, or tool list modification only
+            RETURN "Skill Addition/Modification"
+
+    // ── Step C: Architecture change threshold judgment ───────────────────
+    // Classify as "Architecture Change" if ANY of the following conditions apply
+    // Full pattern list: references/agent-design-patterns.md § "7 Core Architecture Patterns"
+    Architecture change conditions:
+      - Pattern change (e.g., pipeline → fan_out_fan_in)
+      - Simultaneous reorganization of 3 or more agents (additions + deletions + role redefinitions combined)
+      - Modification of orchestrator Step 2 core branching logic
+      - Increase or decrease in Stage count
+
+    IF ANY of architecture change conditions:
+        RETURN "Architecture Change"
+
+    // ── Step D: Multiple types occurring simultaneously ─────────────────
+    // Priority (higher = broader scope):
+    // Architecture Change > Stage/Step Addition > Agent Addition > Skill Addition/Modification > workflow.md Modification
+    RETURN highest_priority_type(matched_types)
+```
+
+---
+
+## Phase Selection Matrix
+
+| Change Type        | Phase 1                    | Phase 2           | Phase 3             | Phase 4           | Phase 5                                                                                      | Phase 6  |
+| ---------------- | -------------------------- | ----------------- | ------------------- | ----------------- | -------------------------------------------------------------------------------------------- | -------- |
+| Agent Addition    | Skip (use Phase 0 results) | Placement decision only | **Required**            | If dedicated skill needed | Orchestrator modification                                                                          | **Required** |
+| Skill Addition/Modification   | Skip                     | Skip            | Skip              | **Required**          | If connection changes                                                                                 | **Required** |
+| Architecture Change    | Skip                     | **Required**          | Affected agents only | Affected skills only   | **Required**                                                                                     | **Required** |
+| Stage/Step Addition  | Skip                     | **Required** (redesign) | If new agents needed | If new skills needed   | **Required** (workflow.md modification)                                                                  | **Required** |
+| workflow.md Modification | Skip                     | Skip            | Skip              | Skip            | **Required** (workflow.md modification + verify reading logic coherence with `orchestrator-template.md` Step 0·Step 2) | **Required** |
+
+---
+
+## Decision Guide
+
+**Agent Addition** — When a new role is created or an existing agent's workload becomes excessive. Phase 1 (domain analysis) is skipped because Phase 0 audit results are already available.
+
+**Skill Addition/Modification** — Only methodology, checklists, or protocols change. Phase 1–3 are skipped because agent personas and architecture remain unchanged.
+
+**Architecture Change** — Pattern change (e.g., Pipeline → Fan-out/Fan-in) or simultaneous reorganization of 3 or more agents. The broadest scope, so full review starts from Phase 2.
+
+**Stage/Step Addition** — Inserting a Stage or Step into an existing workflow. Redesigning the Stage-Step structure in `workflow.md` (Phase 2) is required. Run Phase 3 and 4 as well if new agents or skills are needed.
+
+**workflow.md Modification** — Only Stage/Step structure or exit conditions change; no agent or skill changes. After modifying `workflow.md` in Phase 5, you must verify that the orchestrator's Step 0 (checkpoint stage/step name matching) and Step 2 (step_block extraction path and exit_cond type) reading logic is coherent with the changed structure.
+
+**Architecture change threshold** — Classify as an architecture change if any of the following apply:
+
+| Condition                                 | Example                                    |
+| ------------------------------------ | --------------------------------------- |
+| Pattern change                            | pipeline → fan_out_fan_in               |
+| Simultaneous reorganization of 3+ agents          | Combined additions + deletions + role redefinitions of 3 or more     |
+| Modification of orchestrator Step 2 core branching | Step execution loop structure change                |
+| Change in Stage count                        | Stage 1 → adding Stage 2, or deleting a Stage |
+
+---
+
+## Phase Execution Order Rules
+
+Phases must be executed in **ascending numeric order**. Reverse execution is prohibited.
+
+| Rule                         | Description                                                                                                              |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **Phase 4 → after Phase 3**   | Skills can only be connected after agents are defined. Running Phase 4 without Phase 3 is only allowed for the Skill Addition/Modification change type. |
+| **Phase 5 → after Phase 3·4** | The orchestrator calls agents and skills, so the targets must be defined first.                                      |
+| **Phase 6 → always last**    | Executed last regardless of change type.                                                                               |
+| **"Skip" Phases**           | If drift (mismatch) is detected in the Phase 0 audit, run that Phase partially.                                                      |
+| **Priority when overlapping**         | If multiple change types overlap, use the broadest scope (Architecture Change) as the baseline.                                              |
+
+```
+// Phase execution order dependencies
+Phase 2 → Phase 3 → Phase 4 → Phase 5 → Phase 6
+          (agents)  (skills)  (orchest)  (verify)
+
+// Independent execution allowed (other Phases not needed)
+Skill Addition/Modification:   Phase 4 → Phase 6
+workflow.md Modification: Phase 5 → Phase 6
+```
+
+---
+
+## Validation Rules
+
+- Even **"Skip"** Phases must be partially executed if a mismatch (drift) is detected in the Phase 0 audit.
+- Phase 6 (validation) is **always required** regardless of change type.
+- If multiple change types overlap, use the broadest scope (Architecture Change) as the baseline.
+
+---
+
+## Practical Case Examples
+
+### Case A: Adding 1 Agent + 1 Dedicated Skill
+
+**Situation:** An existing Pipeline harness now requires a security review agent (`@security-reviewer`) and a dedicated skill (`security-checklist`).
+
+```
+classify_change → "Agent Addition" (agent addition + skill addition combined → priority: Agent Addition > Skill Addition)
+
+Phase execution:
+  Phase 3: Create @security-reviewer.toml (new)
+  Phase 4: Create security-checklist/SKILL.md (new)
+  Phase 5: Modify orchestrator skill
+    - Add @security-reviewer to team composition
+    - Insert Step N (security-review)
+    - Update workflow.md Stage·Step
+    - Add "security review", "vulnerability check" keywords to description
+  Phase 6: Structure validation + trigger validation (including new agent)
+
+AGENTS.md change history: "@security-reviewer added | security review absence feedback"
+```
+
+### Case B: Strengthening an Existing Skill Checklist Only
+
+**Situation:** Feedback that the review criteria of the `code-review` skill are insufficient → add checklist items.
+
+```
+classify_change → "Skill Addition/Modification" (no agent file or architecture changes)
+
+Phase execution:
+  Phase 4: Modify code-review/SKILL.md (add checklist items)
+  Phase 6: Skill execution test (Phase 6-3) + trigger validation (Phase 6-4)
+            Structure validation (Phase 6-1) can be omitted if no frontmatter changes
+
+AGENTS.md change history: "code-review skill checklist strengthened | review quality feedback"
+```
+
+### Case C: Architecture Pattern Change (Pipeline → Fan-out/Fan-in)
+
+**Situation:** Parallelizing 3 sequential analysis steps to improve speed. Includes role redefinition of 3 existing agents.
+
+```
+classify_change → "Architecture Change"
+  Condition matched: pattern change (pipeline → fan_out_fan_in) + simultaneous reorganization of 3 agents
+
+Phase execution:
+  Phase 2: Redesign parallel fan-out structure (redefine workflow.md Stage-Step)
+           Redesign findings.md·tasks.md·checkpoint.json flow
+  Phase 3: Modify 3 affected agents
+           - Reflect parallel call pattern
+           - Redefine input/output paths (branching under _workspace/{plan_name}/)
+  Phase 4: Modify skills related to parallel execution (if any)
+  Phase 5: Full orchestrator rewrite
+           - Replace Step execution loop with batch calls
+           - Add checkpoint.json active_pattern update logic
+  Phase 6: Dry-run test (Phase 6-5) is mandatory
+
+AGENTS.md change history: "Architecture Pipeline→Fan-out/Fan-in change | analysis speed improvement goal"
+```
+
+### Case D: Adding Stage 2 (Validation Stage) to Existing Stage 1
+
+**Situation:** A harness currently running with a single Stage (e.g., `sso-integration`) needs a final user validation Stage added.
+
+```
+classify_change → "Stage/Step Addition"
+  Condition matched: Stage count increase (1 → 2)
+
+Phase execution:
+  Phase 2: Redesign workflow.md
+           - Stage 1: sso-integration (existing, deliverable noun phrase)
+           - Stage 2: user-validation (new, user approval gate: "complete after confirming validation results")
+           Define Stage 2 exit conditions and transition protocol (names in kebab-case + deliverable meaning; generic placeholders like `main`·`validate` are prohibited)
+  Phase 3: Add @qa-validator agent (responsible for new Stage)
+  Phase 4: Create validation-checklist skill (if needed)
+  Phase 5: Modify orchestrator
+           - Add Stage 2 execution block
+           - Add checkpoint.json Stage transition (sso-integration → user-validation) logic
+           - Document user approval gate in AGENTS.md
+  Phase 6: Resume flow test (Phase 6-6) required — mid-Stage interruption and resume scenario
+
+AGENTS.md change history: "Stage 2 (user-validation) added | user validation gate absence feedback"
+```
+
+---
+
+## Drift Handling Guide
+
+When mismatch (drift) is found in the Phase 0 audit, resolve the drift before classifying the change type.
+
+| Drift Type                                                   | Cause                                                                                                    | Resolution                                                                                                                                                                                                                    |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Agent file exists / not registered in AGENTS.md**                    | Agent was added but change history was not recorded in AGENTS.md                                                  | Correct AGENTS.md change history, then re-verify with Phase 6-1                                                                                                                                                                                 |
+| **Registered in AGENTS.md / agent file missing**                      | File was deleted but not reflected, or name change not applied                                                                         | Confirm intent via user input request, then restore file or delete AGENTS.md entry                                                                                                                                                         |
+| **Orchestrator references agent ≠ actual file**                 | File renamed during refactoring but not reflected                                                                               | Partial Phase 5 execution — correct agent name in orchestrator                                                                                                                                                           |
+| **Skill description trigger conflict**                             | Keywords overlap with existing skill after adding a new skill                                                                    | Partial Phase 6-4 (trigger validation) execution — adjust description                                                                                                                                                          |
+| **checkpoint.json current_step ≠ workflow.md step name**        | checkpoint.json not updated after modifying workflow.md                                                                   | Confirm current progress position via user input request, then manually correct checkpoint.json                                                                                                                                        |
+| **Orchestrator SKILL.md flat Step list (no Stage hierarchy)** | Stage-Step model not applied at initial creation (e.g., flat `Step 0~4` headers as in `examples/sso-dev-flow`)                   | **Apply `skill-writing-guide.md` §7-6 Migration Guide 6 steps (M1~M6)** — inventory → Stage mapping → pattern assignment → exit condition conversion → write 5 artifacts → bundle schemas/. Canonical package: `references/examples/full-bundle/sso-style.md`. |
+| **Exit condition is natural language ("QA approved", "enough", "when done")**     | LLM arbitrary interpretation expressions remain in workflow.md or orchestrator SKILL.md                                         | Apply `orchestrator-template.md` Step 1.7 schema validation routine → rewrite as verifiable predicates when whitelist violations are detected (`task_*.json status=done`·`{file}.json verdict=PASS`·`iterations ≥ N`, etc.)                                   |
+| **workflow.md required fields missing**                               | One or more of `pattern`·`active agents`·`exit condition`·`next step`·`max iterations`·Stage `user approval gate` missing | Supplement immediately. Refer to the [MANDATORY] 6-field table in `SKILL.md` Phase 2-1. Missing → Zero-Tolerance Failure → user input request → HALT                                                                                                       |
+| **findings.md using arbitrary sections** (`[Review: phase]`, etc.)         | Standard sections not followed                                                                                             | Convert to standard sections (`[Key Insights]`·`[Change Requests]`·`[Shared Variables/Paths]`, etc.). See "findings.md Standard Section Structure" table in `references/team-examples.md`                                                                   |
+| **task\_\*.json persistence unused** (only simple tasks.md checkbox)         | Parallel agent reporting replaced by direct tasks.md modification — race condition risk                                     | Assign each agent the obligation to write `_workspace/tasks/task_{agent}_{id}.json`. Main collects with GLOB, then updates tasks.md via apply_patch                                                                                                    |
+
+**Drift resolution principle:** If even one drift item exists, it must be resolved before executing the change type Phases. Drift resolution itself is confirmed with Phase 6-1 (structure validation) and recorded in the AGENTS.md change history.

--- a/harness/references/orchestrator-procedures.md
+++ b/harness/references/orchestrator-procedures.md
@@ -1,0 +1,125 @@
+# Orchestrator Procedures & Principles
+
+Common error handling procedures, validation principles, and description writing guidelines applied when authoring orchestrator skills.
+Used alongside the Step 0~5 pseudocode in `orchestrator-template.md`.
+
+## Error Handling and Self-Healing
+
+> **Canonical spec.** References to retry, Blocked, and user confirmation requests in other files (qa-agent-guide, agent-design-patterns, etc.) defer to this decision tree.
+
+### Error Response Decision Tree (pseudocode)
+
+```
+PROCEDURE handle_error(agent, task, error_type):
+
+    // ── Immediate user confirmation (no retry) ────────────────────────────
+    IF error_type == "ambiguous_input" OR error_type == "missing_params":
+        CALL request_user_input("Ambiguous input or missing parameters: {details}")
+        RETURN
+
+    IF error_type == "majority_failure":        // Majority of agents failed
+        apply_patch "_workspace/tasks.md" ← record interruption point
+        CALL request_user_input("Majority failure. Requesting confirmation to proceed.")
+        RETURN
+
+    // ── Automatic recovery (resume from Step 0) ───────────────────────────
+    IF error_type == "timeout" OR error_type == "session_restart":
+        // Re-running Step 0 detects checkpoint.json → resumes automatically
+        // ※ Idempotency required: each agent must first check whether output files exist
+        //   and skip already-completed work. Results must be identical regardless of how
+        //   many times resumption occurs.
+        GOTO Step 0
+        RETURN
+
+    // ── Data conflict ─────────────────────────────────────────────────────
+    IF error_type == "data_conflict":
+        RECORD findings.md ← "[Data Conflict]" section with source attribution
+        @reviewer call (conflict_resolution_prompt)
+        IF reviewer resolves conflict:
+            RETURN
+        ELSE:
+            CALL request_user_input("Data conflict unresolved: {details}")
+            RETURN
+
+    // ── Retriable failure ─────────────────────────────────────────────────
+    // Applies to: agent_failure | reviewer_reject | context_limit_exceeded
+    // Applies to: handoff_no_candidate (no handoff target found)
+    IF task.retries < 2:                        // fewer than 3 total attempts
+        task.retries += 1
+        RECORD findings.md ← "Retry {task.retries}/2: {error cause} → approach changed"
+        @agent call (modified_prompt_with_feedback)
+        RETURN
+
+    // ── 3 attempts exhausted → Blocked protocol ───────────────────────────
+    GOTO blocked_protocol
+
+// ── Blocked Protocol (common) ─────────────────────────────────────────────
+PROCEDURE blocked_protocol(agent, task):
+    apply_patch "_workspace/tasks/task_{agent}_{id}.json":
+        status  ← "blocked"
+        result  ← null
+        retries ← task.retries   // preserve final value
+    RECORD findings.md ← "Final rejection: {reason} | Attempt history: {history}"
+    // Advancing Step or Stage is strictly prohibited
+    DO NOT UPDATE checkpoint.json  // Separation of concerns: blocked_protocol records to task file only.
+                                   // The pre-blocked check in Step 2 detects the task file on the next
+                                   // cycle entry and updates checkpoint to blocked. Direct update by
+                                   // blocked_protocol would cause a duplicate update.
+    CALL request_user_input("Blocked: @{agent} — {reason}. Requesting intervention.")
+    HALT    // Arbitrary Skip or Done is strictly prohibited
+
+// ── Special case: Handoff cycle detection ────────────────────────────────
+// (Prevents A→B→A infinite loops. call_history = handoff_chain field in checkpoint.json)
+PROCEDURE handle_handoff(next_agent):
+    READ "_workspace/checkpoint.json" → ckpt
+    call_history ← ckpt.handoff_chain ?? []     // empty array if absent
+
+    IF next_agent IN call_history:
+        RECORD findings.md ← "Circular handoff: {call_history} → {next_agent}"
+        CALL request_user_input("Circular handoff detected: {path}. Requesting intervention.")
+        HALT
+
+    IF LENGTH(call_history) >= 3:               // more than 3 steps
+        RECORD findings.md ← "Handoff exceeded 3 steps: {call_history}"
+        CALL request_user_input("Handoff exceeded 3 steps. Requesting intervention.")
+        HALT
+
+    // Safe → update history then call
+    apply_patch "_workspace/checkpoint.json":
+        ckpt.handoff_chain ← APPEND(call_history, next_agent)
+        ckpt.last_updated  ← NOW()
+    @next_agent call (...)
+
+// Reset handoff_chain on every Step transition
+// (Reset handoff_chain: [] when updating checkpoint.json)
+```
+
+## Test Scenarios
+
+> Full normal flow / resume flow / error flow scenarios: `references/skill-testing-guide.md` § **Orchestrator Test Scenarios** (3 types: normal flow / resume flow / error flow).
+
+## Follow-up Action Keywords for description (Required)
+
+An orchestrator description that contains **only initial trigger keywords is insufficient**. The following follow-up action expressions must be included, or the harness becomes effectively dead code after its first run.
+
+- re-run / run again / update / modify / refine
+- "only {part} of {domain} again", "based on previous results", "improve results"
+- Domain-specific everyday expressions (e.g., for a launch strategy harness: "launch", "promotion", "trending", etc.)
+
+If follow-up keywords are missing from `description`, the Codex CLI trigger router will stop selecting this skill from the second call onward.
+
+## Writing and Execution Principles
+
+1. **Emphasize the intermediary role:** The main agent does not merely invoke tools — it analyzes results and **enriches the input (context) for the next agent**.
+2. **Persistence first:** Update files immediately after every major state change to guard against unexpected termination.
+3. **Atomic state consolidation:** The orchestrator collects and merges split work files produced by parallel agents, preventing write conflicts at the source.
+4. **Strict SandBox Mode isolation:** Do not assign tasks to agents that exceed their defined `sandbox_mode` scope.
+5. **Ensure visibility:** All intermediate steps must be recorded to files via `findings.md` and `tasks.md`.
+6. **Declare Step dependencies:** Declare dependencies through the Step order and exit conditions in workflow.md. The structure of Step N complete → enter Step N+1 must be clearly expressed in workflow.md.
+7. **Realistic error assumptions:** Do not assume "everything succeeds." Include a rule that prohibits Stage advancement when a Step is Blocked.
+8. **Test scenarios required:** Include at least 1 normal + 1 resume + 1 error scenario in the skill body. Without all three, Step 5 validation cannot pass.
+
+## Stage/Step Transition Protocol
+
+> Full details of the Step execution loop, Stage transition gate, and entry/exit control logic in Step 2:
+> See **`references/stage-step-guide.md`**.

--- a/harness/references/orchestrator-template.md
+++ b/harness/references/orchestrator-template.md
@@ -81,13 +81,16 @@ Please resolve the blocking cause and resume. ("continue" / "restart")
    | `references/schemas/agent-worker.template.toml`        | `_workspace/_schemas/agent-worker.template.toml`        |
    | `references/schemas/agent-orchestrator.template.md`    | `_workspace/_schemas/agent-orchestrator.template.md`    |
    | `references/schemas/agent-state-manager.template.toml` | `_workspace/_schemas/agent-state-manager.template.toml` |
+   | `references/schemas/state.py`                          | `_workspace/state.py`                                   |
+
+   > **`state.py` destination is `_workspace/state.py`** (not `_workspace/_schemas/`). Used internally by `@state-manager` — the orchestrator does not call it directly.
 
    > `README.md`, `models.md`, and agent templates are for reference when creating agent definitions — the workspace copy serves as the creation baseline. `models.md` is the SoT for model IDs and must always be synced.
    > **`shell cp ...` is prohibited** — the skill reference path is unreachable via shell from the runtime working directory (user project root). Always use shell `cat` + `apply_patch`.
 
    **Operational rules:**
    - Worker agents must read `_workspace/_schemas/task.schema.json` before writing their own output.
-   - The main agent must validate against the schema every time it updates `task_*.json` or `checkpoint.json`.
+   - `checkpoint.json` writes are validated by `python _workspace/state.py` against `_workspace/_schemas/checkpoint.schema.json` — no separate validation step needed by the orchestrator.
    - When the skill is updated, the new schema applies starting from the next init. Do not modify workspace schemas during an in-progress run (preserve the snapshot).
    - **SoT:** `references/schemas/`. The workspace copy is a snapshot at execution time.
 
@@ -110,7 +113,7 @@ Please resolve the blocking cause and resume. ("continue" / "restart")
    | expert_pool              | + `[Routing Rationale]` (format: `"- {agent}: {reason} (matched keywords: {keywords})"`) |
 
 6. Initialize `tasks.md` — copy `_workspace/_schemas/tasks.template.md` (keep headers only, leave rows empty).
-7. Create `checkpoint.json` — populate all fields from `_workspace/_schemas/checkpoint.schema.json`:
+7. Create `checkpoint.json` — populate all required fields (validated against `_workspace/_schemas/checkpoint.schema.json` by `python _workspace/state.py` on every write):
 
 ```json
 {

--- a/harness/references/orchestrator-template.md
+++ b/harness/references/orchestrator-template.md
@@ -1,0 +1,382 @@
+# Orchestrator Skill Advanced Template (Codex CLI Version)
+
+The orchestrator is the top-level skill used by the main agent to execute orchestration logic. Because the Codex CLI environment **does not support direct communication between sub-agents**, the main agent acts as the sole **Data Broker**, coordinating the team through `findings.md`, `tasks.md`, and `checkpoint.json`.
+
+> **Note:** Sub-agent invocation uses Codex subagent spawn. Parallel: default. Sequential: separate stages via skill instructions. Parallel execution, shell background (dev server, etc.). Details on API differences from Claude Code (why `TeamCreate`, `SendMessage`, `TaskCreate` are absent): see `references/agent-design-patterns.md` § "Execution Mode: Orchestration".
+
+## Orchestrator Base Structure (Data Broker Enhanced)
+
+````markdown
+---
+name: {domain}-orchestrator
+description: "{Domain} harness orchestrator. Coordinates a virtual team through shared discovery (findings.md), state persistence (checkpoint.json), and task management (tasks.md). {Initial trigger keywords}. Also use this skill for follow-up work ({domain} result modification / partial re-run / update / supplement / re-run / improve previous results) to maintain consistency."
+---
+
+# {Domain} Orchestrator
+
+## Virtual Team Composition
+
+> **Common Required Tools (table omitted):** Request user confirmation
+> **Orchestrator-only:** `subagent spawn` — do not grant to worker sub-agents.
+
+| agent     | type                    | role   | skill   | output        |
+| --------- | ----------------------- | ------ | ------- | ------------- |
+| {agent-1} | {custom or built-in}    | {role} | {skill} | {output-file} |
+| {agent-2} | {custom or built-in}    | {role} | {skill} | {output-file} |
+
+## Workflow
+
+### Step 0: Context Check (Durable Execution)
+
+Determine the entry path based on the state of `_workspace/checkpoint.json`. **Evaluate the table top-to-bottom in order** and execute the action of the first matching row.
+
+| `_workspace/` | `ckpt.status`                | Additional condition              | Action                                                                                                 |
+| ------------- | ---------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| absent        | —                            | —                                 | GOTO Step 1                                                                                            |
+| present       | `in_progress` or `partial`   | —                                 | Read workflow.md → GOTO Step 2 ¹                                                                       |
+| present       | `blocked`                    | response = "continue/resume/fix"  | Delete blocked task file ² → update checkpoint `{status:"in_progress"}` → GOTO Step 2                 |
+| present       | `blocked`                    | response = "restart/reset"        | Back up `_workspace/` → `_workspace_{NOW()}/` → GOTO Step 1                                           |
+| present       | `blocked`                    | other (including first entry)     | Report blocked reason ³ → request user confirmation → HALT                                            |
+| present       | `completed`                  | request = "partial modification"  | Determine RESUME_FROM ⁴ → update checkpoint `{status:"partial", current_stage, current_step}` → GOTO Step 2 |
+| present       | `completed`                  | other                             | Back up `_workspace/` → `_workspace_{YYYYMMDD_HHMMSS}/` → GOTO Step 1                                 |
+
+¹ Auto-resume path after context limit exhaustion. No manual intervention required.
+
+² Target for deletion: `_workspace/tasks/task_{ckpt.blocked_agent}_*.json` (identified by `ckpt.blocked_agent`). Do not touch Blocked files from other steps.
+
+³ Blocked reason report format:
+
+```
+Previous execution Blocked. Reason: {ckpt.blocked_reason} | Agent: {ckpt.blocked_agent}
+Please resolve the blocking cause and resume. ("continue" / "restart")
+```
+
+> After requesting user confirmation, re-evaluate this table on the next turn.
+
+⁴ **Partial modification RESUME_FROM decision:**
+
+| Request type                              | RESUME_FROM                                                          |
+| ----------------------------------------- | -------------------------------------------------------------------- |
+| "Modify agent X prompt/output"            | `{stage: ckpt.current_stage, agent: X}`                              |
+| "Modify skill Y"                          | `{skill: Y}` (re-invoke only the relevant agents)                   |
+| "Modify workflow.md / exit condition"     | `{stage: ckpt.current_stage, step: ckpt.current_step}`               |
+| Scope unclear                             | `request_user_input("Confirm modification scope: which agent/skill/file?")` → RETURN |
+
+---
+
+### Step 1: Initialization
+
+1. Parse `{plan_name}` from `user_input`. If absent, `request_user_input("Please specify a task name.")` → RETURN.
+2. Create directories: `_workspace/`, `_workspace/{plan_name}/`, `_workspace/tasks/`, `_workspace/_schemas/`.
+3. **Schema template sync (required):** Read the 5 files from this skill's `references/schemas/` directory and write them as-is to `_workspace/_schemas/`. For each file, execute one `cat` → `apply_patch` pair:
+
+   | Source (skill reference path)                          | Destination (workspace path)                            |
+   | ------------------------------------------------------ | ------------------------------------------------------- |
+   | `references/schemas/task.schema.json`                  | `_workspace/_schemas/task.schema.json`                  |
+   | `references/schemas/checkpoint.schema.json`            | `_workspace/_schemas/checkpoint.schema.json`            |
+   | `references/schemas/workflow.template.md`              | `_workspace/_schemas/workflow.template.md`              |
+   | `references/schemas/findings.template.md`              | `_workspace/_schemas/findings.template.md`              |
+   | `references/schemas/tasks.template.md`                 | `_workspace/_schemas/tasks.template.md`                 |
+   | `references/schemas/models.md`                         | `_workspace/_schemas/models.md`                         |
+   | `references/schemas/agent-worker.template.toml`        | `_workspace/_schemas/agent-worker.template.toml`        |
+   | `references/schemas/agent-orchestrator.template.md`    | `_workspace/_schemas/agent-orchestrator.template.md`    |
+   | `references/schemas/agent-state-manager.template.toml` | `_workspace/_schemas/agent-state-manager.template.toml` |
+
+   > `README.md`, `models.md`, and agent templates are for reference when creating agent definitions — the workspace copy serves as the creation baseline. `models.md` is the SoT for model IDs and must always be synced.
+   > **`shell cp ...` is prohibited** — the skill reference path is unreachable via shell from the runtime working directory (user project root). Always use shell `cat` + `apply_patch`.
+
+   **Operational rules:**
+   - Worker agents must read `_workspace/_schemas/task.schema.json` before writing their own output.
+   - The main agent must validate against the schema every time it updates `task_*.json` or `checkpoint.json`.
+   - When the skill is updated, the new schema applies starting from the next init. Do not modify workspace schemas during an in-progress run (preserve the snapshot).
+   - **SoT:** `references/schemas/`. The workspace copy is a snapshot at execution time.
+
+4. Write `workflow.md` — use `_workspace/_schemas/workflow.template.md` as the starting point. Timing varies by pattern:
+
+   | Pattern                                                                         | Authoring method                                               |
+   | ------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+   | `pipeline` / `fan_out_fan_in` / `producer_reviewer` / `handoff` / `expert_pool` | Write immediately based on the user request                    |
+   | `supervisor` / `hierarchical`                                                   | Call Discovery Agent first → write based on its output         |
+
+5. Initialize `findings.md` — copy `_workspace/_schemas/findings.template.md`, then remove all sections except those required for the pattern:
+
+   | Pattern                  | Sections                                                                              |
+   | ------------------------ | ------------------------------------------------------------------------------------- |
+   | All patterns (common)    | `[Shared Variables/Paths]`                                                            |
+   | fan_out / fan_out_fan_in | + `[Key Insights]`, `[Key Keywords]`, `[Data Conflicts]`                              |
+   | producer_reviewer        | + `[Change Requests]`                                                                 |
+   | pipeline / hierarchical  | + `[Next Stage Instructions]`                                                         |
+   | supervisor / handoff     | + `[Data Conflicts]`                                                                  |
+   | expert_pool              | + `[Routing Rationale]` (format: `"- {agent}: {reason} (matched keywords: {keywords})"`) |
+
+6. Initialize `tasks.md` — copy `_workspace/_schemas/tasks.template.md` (keep headers only, leave rows empty).
+7. Create `checkpoint.json` — populate all fields from `_workspace/_schemas/checkpoint.schema.json`:
+
+```json
+{
+  "execution_id": "YYYYMMDD_HHMMSS",
+  "plan_name": "{plan_name}",
+  "status": "in_progress",
+  "current_stage": "{workflow.stages[0].name}",
+  "current_step": "{workflow.stages[0].steps[0].name}",
+  "active_pattern": "{first_step.pattern}",
+  "stage_history": [],
+  "step_history": [],
+  "stage_artifacts": {},
+  "handoff_chain": [],
+  "tasks_snapshot": { "done": [], "current": null },
+  "shared_variables": {},
+  "last_updated": "NOW()"
+}
+```
+
+> **`@state-manager` delegation pattern (optional):** If the virtual team includes `@state-manager`, delegate steps 5–7 (findings.md / tasks.md / checkpoint.json initialization) and all state updates in Step 2 via `subagent spawn`. The orchestrator focuses on reasoning and coordination; state I/O is handled by `@state-manager` (flash model) after schema validation. Interface: `OPERATION: state.init|checkpoint.update|task.upsert|findings.append|tasks.update|state.archive` + `PAYLOAD:` block. Full spec: `references/schemas/agent-state-manager.template.toml`.
+
+> **Notation bridge:** `workflow.md` declares Stages and Steps using **markdown headers only** (`### Stage 1: {deliverable-name}`, `#### Step 1: {deliverable-name}`), not JSON. The `"current_stage": "{workflow.stages[0].name}"` in the checkpoint.json above is pseudocode meaning "the name parsed from the first `### Stage` header" — it is not a JSON array access.
+> **Parsing example:** `### Stage 1: sso-integration` → `current_stage = "sso-integration"` / `#### Step 1: requirements-gathering` → `current_step = "requirements-gathering"`. The orchestrator reads `workflow.md` via shell `cat`, builds the Stage/Step list in header order, and references them by name (text).
+> **Naming convention (required):** Placeholders such as `main`, `step1`, `task` are prohibited. Use kebab-case + deliverable-meaning noun phrases (Jira title convention). Violations are blocked by workflow.md schema validation.
+
+8. **workflow.md schema validation (required immediately after writing, before cycle validation):**
+
+   Check each Stage/Step block for **missing required fields**. Block immediately if even one is missing.
+
+   | Check item                                                                                                                                  | Method                                                                                                                                                                            | Action on failure                                                                                                                                                   |
+   | ------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | Stage fields: `exit_condition`, `next_stage`, `user_approval_gate`                                                                          | Confirm field presence under header via regex/parser                                                                                                                              | `request_user_input("workflow.md Stage {name} missing required fields: {missing_fields}. Please add them and retry.")` → HALT                                               |
+   | Step fields: `pattern`, `active_agents`, `exit_condition`, `next_step`, `max_iterations`                                                    | Same                                                                                                                                                                              | Same                                                                                                                                                                |
+   | `pattern` value = one of 7 (`pipeline` / `fan_out_fan_in` / `expert_pool` / `producer_reviewer` / `supervisor` / `hierarchical` / `handoff`) | Enum check                                                                                                                                                                        | `request_user_input("Pattern value violation: {value}. Choose one of the 7.")` → HALT                                                                                       |
+   | `active_agents` format = `[@name, ...]`                                                                                                     | Regex `\[(@\w[\w-]*\s*,?\s*)+\]`                                                                                                                                                  | `request_user_input("active_agents format violation.")` → HALT                                                                                                              |
+   | **`exit_condition` verifiable predicate**                                                                                                   | Keyword whitelist: `task_*.json`, `status=done`, `exists`, `verdict=`, `score >=`, `iterations >=`. Violation if no whitelist match AND natural-language keywords (`approved`, `sufficient`, `when complete`, `satisfied`, `appropriately`) are present | `request_user_input("Step {name} exit_condition is natural language ('{value}'). Rewrite as a verifiable predicate: file existence, JSON field value, iteration >= N.")` → HALT |
+   | User approval gate absent                                                                                                                   | Not specified in Stage block                                                                                                                                                      | Same                                                                                                                                                                |
+   | **Stage/Step naming convention (Jira title convention)**                                                                                    | Extract header name → regex `^[a-z][a-z0-9-]*$` match + no placeholder blacklist items (`main`, `step1`, `task`, `work`, `default`, `phase1`, `stage1`, `generic`)               | `request_user_input("Stage/Step name violation: '{name}'. Rewrite as kebab-case + deliverable noun phrase (e.g., sso-integration, requirements-gathering). No placeholders.")` → HALT |
+
+9. **workflow.md cycle validation (after schema validation passes):**
+
+   | Check item                   | Method                                                                                                   | Action on failure                                                                                           |
+   | ---------------------------- | -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+   | Circular reference in Steps  | Trace `next_step` links for each Stage's Steps in order — if a previously visited Step name reappears → cycle | `request_user_input("Circular reference found in workflow.md: {Stage} → {cycle_path}. Please fix and retry.")` → HALT |
+   | `done` not reached in Stage  | If the Step chain end is not `done`                                                                      | Same                                                                                                        |
+   | Undefined Step reference     | If `next_step` value is a Step name that does not exist within the same Stage                            | Same                                                                                                        |
+
+   > Both checks run exactly once before entering the Step 2 loop. Can be skipped on resume paths (Step 0 → Step 2) since workflow.md has already been validated.
+
+10. GOTO Step 2.
+
+---
+
+### Step 2: Step Execution Loop
+
+**At the start of each cycle:**
+
+1. Read `workflow.md`, `checkpoint.json`, `findings.md`.
+2. Extract `workflow[ckpt.current_stage][ckpt.current_step]` → `step_block`. If absent, log error in findings.md → request user confirmation → HALT.
+3. Extract `active_agents`, `pattern`, `exit_cond`, `max_iterations` from `step_block`.
+4. **Resolve symbolic placeholders:** If `active_agents` contains symbolic names like `@selected_expert`:
+   - Read `checkpoint.shared_variables.selected_expert` → substitute with actual agent name.
+   - If field absent → `request_user_input("The expert_pool Step has not been executed yet or selected_expert is not recorded. Which agent should be called?")` → RETURN.
+     > This substitution applies at runtime only. Do not modify the workflow.md file itself.
+5. **Pre-blocked check (required before calling any agent):** If any `_workspace/tasks/task_*.json` has `status=="blocked" AND agent IN active_agents` → update checkpoint to `blocked` → request user confirmation → RETURN. Never call the agent.
+6. Access control: do not call any agent outside the `active_agents` list.
+7. **findings.md context injection:** Include the full `findings.md` in the agent call prompt.
+
+   ```
+   subagent spawn(@{name}, prompt="""
+   {task_description}
+
+   ## Shared Context (findings.md)
+   @{_workspace/findings.md}
+   """)
+   ```
+
+   > Even if findings.md is empty, include the header — agents recognize the section structure.
+
+**Agent invocation by pattern:**
+
+| Pattern                      | Invocation method                                                                        | Post-completion recording                                                   |
+| ---------------------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `pipeline` / `hierarchical`  | Sequential calls, record immediately after each agent                                    | findings.md, tasks.md, checkpoint.json                                      |
+| `fan_out` / `fan_out_fan_in` | Parallel calls → after all complete, `COLLECT ALL task_*.json` → apply_patch ⁷           | tasks/task_{agent}_{id}.json, tasks.md, findings.md, checkpoint.json        |
+| `producer_reviewer`          | —                                                                                        | GOTO Step 3                                                                 |
+| `expert_pool`                | CLASSIFY → single agent sequential ⁵                                                    | findings.md[Routing Rationale], task file, tasks.md                         |
+| `supervisor`                 | Parallel per batch → apply_patch after each batch                                        | tasks.md, checkpoint.json                                                   |
+| `handoff`                    | Sequential, parse `[NEXT_AGENT]` keyword ⁶                                               | task file (receiver or first agent), findings.md, tasks.md                  |
+
+⁵ **expert_pool details:**
+
+1. CLASSIFY(user_request, active_agents): compare keywords vs description → return best agent or AMBIGUOUS.
+2. AMBIGUOUS → `request_user_input("Expert list: {active_agents}")` → RETURN.
+3. Record findings.md[Routing Rationale] → update checkpoint `shared_variables.selected_expert` → call agent → record task file.
+
+⁶ **handoff details:**
+
+1. Call `active_agents[0]`.
+2. If response contains `[NEXT_AGENT: @{name}]`: `handle_handoff({name})` cycle detection → build next_prompt → call `{name}` → record `task_{name}_{id}.json`.
+3. If `[NEXT_AGENT]` absent: record `task_{active_agents[0]}_{id}.json` (standalone completion).
+
+⁷ **fan_out / fan_out_fan_in agent responsibility:** Each parallel agent writes `_workspace/tasks/task_{agent}_{id}.json` directly upon completing its work (the main agent does not write on their behalf). The main agent collects files via GLOB after all complete and merges them with apply_patch.
+
+**Partial failure recovery (when some agent task files are not created):**
+
+1. GLOB result file count < expected agent count → identify missing agents (set difference of active_agents minus GLOB results).
+2. Re-invoke each missing agent with zero-tolerance (max 2 retries, 3 total attempts).
+3. If still missing after retries → call `blocked_protocol(agent, task)` → HALT. Never force-advance with partial results.
+4. Perform apply_patch only after all agent task files are confirmed.
+
+**Exit condition check (by `exit_cond` type):**
+
+| Type | Exit condition format                     | Check method                                                                                                                                      |
+| ---- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A    | All `task_*.json` have `status=done`      | GLOB → check `status` field exhaustively (`"done"` lowercase — per task.schema.json enum)                                                         |
+| B    | Specific file exists                      | `EXISTS(path)`                                                                                                                                    |
+| C    | JSON field value (e.g., `verdict=PASS`)   | READ file → compare field                                                                                                                         |
+| D    | `iterations >= N`                         | Find the last entry in `step_history` array where `stage==current_stage AND step==current_step`, compare `.iterations` (linear search, not dict access) |
+
+**When exit condition is met — Step/Stage transition:**
+
+1. Record completion in checkpoint.json `step_history`.
+2. If `step_block.next_step` is missing (field absent or null/empty) → log error in findings.md → request user confirmation → HALT.
+3. If `next_step != "done"` → update checkpoint (`current_step`, `active_pattern`, `handoff_chain: []`) → re-enter top of Step 2 loop (proceed to next Step).
+4. If `next_step == "done"` → GOTO Stage Transition Gate. (Details: `references/stage-step-guide.md` § "Stage Transition Protocol")
+
+**When exit condition is not met:**
+
+1. `iterations < max_iterations` → find entry in `step_history` array where `stage==current_stage AND step==current_step` and increment `.iterations` (add new entry if none exists) → if `active_pattern == "handoff"`, reset checkpoint.json `handoff_chain: []` (new iteration = new chain) → re-enter top of Step 2 loop (re-execute same Step).
+2. Exhausted → log `"Step {current_step}: max_iterations exhausted, exit condition not met"` in findings.md → blocked_protocol. (Details: `references/orchestrator-procedures.md`)
+
+---
+
+### Step 3: Fix Loop (producer_reviewer only)
+
+```
+retries ← 0
+
+WHILE retries < 3:
+    CALL subagent spawn
+    WRITE "_workspace/{plan_name}/{output}_v{retries+1}.md" ← producer result
+
+    CALL subagent spawn
+    READ "_workspace/tasks/task_{reviewer}_{id}.json" → review
+
+    IF review.status == "done":  // PASS
+        apply_patch { tasks.md ← PASS evidence, checkpoint.json ← tasks_snapshot updated }
+        GOTO Step 4
+
+    ELSE:  // FAIL
+        retries += 1
+        IF retries >= 3:
+            UPDATE tasks.md ← task "blocked"
+            request_user_input("Validation failed after 3 attempts. Requesting intervention.")
+            RETURN
+        WRITE findings.md["Change Requests"] ← review.evidence  // Inject feedback and retry
+```
+
+---
+
+### Step 4: Integration and Final Output
+
+1. `GLOB "_workspace/tasks/task_*.json"` → filter files with `status=="done"` → extract `artifact_path` from each → build `artifacts` list.
+2. Check `[Data Conflicts]` section in findings.md → if conflicts exist, call reviewer agent to resolve. If unresolved, request user confirmation → RETURN.
+3. `_workspace/{plan_name}/final_{output}.md` ← save after MERGE of artifacts.
+   > MERGE: Read each agent output in role order and concatenate by section. Format determined by domain (Markdown: connect as `## {agent_name}\n{content}`, JSON: merge keys, code: list of file paths).
+
+---
+
+### Step 5: Archive and Report
+
+1. Copy `findings.md`, `tasks.md` → `_workspace/{plan_name}/` (preserve detailed history).
+2. Replace `findings.md` with summary: keep only `[Final Result Summary]` + `[Archive Path]` sections.
+3. Update `checkpoint.json`: `status:"completed"`, `current_stage/step:"done"`, record completion in `stage_history`.
+4. Report to user:
+
+```
+Completed: {plan_name}
+Output:         _workspace/{plan_name}/final_{output}.md
+Detailed log:   _workspace/{plan_name}/findings.md
+Tasks:          _workspace/{plan_name}/tasks.md
+```
+
+## Data Persistence Protocol (checkpoint.json Schema)
+
+> **Canonical spec.** Other files such as `stage-step-guide.md` reference this schema.
+
+### Field Descriptions
+
+| Field              | Type   | Description                                                                                                                                | Required      |
+| ------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| `execution_id`     | string | Execution ID in `YYYYMMDD_HHMMSS` format.                                                                                                  | **Required**  |
+| `plan_name`        | string | Execution plan identifier.                                                                                                                 | **Required**  |
+| `status`           | string | `"in_progress"` \| `"completed"` \| `"partial"` \| `"blocked"`.                                                                            | **Required**  |
+| `last_updated`     | string | ISO 8601 timestamp.                                                                                                                        | **Required**  |
+| `current_stage`    | string | Name of the currently active stage. **Deliverable kebab-case required** (e.g., `"sso-integration"`); placeholders (`"main"`, etc.) prohibited. | **Required**  |
+| `current_step`     | string | Name of the currently active step. **Deliverable kebab-case required** (e.g., `"requirements-gathering"`); placeholders (`"main"`, `"step1"`, etc.) prohibited. | **Required**  |
+| `active_pattern`   | string | Execution pattern of the current step (e.g., `"pipeline"`).                                                                               | Recommended   |
+| `stage_history`    | array  | Record of completed stages. Includes `started_at` + `completed_at`.                                                                       | Multi-stage   |
+| `step_history`     | array  | Record of completed steps. Includes `iterations`.                                                                                         | Multi-stage   |
+| `stage_artifacts`  | object | Mapping of key artifact paths per stage.                                                                                                   | Optional      |
+| `tasks_snapshot`   | object | Snapshot of task completion status.                                                                                                        | Optional      |
+| `shared_variables` | object | Runtime variables shared across multiple agents.                                                                                           | Optional      |
+| `handoff_chain`    | array  | Order of agents called within the current step when using the Handoff pattern. Used for cycle detection. Reset on step transition.         | Handoff pattern |
+| `blocked_agent`    | string | Name of the blocked agent when Blocked occurs. Recorded only on `status:"blocked"` transition.                                            | When blocked  |
+| `blocked_reason`   | string | Cause of the Blocked state. Displayed to the user on resume.                                                                               | When blocked  |
+
+### Schema Example
+
+```json
+{
+  "execution_id": "20260425_103000",
+  "plan_name": "blog-writing-run-001",
+  "status": "in_progress",
+  "last_updated": "2026-04-25T10:30:00Z",
+
+  "current_stage": "refine",
+  "current_step": "draft-review",
+  "active_pattern": "producer_reviewer",
+
+  "stage_history": [
+    {
+      "stage": "gather",
+      "started_at": "2026-04-25T09:00:00Z",
+      "completed_at": "2026-04-25T10:00:00Z"
+    }
+  ],
+  "step_history": [
+    {
+      "stage": "gather",
+      "step": "research",
+      "completed_at": "2026-04-25T10:00:00Z",
+      "iterations": 1
+    }
+  ],
+
+  "stage_artifacts": {
+    "gather": "_workspace/research/",
+    "refine": "_workspace/draft.md"
+  },
+  "tasks_snapshot": { "done": ["T1", "T2"], "current": "T3" },
+  "shared_variables": { "main_artifact": "_workspace/plan/02_code.md" },
+  "handoff_chain": ["@incident-triage", "@db-fixer"]
+}
+```
+````
+
+## Split Task File Protocol (Split Task Schema)
+
+The `_workspace/tasks/task_{agent}_{id}.json` schema used by sub-agents to report their own status during parallel execution.
+
+```json
+{
+  "agent": "@coder",
+  "task_id": "T2",
+  "status": "done",
+  "retries": 0,
+  "evidence": "Reviewer PASS report: _workspace/plan/03_review.md",
+  "artifact_path": "_workspace/plan/02_code.md"
+}
+```
+
+> `status`: `"done"` | `"blocked"`. Transition to blocked when `retries >= 2` (0 and 1 allowed = 3 total attempts).
+
+## Procedures & Principles
+
+> Error handling (`handle_error` / `blocked_protocol` / `handle_handoff`), test scenarios, description keywords, authoring principles, Stage/Step reference:
+> See **`references/orchestrator-procedures.md`**.

--- a/harness/references/qa-agent-guide.md
+++ b/harness/references/qa-agent-guide.md
@@ -1,0 +1,291 @@
+# QA Agent Design Guide
+
+A guide for including a QA agent in a build harness. Based on bug patterns and root cause analyses discovered in real projects, this guide provides a verification methodology that systematically catches defects that QA tends to miss. This guide assumes a **Codex CLI orchestration environment** (no direct communication between sub-agents; the main agent acts as Data Broker).
+
+---
+
+## Table of Contents
+
+1. Defect Patterns QA Agents Miss
+2. Integration Coherence Verification
+3. QA Agent Design Principles (Orchestration Mode)
+4. Verification Result Reporting Protocol (JSON Protocol)
+5. Verification Checklist Template
+6. QA Agent Definition Template
+7. Appendix: Lessons Learned from Real Cases
+
+---
+
+## 1. Defect Patterns QA Agents Miss
+
+### 1-1. Boundary Mismatch
+
+The most frequent defect. Two components are each implemented "correctly," but the contract breaks at the connection point.
+
+| Boundary | Mismatch Example | Why It Gets Missed |
+|---|---|---|
+| API response → front-end hook | API returns `{ projects: [...] }`, hook expects `SlideProject[]` | Each is validated independently; no cross-comparison |
+| API response field name → type definition | API uses `thumbnailUrl` (camelCase), type uses `thumbnail_url` (snake_case) | TypeScript generic casting causes the compiler to miss it |
+| File path → link href | Page is at `/dashboard/create` but link points to `/create` | File structure and href are not cross-compared |
+| State transition map → actual status update | Map defines `generating_template → template_approved`, but the transition is missing from code | Only checks that the map exists, does not trace the update code |
+| API endpoint → front-end hook | API exists but has no corresponding hook (never called) | API list and hook list are not mapped 1:1 |
+| Immediate response → async result | API immediately returns `{ status }`, front end accesses `data.failedIndices` | Only checks types without distinguishing sync/async responses |
+
+### 1-2. Why Static Code Review Misses These
+
+- **Limits of TypeScript generics:** `fetchJson<SlideProject[]>()` — even if the runtime response is `{ projects: [...] }`, compilation passes.
+- **`npm run build` passing ≠ correct behavior:** With type casting, `any`, or generics, the build can succeed while the runtime fails.
+- **Existence verification vs. connection verification:** "Does the API exist?" and "Does the API response match the caller's expectations?" are completely different verifications.
+- **One-sided code review:** If the reviewer reads only the producer or only the consumer, a contract mismatch will never be visible.
+
+---
+
+## 2. Integration Coherence Verification
+
+**Cross-comparison verification** areas that must be included in the QA agent.
+
+### 2-1. API Response ↔ Front-End Hook Type Cross-Verification
+
+**Method:** Compare the `NextResponse.json()` call site in each API route with the `fetchJson<T>` type parameter of the corresponding hook.
+
+```
+Verification steps:
+1. Extract the shape of the object passed to NextResponse.json() in the API route
+2. Check the T type of fetchJson<T> in the corresponding hook
+3. Compare whether shape and T match
+4. Check for wrapping (if API returns { data: [...] }, does the hook unwrap .data?)
+```
+
+**Patterns to watch especially:**
+- Pagination API `{ items: [], total, page }` vs. front end expecting an array
+- Mismatch between snake_case DB fields → camelCase API response → front-end type definitions
+- Shape difference between immediate response (202 Accepted) vs. final result
+
+### 2-2. File Path ↔ Link/Router Path Mapping
+
+**Method:** Extract URL paths from page files under `src/app/` and compare against all `href`, `router.push()`, and `redirect()` values in the code.
+
+```
+Verification steps:
+1. Extract URL patterns from page.tsx file paths under src/app/
+   - (group) → removed from URL
+   - [param] → dynamic segment
+2. Collect all href=, router.push(, redirect( values in the code
+3. Verify each link matches an actual existing page path
+4. Watch for URL prefix of pages inside route groups (e.g., dashboard/ prefix)
+```
+
+### 2-3. State Transition Completeness Tracking
+
+**Method:** Extract all `status:` updates from the code and compare against the state transition map.
+
+```
+Verification steps:
+1. Extract the list of allowed transitions from the state transition map (STATE_TRANSITIONS)
+2. Search all API routes for .update({ status: "..." }) patterns
+3. Verify each transition is defined in the map
+4. Identify transitions defined in the map but never executed in code (dead transitions)
+5. Check for missing transitions from intermediate states (e.g., generating_template) to final states (template_approved)
+```
+
+### 2-4. API Endpoint ↔ Front-End Hook 1:1 Mapping
+
+**Method:** List all API routes and front-end hooks to verify they pair up correctly.
+
+```
+Verification steps:
+1. Extract a list of HTTP method endpoints from route.ts files under src/app/api/
+2. Extract a list of fetch call URLs from use*.ts files under src/hooks/
+3. Identify API endpoints not called by any hook → flag as "unused"
+4. Determine whether "unused" is intentional (e.g., admin API) or accidental (missing call)
+```
+
+---
+
+## 3. QA Agent Design Principles (Orchestration Mode)
+
+In the Codex CLI environment, direct communication between sub-agents is not possible, so the orchestrator (main agent) handles coordination.
+
+### 3-1. "Provide Both Sides Simultaneously" Principle
+
+For the QA agent to catch boundary bugs, the main agent must **provide context from both sides** when making the call.
+
+- **Method:** Use shell `cat` to read both the API route and the front-end hook, and specify both paths explicitly in the QA agent prompt.
+- **Agent instruction:** Include "You must open both specified files and cross-compare them" in the system prompt.
+
+### 3-2. Grant Execution Permissions, Not Just Read Access
+
+Effective QA goes beyond simply reading files — it requires using shell `grep` to search for patterns and actually running test, lint, and type-check scripts via the shell. The QA agent should be set to `sandbox_mode = "workspace-write"` or higher to obtain shell execution permissions.
+
+**Run long-running processes in the background.** In Codex CLI, background shell execution uses `&` (e.g., `npm run dev &`). Processes that do not terminate — such as dev servers, build watchers, and test daemons — should be launched in the background, and follow-up verifications such as `curl`, Playwright, or API tests should be run in the foreground within the same turn. This avoids foreground blocking while keeping the E2E/integration QA flow uninterrupted.
+
+| Purpose | Execution Mode | Example |
+|---|---|---|
+| Lint, type check, unit tests | **Foreground** (results needed immediately) | `npm run lint`, `tsc --noEmit`, `pytest` |
+| Dev server, API server | **Background** | `npm run dev &`, `python -m uvicorn app:app &` |
+| Build watcher, file watcher | **Background** | `vite build --watch &`, `jest --watch &` |
+| E2E verification after starting the above servers | Background + Foreground combination | Background dev server, foreground `curl`/Playwright |
+
+Note: If the QA agent launched a background process, it must be terminated when done (`kill $PID` or `pkill`) and recorded in the "Cleanup" section of `qa_report.md` to avoid affecting the next QA invocation.
+
+### 3-3. Prioritize "Cross-Comparison" Over "Existence Check" in Checklists
+
+| Weak Checklist | Strong Checklist |
+|---|---|
+| Does the API endpoint exist? | Does the API endpoint's response shape match the corresponding hook's type? |
+| Is the state transition map defined? | Does every status update in code match a transition in the map? |
+| Does the page file exist? | Does every link in the code point to an actually existing page? |
+| Is TypeScript strict mode on? | Is there no type safety bypassed via generic casting? |
+
+### 3-4. Incremental QA
+
+Do not verify everything in a single pass after full completion. Call the QA agent immediately after each module (producer + consumer) is complete to keep the feedback loop short.
+
+- If the orchestrator places QA only at Step 4 (after full completion), bugs accumulate and early boundary mismatches propagate to subsequent modules.
+- **Recommended pattern:** Run cross-verification of each backend API and its corresponding hook immediately after the API is complete.
+
+### 3-5. Report First; Fixes Are Triggered by Orchestrator Re-invocation
+
+In Codex CLI, the QA agent cannot send instructions directly to other agents. Discovered bugs are recorded in `_workspace/qa_report.md`, and **verification results (PASS/FAIL) are recorded in the split task file (`_workspace/tasks/task_{agent}_{id}.json`) to maintain coherence with the orchestrator**. The main agent reads this report and the split file, summarizes findings in `findings.md`, and then re-invokes the implementation agent if needed.
+
+---
+
+## 4. Verification Result Reporting Protocol (JSON Protocol)
+
+The QA agent must produce split task files in the following format to ensure data coherence in a parallel execution environment.
+
+- **File path:** `_workspace/tasks/task_{agent_name}_{task_id}.json`
+- **Reporting schema:**
+    ```json
+    {
+      "agent": "@qa-inspector",
+      "task_id": "T101",
+      "status": "done",        // "done" | "blocked" — base schema field
+      "retries": 0,            // cumulative retry count. switch to blocked when retries ≥ 2 (0·1 allowed = 3 total attempts)
+      "evidence": "E2E test passed. Logs saved at _workspace/qa/log.txt",
+      "artifact_path": "_workspace/qa_report.md",  // follow base schema field name
+      "result": "PASS"         // QA-only extension field. "PASS" | "FAIL" | null (when Blocked)
+    }
+    ```
+
+> **Canonical schema:** For the normative definitions of the `agent·task_id·status·retries·evidence·artifact_path` fields, refer to `references/orchestrator-template.md` § "Split Task File Protocol". The schema above is an application example from the QA agent's perspective; only `result` is a QA-only extension field.
+
+### Zero-Tolerance Retry Protocol
+
+> **The canonical source is `references/orchestrator-procedures.md` — "Error Handling Decision Tree".** The following is an application summary from the QA agent's perspective.
+
+The QA agent does not arbitrarily skip or ignore results on verification failure. Adhere strictly to the following procedure:
+
+1. **Up to 2 retries (3 total):** Identify the cause of failure, change the approach, and retry. Increment `retries` with each retry.
+2. **Still failing after 3 attempts → `blocked`:** Record `status: "blocked"`, `result: null`. Document the failure cause, attempt history, and required information in detail in the "Blocked Items" section of `qa_report.md`.
+3. **Orchestrator escalation:** When the main agent detects `Blocked`, record `status: "blocked"` in `checkpoint.json` and request user confirmation. **Arbitrary skipping is strictly prohibited.** On restart, Step 0 detects the blocked state → displays the reason → waits for instructions.
+
+---
+
+## 5. Verification Checklist Template
+
+A general integration coherence checklist to include in QA agent definitions. The key is to **read both components sharing a boundary simultaneously** and cross-compare for contract compliance. Select only the relevant sections based on the domain.
+
+```markdown
+### Integration Coherence Verification
+
+#### Boundary Contract (Common to All Domains)
+- [ ] Producer output type/format matches Consumer input expectations
+- [ ] Shared constants/enum values are defined identically on both sides
+- [ ] Null/undefined handling of optional fields is consistent on both sides
+- [ ] Async vs. immediate response formats are clearly distinguished on the consumer side
+
+#### Reference Integrity (Common to All Domains)
+- [ ] All paths, identifiers, and links in the code point to actually existing targets
+- [ ] Dynamic parameters/slots are filled with correct values
+
+#### State Transition Completeness (When a State Machine Exists)
+- [ ] All defined state transitions are executed in code (no dead transitions)
+- [ ] All state change code matches transition definitions (no unauthorized transitions)
+- [ ] No missing transitions from intermediate states to final states
+
+#### Data Flow Coherence (Common to All Domains)
+- [ ] Field names and types from sources (DB, file, API) are consistent throughout the entire pipeline
+- [ ] Data transformations (type, case, unit) are handled explicitly
+
+---
+
+#### [Web App] API ↔ Frontend Connection
+- [ ] Response shape of every API route matches the generic type of the corresponding hook
+- [ ] Wrapped responses ({ items: [...] }) are unwrapped in the hook
+- [ ] snake_case ↔ camelCase conversion is applied consistently
+- [ ] Immediate response (202) and final result shape are distinguished on the front end
+- [ ] Every API endpoint has a corresponding front-end hook that is actually called
+
+#### [Web App] Routing Coherence
+- [ ] All href/router.push values in code match actual page file paths
+- [ ] Path validation accounts for route groups ((group)) being removed from the URL
+- [ ] Dynamic segments ([id]) are filled with correct parameters
+```
+
+---
+
+## 6. QA Agent Definition Template
+
+Follows the official Codex CLI sub-agent format.
+
+```toml
+name = "qa-inspector"
+description = "QA verification specialist. Verifies spec compliance, boundary integration coherence, and artifact quality. Always select this agent for quality review, bug inspection, and coherence verification requests."
+model = "gpt-5.3-codex"
+sandbox_mode = "workspace-write"
+model_reasoning_effort = "high"
+
+developer_instructions = """
+# QA Inspector
+
+## Core Role
+Verify artifact quality against specs and **inter-module integration coherence**. Regardless of domain, the core is to read both components sharing a boundary simultaneously and cross-compare for contract compliance.
+
+## Verification Priority
+
+1. **Integration Coherence** (highest) — Boundary mismatches are the primary cause of runtime errors
+2. **Functional Spec Compliance** — Contracts, state machines, data models
+3. **Artifact Quality** — Format, completeness, readability (apply domain-specific standards)
+4. **Internal Consistency** — Unused references, naming conventions, duplication
+
+## Verification Method: "Read Both Sides Simultaneously"
+
+Boundary verification must be done by **opening both the producer and the consumer at the same time** and comparing them.
+
+| Verification Target | Producer (Left) | Consumer (Right) |
+|---|---|---|
+| Data contract | Output format/type definition | Input expectations/parsing logic |
+| Path/reference | Defined paths, identifiers, links | Paths/identifiers used by the caller |
+| State transition | Transition map/definition | Actual state change code |
+| Data flow | Field names/types from source (DB, file, API) | Field names/types at downstream consumers |
+
+> **Web app example:** `route.ts` NextResponse → `fetchJson<T>` hook / `src/app/` page path → `href` value / `STATE_TRANSITIONS` map → `.update({ status })` code
+
+## Collaboration Protocol (Orchestration)
+
+1. Record verification artifacts in `_workspace/qa_report.md`.
+2. In the **"Fix Instructions"** section, specify discovered bugs concisely as `file:line + fix method`.
+3. For boundary issues, list both the producer and consumer paths in the report so both agents can rework if needed.
+4. The main agent (orchestrator) reads this report, summarizes findings in `findings.md`, and re-invokes the implementation agent if needed.
+5. For ambiguous contracts (e.g., "Is this field optional?"), do not guess — confirm by requesting user input.
+"""
+```
+
+---
+
+## 7. Appendix: Lessons Learned from Real Cases
+
+All content in this guide is drawn from lessons extracted from the actual bugs below.
+
+| Bug | Boundary | Cause |
+|---|---|---|
+| `projects?.filter is not a function` | API → hook | API returns `{ projects: [] }`, hook expects an array |
+| All dashboard links return 404 | File path → href | Missing `/dashboard/` prefix |
+| Theme image not displayed | API → component | `thumbnailUrl` vs. `thumbnail_url` |
+| Theme selection not saved | API → hook | select-theme API exists, but no corresponding hook |
+| Create page waits forever | State transition → code | Missing `template_approved` transition code |
+| `data.failedIndices` crash | Immediate response → front end | Accessing background result from the immediate response |
+| 404 after completion viewing slides | File path → href | `/projects/` → `/dashboard/projects/` |
+
+The common thread across all these bugs is that **each side looks correct on its own, but the issue only appears when both sides are examined together**. Therefore, the first principle of QA agent design is "read both sides simultaneously."

--- a/harness/references/schemas/README.md
+++ b/harness/references/schemas/README.md
@@ -7,7 +7,7 @@ Runtime schema definitions (single source of truth). At runtime, orchestrator St
 | File                             | Type                           | Purpose                                                          |
 | -------------------------------- | ------------------------------ | ---------------------------------------------------------------- |
 | `task.schema.json`               | JSON Schema (Draft 7)          | Worker report validation for `_workspace/tasks/task_{agent}_{id}.json` |
-| `checkpoint.schema.json`         | JSON Schema (Draft 7)          | State validation for `_workspace/checkpoint.json`                |
+| `checkpoint.schema.json`         | JSON Schema (Draft 7)          | Validation SoT for `_workspace/checkpoint.json` — parsed by `state.py` at runtime |
 | `findings.template.md`           | Markdown skeleton              | Data broker initialization for `_workspace/findings.md`         |
 | `tasks.template.md`              | Markdown table skeleton        | Task board initialization for `_workspace/tasks.md`             |
 | `workflow.template.md`           | Markdown block skeleton        | Stage-Step declaration reference for `_workspace/workflow.md`   |
@@ -15,16 +15,18 @@ Runtime schema definitions (single source of truth). At runtime, orchestrator St
 | `agent-worker.template.toml`         | Agent TOML template            | Reference for generating worker agent `.codex/agents/{name}.toml` |
 | `agent-orchestrator.template.md`     | Orchestrator SKILL.md template | Reference for generating orchestrator skills                    |
 | `agent-state-manager.template.toml`  | State manager agent TOML template | Reference for generating State Manager `.codex/agents/state-manager.toml` (optional) |
+| `state.py`                           | Python state manager CLI          | Deployed to `_workspace/state.py` at init — targeted reads/writes to minimize token usage |
 
-> Only `README.md` is not copied to the workspace. The remaining 9 files are synchronized to `_workspace/_schemas/` during Step 1 init.
+> Only `README.md` is not copied to the workspace. 9 files go to `_workspace/_schemas/`. `state.py` is deployed separately to `_workspace/state.py` (callable as `python _workspace/state.py`).
 
 ## Lifecycle
 
 1. **Skill init time:** Maintainer edits files in `references/schemas/` (SoT). When model IDs change, update the `model` field in `models.md` + `agent-worker.template.toml`.
-2. **Step 1 of orchestrator (runtime):** Synchronizes 9 files to `_workspace/_schemas/` via shell or `apply_patch`.
+2. **Step 1 of orchestrator (runtime):** Synchronizes 9 files to `_workspace/_schemas/` and deploys `state.py` to `_workspace/state.py`.
 3. **Agent creation (Phase 3):** Main reads `_workspace/_schemas/agent-worker.template.toml`, performs variable substitution, and writes to `.codex/agents/{name}.toml`.
 4. **Worker write time:** worker reads `_workspace/_schemas/task.schema.json` before producing `task_*.json`.
 5. **Main validation time:** main reads `_schemas/*.schema.json` and validates `task_*.json` / `checkpoint.json`.
+6. **State reads/writes:** orchestrator calls `python _workspace/state.py` instead of raw `cat`/`apply_patch` on state files to reduce token usage.
 
 ## Why duplicate into `_workspace/`?
 

--- a/harness/references/schemas/README.md
+++ b/harness/references/schemas/README.md
@@ -1,0 +1,33 @@
+# `_workspace/_schemas/` Source-of-Truth (Codex CLI Version)
+
+Runtime schema definitions (single source of truth). At runtime, orchestrator Step 1 reads each file and writes to `_workspace/_schemas/` via shell commands or `apply_patch`.
+
+## Files
+
+| File                             | Type                           | Purpose                                                          |
+| -------------------------------- | ------------------------------ | ---------------------------------------------------------------- |
+| `task.schema.json`               | JSON Schema (Draft 7)          | Worker report validation for `_workspace/tasks/task_{agent}_{id}.json` |
+| `checkpoint.schema.json`         | JSON Schema (Draft 7)          | State validation for `_workspace/checkpoint.json`                |
+| `findings.template.md`           | Markdown skeleton              | Data broker initialization for `_workspace/findings.md`         |
+| `tasks.template.md`              | Markdown table skeleton        | Task board initialization for `_workspace/tasks.md`             |
+| `workflow.template.md`           | Markdown block skeleton        | Stage-Step declaration reference for `_workspace/workflow.md`   |
+| `models.md`                      | Model ID registry (SoT)        | Authoritative OpenAI model IDs for agent creation               |
+| `agent-worker.template.toml`         | Agent TOML template            | Reference for generating worker agent `.codex/agents/{name}.toml` |
+| `agent-orchestrator.template.md`     | Orchestrator SKILL.md template | Reference for generating orchestrator skills                    |
+| `agent-state-manager.template.toml`  | State manager agent TOML template | Reference for generating State Manager `.codex/agents/state-manager.toml` (optional) |
+
+> Only `README.md` is not copied to the workspace. The remaining 9 files are synchronized to `_workspace/_schemas/` during Step 1 init.
+
+## Lifecycle
+
+1. **Skill init time:** Maintainer edits files in `references/schemas/` (SoT). When model IDs change, update the `model` field in `models.md` + `agent-worker.template.toml`.
+2. **Step 1 of orchestrator (runtime):** Synchronizes 9 files to `_workspace/_schemas/` via shell or `apply_patch`.
+3. **Agent creation (Phase 3):** Main reads `_workspace/_schemas/agent-worker.template.toml`, performs variable substitution, and writes to `.codex/agents/{name}.toml`.
+4. **Worker write time:** worker reads `_workspace/_schemas/task.schema.json` before producing `task_*.json`.
+5. **Main validation time:** main reads `_schemas/*.schema.json` and validates `task_*.json` / `checkpoint.json`.
+
+## Why duplicate into `_workspace/`?
+
+- **Self-contained workspace:** Resume / handoff / forensic review only needs `_workspace/`.
+- **Drift detection:** snapshots the schema version active at init.
+- **Worker isolation:** workers access `_workspace/` only.

--- a/harness/references/schemas/agent-orchestrator.template.md
+++ b/harness/references/schemas/agent-orchestrator.template.md
@@ -1,5 +1,5 @@
 <!--
-ORCHESTRATOR AGENT TEMPLATE — After variable substitution, save as `.agents/skills/{harness-name}/SKILL.md`.
+ORCHESTRATOR AGENT TEMPLATE — After variable substitution, save as `.codex/skills/{harness-name}/SKILL.md`.
 The orchestrator is generated as a skill SKILL.md, not as an agent .md file.
 Model ID SoT: references/schemas/models.md (always check models.md first before making changes)
 
@@ -49,7 +49,7 @@ Apply `references/orchestrator-template.md` Step 0 procedure. Branch based on `_
    {{STAGE_STEP_SUMMARY}}
 4. Initialize `findings.md` (based on `_workspace/_schemas/findings.template.md`).
 5. Initialize `tasks.md` (based on `_workspace/_schemas/tasks.template.md`).
-6. Create `checkpoint.json` (must conform to `_workspace/_schemas/checkpoint.schema.json` schema):
+6. Create `checkpoint.json` (validated against `_workspace/_schemas/checkpoint.schema.json` by `python _workspace/state.py` on write):
    ```json
    {
      "plan_name": "{{PLAN_NAME}}",

--- a/harness/references/schemas/agent-orchestrator.template.md
+++ b/harness/references/schemas/agent-orchestrator.template.md
@@ -1,0 +1,99 @@
+<!--
+ORCHESTRATOR AGENT TEMPLATE — After variable substitution, save as `.agents/skills/{harness-name}/SKILL.md`.
+The orchestrator is generated as a skill SKILL.md, not as an agent .md file.
+Model ID SoT: references/schemas/models.md (always check models.md first before making changes)
+
+Substitution variables:
+  {{SKILL_NAME}}        kebab-case skill name (e.g. sso-dev-flow)
+  {{DESCRIPTION}}       pushy description + trigger keywords + follow-up action keywords
+  {{PLAN_NAME}}         subdirectory name under _workspace (e.g. sso)
+  {{AGENT_TABLE}}       virtual team table rows (repeated)
+  {{STAGE_STEP_SUMMARY}} workflow.md Stage/Step structure summary
+
+Only the orchestrator can spawn subagents — worker agents are prohibited from doing so.
+Model uses the thinking tier (responsible for complex reasoning and multi-step coordination).
+-->
+
+---
+
+name: {{SKILL_NAME}}
+description: "{{DESCRIPTION}}. Always use this skill for follow-up work (modifications/enhancements/re-runs)."
+
+---
+
+# Skill: {{SKILL_NAME}} Orchestrator
+
+## Virtual Team
+
+| Agent           | Type                   | Role   | Skill   | Output |
+| --------------- | ---------------------- | ------ | ------- | ------ |
+| {{AGENT_TABLE}} |
+
+> Orchestrator model: `gpt-5.5` (responsible for design and reasoning). Verify model ID in: `references/schemas/models.md`
+
+## Workflow
+
+### Step 0: Context Check (Durable Execution)
+
+Apply `references/orchestrator-template.md` Step 0 procedure. Branch based on `_workspace/checkpoint.json` status:
+
+- `in_progress` → Resume (continue from current stage/step)
+- `completed` → Confirm with user: partial re-run or fresh run
+- Not present → Fresh run (proceed to Step 1)
+
+### Step 1: Initialization
+
+1. Create directories: `_workspace/{{PLAN_NAME}}/`, `_workspace/tasks/`, `_workspace/_schemas/`.
+2. **Schema synchronization** — Copy 5 schema files + 3 agent templates from `references/schemas/` to `_workspace/_schemas/` via shell `cat` → `apply_patch` (see `references/orchestrator-template.md` Step 1.3).
+3. Write `workflow.md` (variable substitution from `_workspace/_schemas/workflow.template.md`):
+   {{STAGE_STEP_SUMMARY}}
+4. Initialize `findings.md` (based on `_workspace/_schemas/findings.template.md`).
+5. Initialize `tasks.md` (based on `_workspace/_schemas/tasks.template.md`).
+6. Create `checkpoint.json` (must conform to `_workspace/_schemas/checkpoint.schema.json` schema):
+   ```json
+   {
+     "plan_name": "{{PLAN_NAME}}",
+     "status": "in_progress",
+     "current_stage": "{first Stage name}",
+     "current_step": "{first Step name}",
+     "active_pattern": "{first Step pattern}"
+   }
+   ```
+7. **workflow.md schema validation** — 6 required fields + naming convention (no placeholders) + verifiable exit conditions + pattern enum. Violations cause HALT (see `references/orchestrator-template.md` Step 1.8).
+8. **workflow.md cycle validation** (after passing schema validation).
+
+### Step 2: Step Execution Loop
+
+Apply `references/orchestrator-template.md` Step 2 standard procedure. Invoke agents per pattern, check exit conditions, handle Stage gates, update checkpoint.json.
+
+## Error Handling
+
+Zero-Tolerance: agent failure → up to 2 retries (3 total) → if unresolved, set `task_*.json` status=blocked and request user confirmation. Arbitrary skipping is strictly prohibited.
+
+## Test Scenarios
+
+> Required: at least **1 normal flow + 1 resume flow + 1 error flow**. Step 5 validation cannot pass without all three. Full scenario spec: `references/skill-testing-guide.md` § Orchestrator Test Scenarios.
+
+### Normal Flow
+
+1. User provides `{input}`.
+2. Step 0: `_workspace/` absent → fresh run.
+3. Step 1: Create `workflow.md` · `findings.md` · `tasks.md` · `checkpoint.json`. Stage/Step names follow Jira kebab-case convention (no placeholders like `main`).
+4. Step 2: Invoke agents per workflow.md order (e.g., @{agent-1} → @{agent-2}).
+5. Step 3+: QA / integration / reporting per workflow.md.
+6. **Expected:** `_workspace/{{PLAN_NAME}}/final_{output}` exists, all `tasks.md` items `Done`.
+
+### Resume Flow
+
+1. @{agent-1} completes; session interrupted before @{agent-2} finishes.
+2. User re-invokes → Step 0 detects `checkpoint.json` (`status: in_progress`).
+3. Restore `current_stage` / `current_step` → skip completed work, resume from @{agent-2}.
+4. **Expected:** @{agent-1} output reused as-is; only @{agent-2} and later steps re-execute.
+
+### Error Flow
+
+1. Step 3: @{reviewer} rejects @{agent-2}'s output.
+2. Rejection reason recorded in `findings.md` [Change Requests].
+3. @{agent-2} re-invoked with reviewer report injected → produces corrected output.
+4. @{reviewer} re-validates → passes → proceed to next step.
+5. **Expected:** Final report explicitly notes "Error recovery: @{agent-2} revised after @{reviewer} rejection".

--- a/harness/references/schemas/agent-state-manager.template.toml
+++ b/harness/references/schemas/agent-state-manager.template.toml
@@ -1,0 +1,111 @@
+# STATE MANAGER AGENT TEMPLATE — After variable substitution, save as `.codex/agents/state-manager.toml`.
+# Model: gpt-5.4-mini (lightweight, dedicated CRUD only). Called by orchestrator via subagent spawn.
+# Schema SoT: _workspace/_schemas/ (use the copy synchronized in Step 1.3).
+#
+# Substitution variables:
+#   {{PLAN_NAME}}   subdirectory name under _workspace (e.g. sso)
+
+name = "state-manager"
+description = "Dedicated CRUD agent for workspace state files (checkpoint.json, task_*.json, findings.md, tasks.md). Called by orchestrator via OPERATION commands. Validates against schema before atomic writes."
+
+model = "gpt-5.4-mini"
+sandbox_mode = "workspace-write"
+model_reasoning_effort = "low"
+
+developer_instructions = """
+Dedicated CRUD agent for workspace state files. Handles only orchestrator subagent spawn calls. Never request user confirmation — return `ERROR:` prefix when input is unclear.
+
+## Supported OPERATIONs
+
+The orchestrator calls with the following format:
+
+```
+OPERATION: <op>
+PAYLOAD:
+<json or markdown>
+```
+
+| OPERATION           | Target File                                  | Action                                                                 |
+| ------------------- | -------------------------------------------- | ---------------------------------------------------------------------- |
+| `state.init`        | checkpoint.json, findings.md, tasks.md       | Create files with initial values from PAYLOAD                          |
+| `checkpoint.update` | _workspace/checkpoint.json                   | Update only the specified PAYLOAD fields (preserve the rest)           |
+| `task.upsert`       | _workspace/tasks/task_{agent}_{id}.json      | Create if not exists, update if exists                                 |
+| `findings.append`   | _workspace/findings.md                       | Append PAYLOAD section under the matching header                       |
+| `tasks.update`      | _workspace/tasks.md                          | Update the status and evidence of the row matching PAYLOAD's ID        |
+| `state.archive`     | findings.md, tasks.md                        | Copy to `_workspace/{{PLAN_NAME}}/`, then replace findings.md with a summary |
+
+## Operating Principles
+
+1. Always read the schema file via shell `cat _workspace/_schemas/` before writing.
+   - `task.upsert` → validate against `task.schema.json`
+   - `checkpoint.update` → validate against `checkpoint.schema.json`
+2. `checkpoint.update`: read file via shell `cat` → merge fields → update `last_updated` → write via `apply_patch`.
+3. `task.upsert`: enforce `status` enum in lowercase (`todo|in-progress|done|blocked`).
+4. `findings.append`: if the target section header does not exist, append a new section at end of file.
+5. Validation failure or missing required field → abort write, return `ERROR: {reason}`.
+
+## File I/O
+
+- **Read:** shell `cat <path>`
+- **Write:** `apply_patch` (surgical modification principle, never overwrite entire file)
+- **New file:** shell `tee` or `apply_patch` new-file creation mode
+
+## Input/Output Protocol
+
+- **Input:** `OPERATION` + `PAYLOAD` block from orchestrator prompt.
+- **Output:** `OK: {op} {target_file}` or `ERROR: {reason}`.
+- No explanations beyond the output. Single-line responses only.
+
+## Call Examples
+
+### checkpoint.update
+
+```
+OPERATION: checkpoint.update
+PAYLOAD:
+{
+  "current_stage": "develop-review",
+  "current_step": "loop",
+  "active_pattern": "producer_reviewer",
+  "last_updated": "20260427_150000"
+}
+```
+
+### task.upsert
+
+```
+OPERATION: task.upsert
+PAYLOAD:
+{
+  "id": "task_go-developer_001",
+  "agent": "go-developer",
+  "stage": "develop-review",
+  "step": "loop",
+  "status": "done",
+  "evidence": "Confirmed _workspace/sso/auth.go created",
+  "artifact": "src/auth/auth.go",
+  "timestamp": "20260427_150000",
+  "iterations": 1
+}
+```
+
+### findings.append
+
+```
+OPERATION: findings.append
+PAYLOAD:
+## [Change Requests]
+- auth.go: Use `<` instead of `<=` for JWT expiry check → needs fix
+```
+
+### state.archive
+
+```
+OPERATION: state.archive
+PAYLOAD:
+{
+  "plan_name": "{{PLAN_NAME}}",
+  "summary": "SSO authentication implementation complete. qa_verdict=PASS (2nd attempt)."
+}
+```
+"""

--- a/harness/references/schemas/agent-state-manager.template.toml
+++ b/harness/references/schemas/agent-state-manager.template.toml
@@ -36,19 +36,30 @@ PAYLOAD:
 
 ## Operating Principles
 
-1. Always read the schema file via shell `cat _workspace/_schemas/` before writing.
-   - `task.upsert` → validate against `task.schema.json`
-   - `checkpoint.update` → validate against `checkpoint.schema.json`
-2. `checkpoint.update`: read file via shell `cat` → merge fields → update `last_updated` → write via `apply_patch`.
-3. `task.upsert`: enforce `status` enum in lowercase (`todo|in-progress|done|blocked`).
-4. `findings.append`: if the target section header does not exist, append a new section at end of file.
-5. Validation failure or missing required field → abort write, return `ERROR: {reason}`.
+1. Always validate before writing — `python _workspace/state.py` enforces all rules automatically.
+   - `task.upsert` → validates inline (required fields, status enum, id/agent pattern, iterations≥1)
+   - `checkpoint.update` → validates against `_workspace/_schemas/checkpoint.schema.json` (parsed at runtime by state.py)
+2. `task.upsert`: enforce `status` enum in lowercase (`todo|in-progress|done|blocked`).
+3. `findings.append`: if the target section header does not exist, a new section is created automatically.
+4. Validation failure or missing required field → abort write, return `ERROR: {reason}`.
 
 ## File I/O
 
-- **Read:** shell `cat <path>`
-- **Write:** `apply_patch` (surgical modification principle, never overwrite entire file)
-- **New file:** shell `tee` or `apply_patch` new-file creation mode
+Use `python _workspace/state.py` for all state file operations — targeted reads/writes minimize token usage.
+
+| Operation target              | Command                                                                                   |
+| ----------------------------- | ----------------------------------------------------------------------------------------- |
+| Read checkpoint field         | `python _workspace/state.py checkpoint get --field <KEY>`                                 |
+| Update checkpoint field       | `python _workspace/state.py checkpoint update --field <KEY> --value <VAL>`               |
+| Append to findings section    | `python _workspace/state.py findings append --section <NAME> --text <TEXT>`              |
+| Read findings section         | `python _workspace/state.py findings get --section <NAME>`                               |
+| Update task row in tasks.md   | `python _workspace/state.py tasks update --id <ID> --status <S> [--evidence E]`          |
+| Collect task_*.json → tasks.md | `python _workspace/state.py tasks collect`                                               |
+
+Fallback to `apply_patch` only when:
+- Writing a new `_workspace/tasks/task_{agent}_{id}.json` file (`task.upsert` — state.py does not create individual task files)
+- `state.init` initial file creation from templates
+- `state.archive` file copy operations
 
 ## Input/Output Protocol
 

--- a/harness/references/schemas/agent-worker.template.toml
+++ b/harness/references/schemas/agent-worker.template.toml
@@ -1,0 +1,68 @@
+# WORKER AGENT TEMPLATE — After variable substitution, save as `.codex/agents/{name}.toml`.
+# Model ID SoT: references/schemas/models.md
+#
+# Substitution variables:
+#   {{AGENT_NAME}}       kebab-case agent name (e.g. backend-coder)
+#   {{DESCRIPTION}}      1-2 sentence description used by Codex for automatic routing
+#   {{ROLE_SUMMARY}}     One-line role summary
+#   {{DOMAIN}}           Responsible domain / area of expertise
+#   {{OUTPUT_PATH}}      _workspace/{plan_name}/{step}/{agent}-result.md or task_*.json
+#   {{OUTPUT_FORMAT}}    Output format (JSON, Markdown, code file, etc.)
+#   {{SANDBOX_MODE}}     Choose by role:
+#                          read-only         → Analyst / Architect / Planner (read and research only)
+#                          workspace-write   → Coder / Reviewer / QA / State Manager (file writes and tests)
+#                          danger-full-access → Operator / Deployer (external process execution)
+#   {{MODEL}}            See models.md
+#   {{REASONING_EFFORT}} Choose by complexity:
+#                          low          → State Manager / simple CRUD
+#                          medium       → Analyst / Researcher (research and documentation)
+#                          high         → Coder / Reviewer / QA (complex implementation and debugging)
+#                          xhigh   → Orchestrator / Architect (multi-step reasoning and planning)
+
+name = "{{AGENT_NAME}}"
+description = "{{DESCRIPTION}}. Always use this agent for follow-up work (modifications/enhancements/re-runs)."
+
+model = "{{MODEL}}"
+sandbox_mode = "{{SANDBOX_MODE}}"
+model_reasoning_effort = "{{REASONING_EFFORT}}"
+
+developer_instructions = """
+You are an expert in {{DOMAIN}}. {{ROLE_SUMMARY}}
+
+## Core Responsibilities
+
+1. (Responsibility 1)
+2. (Responsibility 2)
+3. (Responsibility 3)
+
+## Operating Principles
+
+- Do not guess. If required information is missing, stop and report clearly to the orchestrator.
+- Record output at the specified path ({{OUTPUT_PATH}}) exactly.
+- After completion, output `[DONE: {{AGENT_NAME}}]`.
+
+## Input/Output Protocol
+
+- **Input:** `_workspace/findings.md` summary + assigned task information injected into the prompt by the orchestrator.
+- **Output path:** {{OUTPUT_PATH}}
+- **Format:** {{OUTPUT_FORMAT}}
+- **Completion signal:** Output `[DONE: {{AGENT_NAME}}]` after recording the output.
+
+## Collaboration Protocol (Codex CLI)
+
+- No direct communication between subagents. The orchestrator mediates via `findings.md` and `tasks.md`.
+- Read `_workspace/_schemas/task.schema.json` before writing a task file; conform to the schema.
+- Enforce status enum in lowercase: `todo | in-progress | done | blocked`.
+- If another agent's output is needed, the orchestrator injects the path into the prompt — do not search directly.
+
+## File I/O
+
+- **Read:** `cat _workspace/findings.md` or read files directly.
+- **Write:** Use `apply_patch` (surgical modification principle, never overwrite entire file).
+- **New file:** shell `tee` or `apply_patch` new-file creation mode.
+
+## Error Handling
+
+- Missing required input → stop task + report detailed log to orchestrator.
+- Retry limit reached (2 retries) → report as blocked. Arbitrary skipping is strictly prohibited.
+"""

--- a/harness/references/schemas/checkpoint.schema.json
+++ b/harness/references/schemas/checkpoint.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://harness/schemas/checkpoint.schema.json",
+  "$id": "https://codex-harness/schemas/checkpoint.schema.json",
   "title": "checkpoint.json",
   "description": "Durable execution state. Main agent sole writer.",
   "type": "object",

--- a/harness/references/schemas/checkpoint.schema.json
+++ b/harness/references/schemas/checkpoint.schema.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://harness/schemas/checkpoint.schema.json",
+  "title": "checkpoint.json",
+  "description": "Durable execution state. Main agent sole writer.",
+  "type": "object",
+  "required": [
+    "execution_id",
+    "plan_name",
+    "status",
+    "current_stage",
+    "current_step",
+    "active_pattern",
+    "stage_history",
+    "step_history",
+    "stage_artifacts",
+    "handoff_chain",
+    "tasks_snapshot",
+    "shared_variables",
+    "last_updated"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "execution_id": {
+      "type": "string",
+      "pattern": "^[0-9]{8}_[0-9]{6}$",
+      "description": "Initial creation timestamp. Immutable."
+    },
+    "plan_name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "User-supplied or parsed work name. Used for _workspace/{plan_name}/ subdir."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["in_progress", "partial", "blocked", "completed"],
+      "description": "in_progress = normal run; partial = post-completion patch; blocked = waiting on user; completed = done."
+    },
+    "current_stage": {
+      "type": "string",
+      "description": "Stage name parsed from workflow.md '### Stage N: {name}' header."
+    },
+    "current_step": {
+      "type": "string",
+      "description": "Step name parsed from workflow.md '#### Step N: {name}' header. ≡ Task."
+    },
+    "active_pattern": {
+      "type": "string",
+      "enum": [
+        "pipeline",
+        "fan_out_fan_in",
+        "expert_pool",
+        "producer_reviewer",
+        "supervisor",
+        "hierarchical",
+        "handoff"
+      ],
+      "description": "Pattern of current_step. Drives invocation strategy in Step 2."
+    },
+    "stage_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["stage", "completed_at"],
+        "properties": {
+          "stage": { "type": "string" },
+          "completed_at": {
+            "type": "string",
+            "pattern": "^[0-9]{8}_[0-9]{6}$"
+          },
+          "user_approved": { "type": "boolean" }
+        }
+      },
+      "description": "Append-only log of completed Stages."
+    },
+    "step_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["stage", "step", "iterations", "completed_at"],
+        "properties": {
+          "stage": { "type": "string" },
+          "step": { "type": "string" },
+          "iterations": { "type": "integer", "minimum": 1 },
+          "completed_at": { "type": "string", "pattern": "^[0-9]{8}_[0-9]{6}$" }
+        }
+      },
+      "description": "Append-only log of completed Steps with iteration count (loop pattern check)."
+    },
+    "stage_artifacts": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      "description": "Map: stage_name → list of artifact file paths produced."
+    },
+    "handoff_chain": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Active handoff sequence (handoff pattern only). Reset to [] on stage transition or step completion."
+    },
+    "tasks_snapshot": {
+      "type": "object",
+      "required": ["done", "current"],
+      "properties": {
+        "done": { "type": "array", "items": { "type": "string" } },
+        "current": { "type": ["string", "null"] }
+      },
+      "description": "Cached list of done task ids and currently-active task id."
+    },
+    "shared_variables": {
+      "type": "object",
+      "description": "Runtime symbolic placeholder values. Example: {selected_expert: '@bug-analyst'} for expert_pool resolution."
+    },
+    "blocked_reason": {
+      "type": "string",
+      "description": "Required when status=blocked. Surface to user via user confirmation request."
+    },
+    "blocked_agent": {
+      "type": "string",
+      "pattern": "^@[a-zA-Z0-9_-]+$",
+      "description": "Required when status=blocked. Identifies which task_*.json files to clear on resume."
+    },
+    "last_updated": {
+      "type": "string",
+      "pattern": "^[0-9]{8}_[0-9]{6}$",
+      "description": "Refreshed on every checkpoint write."
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "status": { "const": "blocked" } } },
+      "then": { "required": ["blocked_reason", "blocked_agent"] }
+    }
+  ]
+}

--- a/harness/references/schemas/checkpoint.schema.json
+++ b/harness/references/schemas/checkpoint.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://codex-harness/schemas/checkpoint.schema.json",
+  "$id": "https://harness/schemas/checkpoint.schema.json",
   "title": "checkpoint.json",
   "description": "Durable execution state. Main agent sole writer.",
   "type": "object",

--- a/harness/references/schemas/findings.template.md
+++ b/harness/references/schemas/findings.template.md
@@ -1,0 +1,40 @@
+# Findings: {plan_name}
+
+<!--
+findings.md schema — Main agent sole writer. All workers read via prompt injection.
+Init: include only sections required by the active patterns (see table below).
+Do NOT invent custom section names. Pattern → section mapping is fixed.
+
+| Pattern                  | Required sections (in addition to [Shared Variables/Paths])               |
+|--------------------------|---------------------------------------------------------------------------|
+| pipeline / hierarchical  | [Next Step Instructions]                                                  |
+| fan_out / fan_out_fan_in | [Key Insights], [Key Keywords], [Data Conflicts]                          |
+| producer_reviewer        | [Change Requests]                                                         |
+| supervisor / handoff     | [Data Conflicts]                                                          |
+| expert_pool              | [Routing Rationale]  (format: "- {agent}: {reason} (matching: {keyword})")|
+
+All patterns share: [Shared Variables/Paths].
+-->
+
+## [Shared Variables/Paths]
+<!-- Required for all patterns. Workspace paths, API contracts, persistence resume points. -->
+- Working directory:
+- Output paths:
+
+## [Key Insights]
+<!-- fan_out / fan_out_fan_in only. Worker outputs synthesized by main. -->
+
+## [Key Keywords]
+<!-- fan_out / fan_out_fan_in only. Common keywords injected into worker prompts. -->
+
+## [Data Conflicts]
+<!-- fan_out / supervisor / handoff. Conflicting outputs with sources cited. Never delete a side. -->
+
+## [Change Requests]
+<!-- producer_reviewer only. Reviewer's REJECT feedback for next producer iteration. -->
+
+## [Next Step Instructions]
+<!-- pipeline / hierarchical only. Hand-off guidance to next agent. -->
+
+## [Routing Rationale]
+<!-- expert_pool only. Format: "- @agent-name: {reason} (matching: {keyword})" -->

--- a/harness/references/schemas/models.md
+++ b/harness/references/schemas/models.md
@@ -1,0 +1,31 @@
+# OpenAI Model ID Registry (SoT)
+
+**Single authoritative source of model IDs** referenced by Codex agent templates. Updating only this file propagates changes to all templates.
+
+## Model Assignment by Role
+
+| Role Tier                                          | Model ID       | Notes                                                        |
+| -------------------------------------------------- | -------------- | ------------------------------------------------------------ |
+| Orchestrator, Architect (complex reasoning/design) | `gpt-5.5`      | 256K ctx, deep reasoning, research, multi-step planning      |
+| Worker (Coder, Analyst, Reviewer, Operator)        | `gpt-5.5`      | 1M ctx, large codebase, refactoring, 80% SWE-Bench           |
+| State Manager (dedicated CRUD)                     | `gpt-5.4-mini` | 400K ctx, fast and low-cost ($0.30/1M) — simple file read/write only |
+
+> Warning: Hard-coding an incorrect model ID in an agent TOML will cause a runtime error.
+
+## model_reasoning_effort Selection Criteria
+
+| Value    | Suitable Agents         | Characteristics                                      |
+| -------- | ----------------------- | ---------------------------------------------------- |
+| `low`    | State Manager           | Simple CRUD, speed and cost priority                 |
+| `medium` | Analyst, Researcher     | Research and documentation, sufficient reasoning     |
+| `high`   | Coder, Reviewer, QA     | Complex implementation and debugging                 |
+| `xhigh`  | Orchestrator, Architect | Multi-step agent reasoning and planning (highest cost) |
+
+## Update Protocol
+
+When a new model is released, update only this file:
+
+1. Modify model IDs in the table above (add a new model row or replace an existing ID).
+2. Apply the same change to the `model` field in `references/schemas/agent-worker.template.toml`.
+3. All agents subsequently created by the harness will use the new ID.
+4. **Existing generated agents require manual updates** (edit `.codex/agents/*.toml` directly).

--- a/harness/references/schemas/state.py
+++ b/harness/references/schemas/state.py
@@ -1,0 +1,572 @@
+#!/usr/bin/env python3
+"""Harness state manager — targeted reads/writes to avoid full-file cat.
+
+Usage (run from project root):
+  python _workspace/state.py checkpoint get [--field KEY]
+  python _workspace/state.py checkpoint update --field KEY --value VALUE
+  python _workspace/state.py checkpoint status
+  python _workspace/state.py checkpoint append-stage --stage NAME [--completed-at TS] [--user-approved]
+  python _workspace/state.py checkpoint append-step  --stage NAME --step NAME --iterations N [--completed-at TS]
+
+  python _workspace/state.py tasks list [--status todo|in-progress|done|blocked]
+  python _workspace/state.py tasks update --id ID --status STATUS [--evidence TEXT] [--output PATH]
+  python _workspace/state.py tasks collect
+
+  python _workspace/state.py findings get [--section SECTION]
+  python _workspace/state.py findings append --section SECTION --text TEXT
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = Path(__file__).parent
+CHECKPOINT = WORKSPACE / "checkpoint.json"
+TASKS_MD = WORKSPACE / "tasks.md"
+FINDINGS_MD = WORKSPACE / "findings.md"
+TASK_GLOB = str(WORKSPACE / "tasks" / "task_*.json")
+_CHECKPOINT_SCHEMA = WORKSPACE / "_schemas" / "checkpoint.schema.json"
+_TASK_SCHEMA      = WORKSPACE / "_schemas" / "task.schema.json"
+
+_HISTORY_FIELDS = frozenset({"stage_history", "step_history"})
+_TS_RE  = re.compile(r"^\d{8}_\d{6}$")
+_TS_PAT = "^[0-9]{8}_[0-9]{6}$"
+
+_CP_RULES: "dict | None" = None
+_TP_RULES: "dict | None" = None
+
+
+def _allof_conditionals(schema: dict) -> list:
+    """Parse allOf if/then blocks → list of (field, const_value, frozenset(required))."""
+    result = []
+    for clause in schema.get("allOf", []):
+        then_req = frozenset(clause.get("then", {}).get("required", []))
+        for field, constraint in clause.get("if", {}).get("properties", {}).items():
+            if "const" in constraint:
+                result.append((field, constraint["const"], then_req))
+    return result
+
+
+def _parse_cp_schema() -> dict:
+    if not _CHECKPOINT_SCHEMA.exists():
+        sys.exit(f"ERROR: schema not found: {_CHECKPOINT_SCHEMA}\nRun Step 1 (schema sync) first.")
+    s = json.loads(_CHECKPOINT_SCHEMA.read_text())
+    props = s.get("properties", {})
+
+    def _ts(p: dict) -> frozenset:
+        return frozenset(k for k, v in p.items() if v.get("pattern") == _TS_PAT)
+
+    def _compiled_patterns(p: dict) -> dict:
+        return {k: re.compile(v["pattern"]) for k, v in p.items()
+                if "pattern" in v and v["pattern"] != _TS_PAT}
+
+    sh = props.get("stage_history", {}).get("items", {})
+    ph = props.get("step_history", {}).get("items", {})
+    ph_props = ph.get("properties", {})
+    ph_int = frozenset(k for k, v in ph_props.items() if "minimum" in v)
+
+    return {
+        "required":      frozenset(s.get("required", [])),
+        "allowed":       frozenset(props.keys()),
+        "status_enum":   frozenset(props.get("status", {}).get("enum", [])),
+        "pattern_enum":  frozenset(props.get("active_pattern", {}).get("enum", [])),
+        "ts_top":        _ts(props),
+        "pattern_top":   _compiled_patterns(props),
+        "obj_top":       frozenset(k for k, v in props.items() if v.get("type") == "object"),
+        "str_arr_top":   frozenset(k for k, v in props.items()
+                             if v.get("type") == "array"
+                             and v.get("items", {}).get("type") == "string"),
+        "plan_minlen":   props.get("plan_name", {}).get("minLength", 1),
+        "sh_str_req":    frozenset(sh.get("required", [])) - _ts(sh.get("properties", {})),
+        "sh_ts":         _ts(sh.get("properties", {})),
+        "ph_str_req":    frozenset(ph.get("required", [])) - _ts(ph_props) - ph_int,
+        "ph_ts":         _ts(ph_props),
+        "ph_int_min":    {k: ph_props[k]["minimum"] for k in ph_int},
+        "snap_required": frozenset(props.get("tasks_snapshot", {}).get("required", [])),
+        "conditionals":  _allof_conditionals(s),
+    }
+
+
+def _parse_task_schema() -> dict:
+    if not _TASK_SCHEMA.exists():
+        sys.exit(f"ERROR: schema not found: {_TASK_SCHEMA}\nRun Step 1 (schema sync) first.")
+    s = json.loads(_TASK_SCHEMA.read_text())
+    props = s.get("properties", {})
+    return {
+        "required":       frozenset(s.get("required", [])),
+        "allowed":        frozenset(props.keys()),
+        "status_enum":    frozenset(props.get("status", {}).get("enum", [])),
+        "ts_fields":      frozenset(k for k, v in props.items() if v.get("pattern") == _TS_PAT),
+        "pattern_fields": {k: re.compile(v["pattern"]) for k, v in props.items()
+                           if "pattern" in v and v["pattern"] != _TS_PAT},
+        "int_min":        {k: v["minimum"] for k, v in props.items() if "minimum" in v},
+        "str_min":        {k: v["minLength"] for k, v in props.items() if "minLength" in v},
+        "conditionals":   _allof_conditionals(s),
+    }
+
+
+def _cp_rules() -> dict:
+    global _CP_RULES
+    if _CP_RULES is None:
+        _CP_RULES = _parse_cp_schema()
+    return _CP_RULES
+
+
+def _tp_rules() -> dict:
+    global _TP_RULES
+    if _TP_RULES is None:
+        _TP_RULES = _parse_task_schema()
+    return _TP_RULES
+
+
+# ── validators ────────────────────────────────────────────────────────────────
+
+def _errors_checkpoint(data: dict) -> list[str]:
+    r = _cp_rules()
+    errs: list[str] = []
+
+    extra = data.keys() - r["allowed"]
+    if extra:
+        errs.append(f"extra fields not allowed: {sorted(extra)}")
+    missing = r["required"] - data.keys()
+    if missing:
+        errs.append(f"missing required fields: {sorted(missing)}")
+    plan = data.get("plan_name")
+    if plan is not None and (not isinstance(plan, str) or len(plan) < r["plan_minlen"]):
+        errs.append("plan_name must be a non-empty string")
+    if "status" in data and r["status_enum"] and data["status"] not in r["status_enum"]:
+        errs.append(f"status '{data['status']}' not in {sorted(r['status_enum'])}")
+    if "active_pattern" in data and r["pattern_enum"] and data["active_pattern"] not in r["pattern_enum"]:
+        errs.append(f"active_pattern '{data['active_pattern']}' not in {sorted(r['pattern_enum'])}")
+    for f in r["ts_top"]:
+        if f in data and not _TS_RE.match(str(data[f])):
+            errs.append(f"{f} must match YYYYMMDD_HHMMSS, got '{data[f]}'")
+    for f, pat_re in r["pattern_top"].items():
+        if f in data and not pat_re.match(str(data[f])):
+            errs.append(f"{f} must match pattern, got '{data[f]}'")
+    for f in r["obj_top"]:
+        if f in data and not isinstance(data[f], dict):
+            errs.append(f"{f} must be an object")
+    for f in r["str_arr_top"]:
+        if f in data:
+            if not isinstance(data[f], list):
+                errs.append(f"{f} must be an array")
+            else:
+                for j, el in enumerate(data[f]):
+                    if not isinstance(el, str):
+                        errs.append(f"{f}[{j}] must be a string, got {type(el).__name__}")
+    for field, const_val, then_req in r["conditionals"]:
+        if data.get(field) == const_val:
+            for f in then_req:
+                if not data.get(f):
+                    errs.append(f"{field}={const_val} requires '{f}'")
+    snap = data.get("tasks_snapshot")
+    if snap is not None:
+        if not isinstance(snap, dict):
+            errs.append("tasks_snapshot must be an object")
+        else:
+            for f in r["snap_required"]:
+                if f not in snap:
+                    errs.append(f"tasks_snapshot.{f} is required")
+            if "done" in snap and not isinstance(snap["done"], list):
+                errs.append("tasks_snapshot.done must be an array")
+            if "current" in snap and snap["current"] is not None and not isinstance(snap["current"], str):
+                errs.append("tasks_snapshot.current must be string or null")
+    for i, item in enumerate(data.get("stage_history", [])):
+        for f in r["sh_str_req"]:
+            if not item.get(f):
+                errs.append(f"stage_history[{i}].{f} is required and non-empty")
+        for f in r["sh_ts"]:
+            ca = item.get(f, "")
+            if not _TS_RE.match(str(ca)):
+                errs.append(f"stage_history[{i}].{f} must match YYYYMMDD_HHMMSS, got '{ca}'")
+    for i, item in enumerate(data.get("step_history", [])):
+        for f in r["ph_str_req"]:
+            if not item.get(f):
+                errs.append(f"step_history[{i}].{f} is required and non-empty")
+        for f in r["ph_ts"]:
+            ca = item.get(f, "")
+            if not _TS_RE.match(str(ca)):
+                errs.append(f"step_history[{i}].{f} must match YYYYMMDD_HHMMSS, got '{ca}'")
+        for f, minimum in r["ph_int_min"].items():
+            val = item.get(f)
+            if not isinstance(val, int) or val < minimum:
+                errs.append(f"step_history[{i}].{f} must be integer >= {minimum}, got '{val}'")
+    return errs
+
+
+def _errors_task(data: dict) -> list[str]:
+    r = _tp_rules()
+    errs: list[str] = []
+
+    extra = data.keys() - r["allowed"]
+    if extra:
+        errs.append(f"extra fields not allowed: {sorted(extra)}")
+    missing = r["required"] - data.keys()
+    if missing:
+        errs.append(f"missing required fields: {sorted(missing)}")
+    if "status" in data and r["status_enum"] and data["status"] not in r["status_enum"]:
+        errs.append(f"status '{data['status']}' not in {sorted(r['status_enum'])}")
+    for f in r["ts_fields"]:
+        if f in data and not _TS_RE.match(str(data[f])):
+            errs.append(f"{f} must match YYYYMMDD_HHMMSS, got '{data[f]}'")
+    for f, pat_re in r["pattern_fields"].items():
+        if f in data and not pat_re.match(str(data[f])):
+            errs.append(f"{f} must match pattern, got '{data[f]}'")
+    for f, minimum in r["int_min"].items():
+        if f in data:
+            val = data[f]
+            if not isinstance(val, int) or val < minimum:
+                errs.append(f"{f} must be integer >= {minimum}, got '{val}'")
+    for f, minlen in r["str_min"].items():
+        if f in data and (not isinstance(data[f], str) or len(data[f]) < minlen):
+            errs.append(f"{f} must be non-empty string (minLength {minlen})")
+    for field, const_val, then_req in r["conditionals"]:
+        if data.get(field) == const_val:
+            for f in then_req:
+                if not data.get(f):
+                    errs.append(f"status={const_val} requires '{f}'")
+    return errs
+
+
+def _validate_checkpoint(data: dict, label: str = "checkpoint.json") -> None:
+    errs = _errors_checkpoint(data)
+    if errs:
+        sys.exit(f"validation error ({label}):\n" + "\n".join(f"  - {e}" for e in errs))
+
+
+def _validate_task(data: dict, label: str) -> None:
+    errs = _errors_task(data)
+    if errs:
+        sys.exit(f"validation error ({label}):\n" + "\n".join(f"  - {e}" for e in errs))
+
+
+# ── utils ─────────────────────────────────────────────────────────────────────
+
+def now_ts() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+
+def atomic_write(path: Path, content: str) -> None:
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(content, encoding="utf-8")
+    tmp.replace(path)
+
+
+# ── checkpoint ────────────────────────────────────────────────────────────────
+
+def cmd_checkpoint_get(args) -> None:
+    if not CHECKPOINT.exists():
+        sys.exit("checkpoint.json not found")
+    data = json.loads(CHECKPOINT.read_text())
+    if args.field:
+        val = data.get(args.field)
+        if val is None:
+            sys.exit(f"field '{args.field}' not found")
+        print(json.dumps(val) if isinstance(val, (dict, list)) else val)
+    else:
+        print(CHECKPOINT.read_text(), end="")
+
+
+def cmd_checkpoint_update(args) -> None:
+    if args.field in _HISTORY_FIELDS:
+        sys.exit(
+            f"'{args.field}' is append-only. "
+            "Use 'checkpoint append-stage' or 'checkpoint append-step'."
+        )
+    if not CHECKPOINT.exists():
+        sys.exit("checkpoint.json not found")
+    data = json.loads(CHECKPOINT.read_text())
+    try:
+        value = json.loads(args.value)
+    except (json.JSONDecodeError, TypeError):
+        value = args.value
+    data[args.field] = value
+    data["last_updated"] = now_ts()
+    _validate_checkpoint(data)
+    atomic_write(CHECKPOINT, json.dumps(data, indent=2, ensure_ascii=False))
+    print(f"checkpoint.{args.field} = {value}")
+
+
+def cmd_checkpoint_status(args) -> None:
+    if not CHECKPOINT.exists():
+        sys.exit("checkpoint.json not found")
+    data = json.loads(CHECKPOINT.read_text())
+    print(data.get("status", "unknown"))
+
+
+def cmd_checkpoint_append_stage(args) -> None:
+    if not CHECKPOINT.exists():
+        sys.exit("checkpoint.json not found")
+    data = json.loads(CHECKPOINT.read_text())
+    entry: dict = {
+        "stage": args.stage,
+        "completed_at": args.completed_at or now_ts(),
+    }
+    if args.user_approved:
+        entry["user_approved"] = True
+    data.setdefault("stage_history", []).append(entry)
+    data["last_updated"] = now_ts()
+    _validate_checkpoint(data)
+    atomic_write(CHECKPOINT, json.dumps(data, indent=2, ensure_ascii=False))
+    print(f"stage_history ← {entry}")
+
+
+def cmd_checkpoint_append_step(args) -> None:
+    if not CHECKPOINT.exists():
+        sys.exit("checkpoint.json not found")
+    data = json.loads(CHECKPOINT.read_text())
+    entry: dict = {
+        "stage": args.stage,
+        "step": args.step,
+        "iterations": args.iterations,
+        "completed_at": args.completed_at or now_ts(),
+    }
+    data.setdefault("step_history", []).append(entry)
+    data["last_updated"] = now_ts()
+    _validate_checkpoint(data)
+    atomic_write(CHECKPOINT, json.dumps(data, indent=2, ensure_ascii=False))
+    print(f"step_history ← {entry}")
+
+
+# ── tasks ─────────────────────────────────────────────────────────────────────
+
+def _parse_tasks() -> tuple[list[str], list[dict]]:
+    if not TASKS_MD.exists():
+        return [], []
+    lines = TASKS_MD.read_text(encoding="utf-8").splitlines()
+    preamble, rows, in_table = [], [], False
+    for line in lines:
+        if not in_table and line.startswith("|") and "ID" in line and "Agent" in line:
+            in_table = True
+            continue
+        if not in_table:
+            preamble.append(line)
+            continue
+        if re.match(r"^\|[-| ]+\|$", line.rstrip()):
+            continue
+        if not line.startswith("|"):
+            continue
+        parts = [p.strip() for p in line.strip("|").split("|")]
+        if len(parts) >= 4:
+            rows.append({
+                "id":       parts[0],
+                "agent":    parts[1],
+                "task":     parts[2],
+                "status":   parts[3],
+                "evidence": parts[4] if len(parts) > 4 else "",
+                "output":   parts[5] if len(parts) > 5 else "",
+            })
+    return preamble, rows
+
+
+def _render_tasks(preamble: list[str], rows: list[dict]) -> str:
+    out = "\n".join(preamble) + ("\n" if preamble else "")
+    out += "| ID | Agent | Task | Status | Evidence | Output Path |\n"
+    out += "|----|-------|------|--------|----------|-------------|\n"
+    for r in rows:
+        out += (f"| {r['id']} | {r['agent']} | {r['task']} | {r['status']}"
+                f" | {r['evidence'] or '-'} | {r['output']} |\n")
+    return out
+
+
+def cmd_tasks_list(args) -> None:
+    _, rows = _parse_tasks()
+    if args.status:
+        rows = [r for r in rows if r["status"] == args.status]
+    if not rows:
+        print("(none)")
+        return
+    for r in rows:
+        line = f"[{r['id']}] {r['agent']} | {r['status']} | {r['task']}"
+        if r["evidence"] and r["evidence"] != "-":
+            line += f" | {r['evidence']}"
+        print(line)
+
+
+def cmd_tasks_update(args) -> None:
+    preamble, rows = _parse_tasks()
+    for r in rows:
+        if r["id"] == args.id:
+            r["status"] = args.status
+            if args.evidence:
+                r["evidence"] = args.evidence
+            if args.output:
+                r["output"] = args.output
+            atomic_write(TASKS_MD, _render_tasks(preamble, rows))
+            print(f"task {args.id} → {args.status}")
+            return
+    sys.exit(f"task id '{args.id}' not found")
+
+
+def cmd_tasks_collect(args) -> None:
+    files = sorted(glob.glob(TASK_GLOB))
+    if not files:
+        print("no task_*.json files found")
+        return
+    preamble, rows = _parse_tasks()
+    row_map = {r["id"]: r for r in rows}
+    skipped = 0
+    for f in files:
+        try:
+            t = json.loads(Path(f).read_text())
+        except Exception as e:
+            print(f"skip {f}: {e}", file=sys.stderr)
+            skipped += 1
+            continue
+        tid = t.get("id", "")
+        if not tid:
+            print(f"skip {f}: missing 'id' field", file=sys.stderr)
+            skipped += 1
+            continue
+        errs = _errors_task(t)
+        if errs:
+            print(f"skip {f}: " + "; ".join(errs), file=sys.stderr)
+            skipped += 1
+            continue
+        if tid in row_map:
+            row_map[tid]["status"] = t.get("status", row_map[tid]["status"])
+            if t.get("evidence"):
+                row_map[tid]["evidence"] = t["evidence"]
+            if t.get("artifact"):
+                row_map[tid]["output"] = t["artifact"]
+        else:
+            row_map[tid] = {
+                "id":       tid,
+                "agent":    t.get("agent", ""),
+                "task":     "",
+                "status":   t.get("status", "todo"),
+                "evidence": t.get("evidence", ""),
+                "output":   t.get("artifact", ""),
+            }
+    collected = len(files) - skipped
+    atomic_write(TASKS_MD, _render_tasks(preamble, list(row_map.values())))
+    print(f"collected {collected}/{len(files)} task files → tasks.md updated"
+          + (f" ({skipped} skipped)" if skipped else ""))
+
+
+# ── findings ──────────────────────────────────────────────────────────────────
+
+def _parse_findings(text: str) -> tuple[str, dict[str, str]]:
+    sections, preamble_lines, current, buf = {}, [], None, []
+    for line in text.splitlines(keepends=True):
+        m = re.match(r"^## \[(.+?)\]", line)
+        if m:
+            if current is not None:
+                sections[current] = "".join(buf)
+            current, buf = m.group(1), [line]
+        elif current is None:
+            preamble_lines.append(line)
+        else:
+            buf.append(line)
+    if current is not None:
+        sections[current] = "".join(buf)
+    return "".join(preamble_lines), sections
+
+
+def cmd_findings_get(args) -> None:
+    if not FINDINGS_MD.exists():
+        sys.exit("findings.md not found")
+    text = FINDINGS_MD.read_text(encoding="utf-8")
+    if args.section:
+        _, sections = _parse_findings(text)
+        if args.section not in sections:
+            sys.exit(f"section '[{args.section}]' not found")
+        print(sections[args.section], end="")
+    else:
+        print(text, end="")
+
+
+def cmd_findings_append(args) -> None:
+    if not FINDINGS_MD.exists():
+        sys.exit("findings.md not found")
+    text = FINDINGS_MD.read_text(encoding="utf-8")
+    preamble, sections = _parse_findings(text)
+    if args.section not in sections:
+        sections[args.section] = f"## [{args.section}]\n"
+    sections[args.section] = sections[args.section].rstrip("\n") + f"\n- {args.text}\n"
+    atomic_write(FINDINGS_MD, preamble + "".join(sections.values()))
+    print(f"appended to [{args.section}]")
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    p = argparse.ArgumentParser(prog="state.py", description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    res = p.add_subparsers(dest="resource", required=True)
+
+    # checkpoint
+    cp = res.add_parser("checkpoint")
+    cp_sub = cp.add_subparsers(dest="action", required=True)
+
+    cg = cp_sub.add_parser("get")
+    cg.add_argument("--field", default=None, metavar="KEY")
+    cg.set_defaults(func=cmd_checkpoint_get)
+
+    cu = cp_sub.add_parser("update", help="Set a single field (history fields blocked)")
+    cu.add_argument("--field", required=True, metavar="KEY")
+    cu.add_argument("--value", required=True, metavar="VALUE")
+    cu.set_defaults(func=cmd_checkpoint_update)
+
+    cs = cp_sub.add_parser("status")
+    cs.set_defaults(func=cmd_checkpoint_status)
+
+    cas = cp_sub.add_parser("append-stage")
+    cas.add_argument("--stage", required=True)
+    cas.add_argument("--completed-at", default=None, metavar="YYYYMMDD_HHMMSS")
+    cas.add_argument("--user-approved", action="store_true")
+    cas.set_defaults(func=cmd_checkpoint_append_stage)
+
+    cass = cp_sub.add_parser("append-step")
+    cass.add_argument("--stage", required=True)
+    cass.add_argument("--step", required=True)
+    cass.add_argument("--iterations", required=True, type=int)
+    cass.add_argument("--completed-at", default=None, metavar="YYYYMMDD_HHMMSS")
+    cass.set_defaults(func=cmd_checkpoint_append_step)
+
+    # tasks
+    tk = res.add_parser("tasks")
+    tk_sub = tk.add_subparsers(dest="action", required=True)
+
+    tl = tk_sub.add_parser("list")
+    tl.add_argument("--status", default=None,
+                    choices=["todo", "in-progress", "done", "blocked"])
+    tl.set_defaults(func=cmd_tasks_list)
+
+    tu = tk_sub.add_parser("update")
+    tu.add_argument("--id", required=True)
+    tu.add_argument("--status", required=True,
+                    choices=["todo", "in-progress", "done", "blocked"])
+    tu.add_argument("--evidence", default=None)
+    tu.add_argument("--output", default=None, metavar="PATH")
+    tu.set_defaults(func=cmd_tasks_update)
+
+    tc = tk_sub.add_parser("collect")
+    tc.set_defaults(func=cmd_tasks_collect)
+
+    # findings
+    fn = res.add_parser("findings")
+    fn_sub = fn.add_subparsers(dest="action", required=True)
+
+    fg = fn_sub.add_parser("get")
+    fg.add_argument("--section", default=None, metavar="SECTION")
+    fg.set_defaults(func=cmd_findings_get)
+
+    fa = fn_sub.add_parser("append")
+    fa.add_argument("--section", required=True, metavar="SECTION")
+    fa.add_argument("--text", required=True)
+    fa.set_defaults(func=cmd_findings_append)
+
+    args = p.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/harness/references/schemas/task.schema.json
+++ b/harness/references/schemas/task.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://codex-harness/schemas/task.schema.json",
+  "$id": "https://harness/schemas/task.schema.json",
   "title": "task_{agent}_{id}.json",
   "description": "Worker → Main agent atomic report. Workers write only their own file; main aggregates via GLOB.",
   "type": "object",

--- a/harness/references/schemas/task.schema.json
+++ b/harness/references/schemas/task.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://harness/schemas/task.schema.json",
+  "$id": "https://codex-harness/schemas/task.schema.json",
   "title": "task_{agent}_{id}.json",
   "description": "Worker → Main agent atomic report. Workers write only their own file; main aggregates via GLOB.",
   "type": "object",

--- a/harness/references/schemas/task.schema.json
+++ b/harness/references/schemas/task.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://harness/schemas/task.schema.json",
+  "title": "task_{agent}_{id}.json",
+  "description": "Worker → Main agent atomic report. Workers write only their own file; main aggregates via GLOB.",
+  "type": "object",
+  "required": ["id", "agent", "stage", "step", "status", "timestamp"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^task_[a-zA-Z0-9_-]+_[0-9]+$",
+      "description": "Format: task_{agent-name-without-@}_{seq}. Example: task_researcher-trend_1"
+    },
+    "agent": {
+      "type": "string",
+      "pattern": "^@[a-zA-Z0-9_-]+$",
+      "description": "Calling agent name with @ prefix. Must match .codex/agents/{name}.toml filename."
+    },
+    "stage": {
+      "type": "string",
+      "minLength": 1,
+      "description": "current_stage at time of writing (mirrors checkpoint.json)."
+    },
+    "step": {
+      "type": "string",
+      "minLength": 1,
+      "description": "current_step (≡ Task) at time of writing."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["todo", "in-progress", "done", "blocked"],
+      "description": "Task state. Only worker writes todo→in-progress→done. Blocked requires blocked_reason."
+    },
+    "evidence": {
+      "type": "string",
+      "description": "Verifiable predicate proving completion. Examples: 'go test ./... PASS', '_workspace/sso/research.md exists', 'verdict.json verdict=PASS'. Required when status=done."
+    },
+    "artifact": {
+      "type": "string",
+      "description": "Path to deliverable file produced. Convention: _workspace/{plan_name}/{step}_{agent}_{name}_v{n}.{ext}"
+    },
+    "blocked_reason": {
+      "type": "string",
+      "description": "Required when status=blocked. Concrete blocker description for user confirmation request routing."
+    },
+    "timestamp": {
+      "type": "string",
+      "pattern": "^[0-9]{8}_[0-9]{6}$",
+      "description": "Format: YYYYMMDD_HHMMSS. UTC."
+    },
+    "iterations": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Retry count for this task. Zero-Tolerance: hard cap = 3 (initial + 2 retries)."
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "status": { "const": "done" } } },
+      "then": { "required": ["evidence", "artifact"] }
+    },
+    {
+      "if": { "properties": { "status": { "const": "blocked" } } },
+      "then": { "required": ["blocked_reason"] }
+    }
+  ]
+}

--- a/harness/references/schemas/tasks.template.md
+++ b/harness/references/schemas/tasks.template.md
@@ -1,0 +1,16 @@
+<!--
+tasks.md schema — Main agent sole writer. Aggregates from _workspace/tasks/task_*.json via GLOB + apply_patch.
+Workers DO NOT modify this file directly — race condition on parallel writes.
+
+Columns:
+- ID:            Unique row id (matches task_*.json `id` field minus prefix, or sequential).
+- Agent:         @agent-name (matches task_*.json `agent`).
+- Task:          Brief task description (one line).
+- Status:        todo | in-progress | done | blocked  (mirrors task_*.json `status`).
+- Evidence:      Verifiable predicate from task_*.json `evidence` (only when status=done).
+- Output Path:   From task_*.json `artifact` (deliverable file path).
+-->
+
+| ID | Agent | Task | Status | Evidence | Output Path |
+|----|-------|------|--------|----------|-------------|
+| 1  |       |      | todo   | -        |             |

--- a/harness/references/schemas/workflow.template.md
+++ b/harness/references/schemas/workflow.template.md
@@ -1,0 +1,60 @@
+<!--
+workflow.md schema — Stage (parent issue / Jira Issue) → Step (sub-issue / Jira Sub-issue) hierarchy. Static declaration.
+MANDATORY fields per block (Zero-Tolerance: missing field → HALT).
+
+NAMING CONVENTION (Jira issue title style — MANDATORY):
+- Stage·Step name MUST be a deliverable-meaningful noun phrase in kebab-case.
+- Format: ^[a-z][a-z0-9-]*$  (lowercase letter start, digits/hyphens allowed)
+- BANNED placeholders: main, step1, task, work, default, phase1, stage1, generic
+- ALLOWED examples: sso-integration, payment-flow, requirements-gathering, api-design, load-test
+- Single-Stage / single-Step cases STILL follow this rule — no `main` shortcut.
+
+Stage block required fields:
+- exit condition:        "all steps complete" or verifiable predicate
+- next stage:            {next_stage_name} | done
+- user approval gate:    required | none (last stage)
+
+Step (Task) block required fields:
+- pattern:               pipeline | fan_out_fan_in | expert_pool | producer_reviewer | supervisor | hierarchical | handoff
+- active agents:         [@name1, @name2, ...]   (must match .codex/agents/{name}.toml)
+- exit condition:        VERIFIABLE PREDICATE (file exists / JSON field value / iterations ≥ N)
+                         BANNED: "QA approved", "sufficient", "when complete", "satisfied" (subject to LLM interpretation)
+- next step:             {next_step_name} | done
+- max iterations:        integer (non-loop=1, loop ≤3)
+
+Symbolic placeholders allowed in active agents (e.g. [@selected_expert]) — main resolves
+at runtime via checkpoint.json shared_variables. workflow.md itself is NOT modified.
+-->
+
+<!-- Reference patterns (optional, no effect on execution): {STAGE_1}={pattern}, {STAGE_2}={pattern} -->
+
+## Stage Definitions
+
+### Stage 1: {{STAGE_1_NAME}}
+- exit condition: all steps complete
+- next stage: {{STAGE_2_NAME_OR_done}}
+- user approval gate: {{required/none}}
+
+#### Step 1: {{STEP_1_NAME}}
+- pattern: {{PATTERN}}
+- active agents: [{{@AGENT_1}}]
+- exit condition: {{VERIFIABLE_PREDICATE}}
+- next step: {{STEP_2_NAME_OR_done}}
+- max iterations: {{N}}
+
+<!-- Add more Step blocks within Stage 1 by copying the above. -->
+
+<!-- Add Stage 2+ by copying the Stage block. Single-stage workflow: omit. -->
+<!--
+### Stage 2: {{STAGE_2_NAME}}
+- exit condition: all steps complete
+- next stage: done
+- user approval gate: none (last stage)
+
+#### Step 1: {{STEP_1_NAME}}
+- pattern: {{PATTERN}}
+- active agents: [{{@AGENT_2}}, {{@AGENT_3}}]
+- exit condition: {{VERIFIABLE_PREDICATE}}
+- next step: done
+- max iterations: {{N}}
+-->

--- a/harness/references/skill-testing-guide.md
+++ b/harness/references/skill-testing-guide.md
@@ -86,7 +86,7 @@ For each test prompt, invoke two sub-agents **in parallel within a single respon
 ```
 Invoke @tester-with-skill
   Prompt: "{test prompt}"
-  Skill path specified: .agents/skills/{skill-name}/
+  Skill path specified: .codex/skills/{skill-name}/
   Output path: _workspace/{skill-name}/iteration-N/eval-{id}/with_skill/outputs/
 ```
 
@@ -312,7 +312,7 @@ Write 20 eval queries — 10 should-trigger + 10 should-NOT-trigger.
 
 Confirm that the new skill's description does not overlap with the trigger area of existing skills.
 
-1. Collect descriptions from the existing skill list (scan all `.agents/skills/*/SKILL.md` via shell `find` and shell `cat`).
+1. Collect descriptions from the existing skill list (scan all `.codex/skills/*/SKILL.md` via shell `find` and shell `cat`).
 2. Confirm that the new skill's should-trigger queries do not incorrectly trigger existing skills.
 3. If a conflict is found, describe the **boundary conditions** in the description more clearly (explicitly state the differentiating points from similar skills).
 

--- a/harness/references/skill-testing-guide.md
+++ b/harness/references/skill-testing-guide.md
@@ -1,0 +1,457 @@
+# Skill Testing & Iterative Improvement Guide
+
+Methodology for validating and iteratively improving the quality of skills created in the harness. Supplementary reference for `SKILL.md` Phase 6 (validation and testing). This guide is written on the premise of the **Codex CLI orchestration environment** (no direct communication between sub-agents; the main agent acts as Grader and Analyzer).
+
+---
+
+## Table of Contents
+
+1. [Testing Framework Overview](#1-testing-framework-overview)
+2. [Writing Test Prompts](#2-writing-test-prompts)
+3. [Execution Testing: With-skill vs Baseline](#3-execution-testing-with-skill-vs-baseline)
+4. [Quantitative Evaluation: Assertion-Based Scoring](#4-quantitative-evaluation-assertion-based-scoring)
+5. [Using Specialized Agents (Grader / Comparator / Analyzer)](#5-using-specialized-agents-grader--comparator--analyzer)
+6. [Iterative Improvement Loop](#6-iterative-improvement-loop)
+7. [Description Trigger Validation](#7-description-trigger-validation)
+8. [Workspace Structure](#8-workspace-structure)
+
+---
+
+## 1. Testing Framework Overview
+
+Skill quality validation is a combination of **qualitative evaluation** and **quantitative evaluation**.
+
+| Evaluation Type | Method | Suitable Skills |
+|---|---|---|
+| **Qualitative** | User directly reviews the output | Subjective quality such as writing style, design, creative work |
+| **Quantitative** | Automated assertion-based scoring | Objectively verifiable items such as file creation, data extraction, code generation |
+
+Core loop: **Write → Parallel test execution → Evaluate → Improve → Re-test**
+
+In Codex CLI, since there is no communication between sub-agents, **the main agent doubles as the Grader and Analyzer, or invokes a dedicated QA agent (`@grader`)** to perform scoring.
+
+---
+
+## 2. Writing Test Prompts
+
+### 2-1. Principles
+
+Test prompts should be **specific and natural sentences that an actual user would input**. Abstract or artificial prompts have low test value.
+
+### 2-2. Bad Examples
+
+```
+"Process the PDF"
+"Extract the data"
+"Generate a chart"
+```
+
+### 2-3. Good Examples
+
+```
+"In 'Q4_Sales_Final_v2.xlsx' in the downloads folder, use column C (Sales) and
+column D (Cost) to add a profit margin (%) column. Then sort descending by
+profit margin."
+```
+
+```
+"Extract the table on page 3 of this PDF and convert it to CSV. The table header
+spans 2 rows — the first row is the category and the second row is the actual
+column name."
+```
+
+### 2-4. Prompt Diversity
+
+- Mix **formal / casual** tone
+- Mix **explicit / implicit** intent (cases where file format is stated directly vs. must be inferred from context)
+- Mix **simple / complex** tasks
+- Some prompts should include abbreviations, typos, and casual expressions
+
+### 2-5. Coverage
+
+Start with 2–3 prompts, designed to cover:
+- 1 core use case
+- 1 edge case
+- (Optional) 1 composite task
+
+---
+
+## 3. Execution Testing: With-skill vs Baseline
+
+### 3-1. Comparative Execution Structure (Codex CLI Parallel Invocation)
+
+For each test prompt, invoke two sub-agents **in parallel within a single response turn**.
+
+**With-skill execution:**
+```
+Invoke @tester-with-skill
+  Prompt: "{test prompt}"
+  Skill path specified: .agents/skills/{skill-name}/
+  Output path: _workspace/{skill-name}/iteration-N/eval-{id}/with_skill/outputs/
+```
+
+**Baseline execution:**
+```
+Invoke @tester-baseline
+  Prompt: "{test prompt}"  (same)
+  Skill path not provided (skill not activated)
+  Output path: _workspace/{skill-name}/iteration-N/eval-{id}/without_skill/outputs/
+```
+
+In Codex CLI, agent-level parallelism is achieved by calling multiple sub-agents consecutively within a single response turn. (Shell commands can be executed simultaneously in the background with `&`, but this is separate from evaluation agent invocations.)
+
+### 3-2. Baseline Selection
+
+| Situation | Baseline |
+|---|---|
+| New skill creation | Same prompt run without the skill |
+| Improving an existing skill | Previous skill version (snapshot) — reuse results preserved in the iteration-N-1 directory |
+
+### 3-3. Capturing Timing/Cost Data
+
+Save elapsed time and tokens **immediately** from the agent completion notification. This is only accessible at the time of notification and cannot be recovered afterward.
+
+```json
+{
+  "total_tokens": 84852,
+  "duration_ms": 23332,
+  "total_duration_seconds": 23.3
+}
+```
+
+Since Codex CLI includes token/time metadata in execution results, the main agent records this in `_workspace/{skill-name}/iteration-N/eval-{id}/{variant}/timing.json` via `apply_patch`.
+
+---
+
+## 4. Quantitative Evaluation: Assertion-Based Scoring
+
+### 4-1. Assertion Writing Principles
+
+When output can be verified objectively, define assertions for automated scoring.
+
+**Good assertions:**
+- Can be objectively determined as true/false
+- Has a descriptive name so it is clear what is being checked just from the result
+- Validates the **core value** of the skill
+
+**Bad assertions:**
+- Those that always pass regardless of whether the skill is used (e.g., "output exists")
+- Those that require subjective judgment (e.g., "is well written")
+
+### 4-2. Programmatic Validation
+
+If an assertion can be verified by code, write it as a script. It is faster and more reliable than visual inspection, and can be reused across iterations.
+
+In Codex CLI, the main agent runs validation scripts (Python, shell, etc.) via the shell and records results in `grading.json`.
+
+### 4-3. Caution with Non-Discriminating Assertions
+
+Assertions that pass 100% in **both configurations (With-skill / Baseline)** do not measure the differential value of the skill. Remove such assertions or replace them with more challenging ones.
+
+### 4-4. Scoring Result Schema
+
+```json
+{
+  "expectations": [
+    {
+      "text": "Profit margin column was added",
+      "passed": true,
+      "evidence": "Confirmed 'profit_margin_pct' column in column E"
+    },
+    {
+      "text": "Sorted descending by profit margin",
+      "passed": false,
+      "evidence": "Original order preserved without sorting"
+    }
+  ],
+  "summary": {
+    "passed": 1,
+    "failed": 1,
+    "total": 2,
+    "pass_rate": 0.50
+  }
+}
+```
+
+This schema is stored at the path `_workspace/{skill-name}/iteration-N/eval-{id}/{variant}/grading.json`.
+
+> **Path distinction:**
+> - **Long-term iterative improvement (this file):** `_workspace/{skill-name}/iteration-N/eval-{id}/{variant}/grading.json`
+> - **One-time validation during harness construction (`SKILL.md` Phase 6):** `_workspace/evals/{timestamp}/grading.json`
+>
+> Since the two paths serve different purposes, they can coexist. When aggregating in Phase 6, scan both paths or specify the target path explicitly.
+
+---
+
+## 5. Using Specialized Agents (Grader / Comparator / Analyzer)
+
+In the Codex CLI environment, since direct communication between sub-agents is not possible, the main agent **sequentially invokes** dedicated evaluation agents and brokers results via `findings.md` and `grading.json`.
+
+### 5-1. Grader (Scorer)
+
+Performs assertion-based scoring and cross-validates by extracting verifiable claims from the output.
+
+**Role:**
+- Pass/fail determination per assertion + providing evidence
+- Extract factual claims from output and verify them
+- Feedback on the quality of the eval itself (suggest when assertions are too easy or ambiguous)
+
+**Recommended shell commands:** shell `cat`, shell `grep`.
+
+### 5-2. Comparator (Blind Evaluator)
+
+Anonymizes the two outputs as A/B and judges quality without knowing which was produced with the skill.
+
+**When to use:** When you want to rigorously confirm "is the new version really better?". Can be omitted in general iterative improvement.
+
+**Evaluation criteria:**
+- Content: accuracy, completeness
+- Structure: organization, formatting, usability
+- Overall score
+
+**Codex CLI note:** The main agent must anonymize the two outputs as `_workspace/.../variant_A.md` and `variant_B.md`, then pass only the paths to the Comparator. If "with_skill"/"without_skill" labels are exposed in the prompt, the blind nature is compromised.
+
+### 5-3. Analyzer (Analyst)
+
+Analyzes statistical patterns from benchmark data:
+- Non-discriminating assertions (both configurations pass → no discriminating power)
+- High-variance evals (results vary greatly between runs → unstable)
+- Time/token trade-offs (skill improves quality but also increases cost)
+
+Results are recorded in `_workspace/{skill-name}/iteration-N/benchmark.json` and in the [Key Insights] section of `findings.md`.
+
+**`benchmark.json` schema:**
+```json
+{
+  "iteration": 1,
+  "timestamp": "2026-04-25T12:00:00Z",
+  "eval_count": 3,
+  "with_skill": {
+    "pass_rate": 0.83,
+    "avg_tokens": 45230,
+    "avg_duration_ms": 18500
+  },
+  "without_skill": {
+    "pass_rate": 0.50,
+    "avg_tokens": 38100,
+    "avg_duration_ms": 12300
+  },
+  "skill_delta": {
+    "pass_rate_improvement": 0.33,
+    "token_overhead": 7130,
+    "duration_overhead_ms": 6200
+  },
+  "non_discriminating": ["eval-simple-csv-export"],
+  "high_variance": [],
+  "notes": "Simple CSV export assertion passes in both configurations — candidate for removal"
+}
+```
+
+---
+
+## 6. Iterative Improvement Loop
+
+### 6-1. Collecting Feedback
+
+Show the output to the user and collect feedback. Empty feedback is interpreted as "no issues".
+
+### 6-2. Improvement Principles
+
+1. **Generalize the feedback** — narrow fixes that only match the test example are overfitting. Fix at the principle level.
+2. **Remove what doesn't earn its weight** — read the transcript; if the skill is causing the agent to do unproductive work, delete it.
+3. **Explain the why** — even if the user's feedback is brief, understand why it matters and reflect that understanding in the skill.
+4. **Bundle repetitive work** — if the same helper script is generated in every test, include it in `scripts/` in advance.
+
+### 6-3. Iteration Procedure
+
+```
+1. Modify the skill
+2. Re-run all test cases in a new iteration-N+1/ directory
+3. Present results to the user (compared to the previous iteration)
+4. Collect feedback (request user confirmation if ambiguous)
+5. Modify again → repeat
+```
+
+**Termination conditions:**
+- User is satisfied
+- All feedback is empty (no issues with any output)
+- No more meaningful improvements
+
+### 6-4. Draft → Review Pattern
+
+When modifying a skill, write a draft and then **read it again with fresh eyes** and improve. Do not try to write it perfectly in one pass — go through a draft-review cycle.
+
+---
+
+## 7. Description Trigger Validation
+
+The Codex CLI trigger router selects a skill based solely on the description. Therefore, the description is the skill's **only practical API**.
+
+### 7-1. Writing Trigger Eval Queries
+
+Write 20 eval queries — 10 should-trigger + 10 should-NOT-trigger.
+
+**Query quality criteria:**
+- Specific and natural sentences that an actual user would input
+- Include specific details such as file paths, personal context, column names, company names
+- Mix length, tone, and format variably
+- Focus on **edge cases** rather than clear-cut answers
+
+**Should-trigger queries (10):**
+- Same intent expressed in various ways (formal/casual)
+- Cases where the skill/file type is not explicitly mentioned but is clearly needed
+- Non-mainstream use cases
+- Cases that compete with other skills but this skill should win
+
+**Should-NOT-trigger queries (10):**
+- **Near-misses are the key** — queries with similar keywords but where a different tool/skill is appropriate
+- Clearly unrelated queries ("write a fibonacci function") have no test value
+- Adjacent domain, ambiguous phrasing, keyword overlap but different context
+
+### 7-2. Existing Skill Conflict Validation
+
+Confirm that the new skill's description does not overlap with the trigger area of existing skills.
+
+1. Collect descriptions from the existing skill list (scan all `.agents/skills/*/SKILL.md` via shell `find` and shell `cat`).
+2. Confirm that the new skill's should-trigger queries do not incorrectly trigger existing skills.
+3. If a conflict is found, describe the **boundary conditions** in the description more clearly (explicitly state the differentiating points from similar skills).
+
+### 7-3. Automated Optimization (Optional Advanced Feature)
+
+When description optimization is needed:
+
+1. Split 20 eval queries into Train (60%) / Test (40%).
+2. Measure trigger accuracy with the current description.
+3. Analyze failure cases and generate an improved description.
+4. Select best description based on the Test set (not the Train set — to prevent overfitting).
+5. Repeat up to 5 times.
+
+> Codex CLI automation is performed by a script that calls `codex -p "..."` from the shell. Token costs are high, so run this as a final step after the skill has been sufficiently stabilized.
+
+---
+
+## 8. Workspace Structure
+
+Directory structure for systematically managing test and evaluation results.
+
+> **Naming distinction:** Here, `{skill-name}` is the **name of the skill being tested**. It is a separate level from `{plan_name}` in `_workspace/{plan_name}/` used during orchestration runs. Skill test results are stored under `_workspace/{skill-name}/`, and orchestration run outputs are stored separately under `_workspace/{plan_name}/`.
+
+```
+_workspace/{skill-name}/
+├── iteration-1/
+│   ├── eval-descriptive-name-1/
+│   │   ├── eval_metadata.json
+│   │   ├── with_skill/
+│   │   │   ├── outputs/
+│   │   │   ├── timing.json
+│   │   │   └── grading.json
+│   │   └── without_skill/
+│   │       ├── outputs/
+│   │       ├── timing.json
+│   │       └── grading.json
+│   ├── eval-descriptive-name-2/
+│   │   └── ...
+│   └── benchmark.json
+├── iteration-2/
+│   └── ...
+└── evals/
+    └── evals.json
+```
+
+**Rules:**
+- Eval directories use **descriptive names** rather than numbers (e.g., `eval-multi-page-table-extraction`).
+- Each iteration is preserved in an independent directory (overwriting a previous iteration is prohibited).
+- `_workspace/` is not deleted — retained for post-hoc verification, audit trails, and blind comparison.
+- `evals.json` accumulates **evaluation metadata for the entire session** (skill version, total number of iterations, final pass rate, etc.) to track long-term quality trends in the harness.
+
+**`evals.json` schema:**
+```json
+{
+  "skill_name": "pdf-extractor",
+  "skill_version": "1.0.0",
+  "created_at": "2026-04-25T10:00:00Z",
+  "total_iterations": 3,
+  "final_pass_rate": 0.85,
+  "iterations": [
+    {
+      "iteration": 1,
+      "eval_count": 3,
+      "pass_rate": 0.67,
+      "timestamp": "2026-04-25T10:00:00Z",
+      "notes": "Initial version — 2 of 3 assertions passed"
+    },
+    {
+      "iteration": 2,
+      "eval_count": 3,
+      "pass_rate": 0.83,
+      "timestamp": "2026-04-25T11:00:00Z",
+      "notes": "Re-tested after improving multi-step table processing"
+    }
+  ]
+}
+```
+
+---
+
+## Orchestrator Test Scenarios
+
+An orchestrator must describe **at least 1 normal flow + 1 error flow + 1 resume flow** in the skill body.
+
+> **Naming distinction:** "Orchestrator Steps 0~5" are the **internal execution steps of the orchestrator skill itself** (context check, initialization, agent invocation, QA, integration, reporting). This is a separate concept from the Stage/Step hierarchy in `workflow.md`.
+
+### Normal Flow
+
+1. User provides `{input}`.
+2. Orchestrator Step 0 confirms `_workspace/` does not exist → selects initial run mode.
+3. Orchestrator Step 1 initializes `workflow.md`·`tasks.md`·`findings.md`.
+   - `workflow.md`: Record Stage 1 (`{plan_name}` deliverable kebab-case) / Step 1 (deliverable kebab-case) / active agent list. **Placeholders (`main`) are prohibited** — use Jira title convention.
+   - `checkpoint.json`: Initialize `current_stage: "{deliverable-kebab}"`, `current_step: "{deliverable-kebab}"`, `active_pattern: {first step pattern}`, `status: "in_progress"`.
+4. Orchestrator Step 2 runs [Step execution loop] — invokes the agent for the current Step in workflow.md.
+   - Run @analyst → @coder sequentially (batch invocations where parallelism is possible).
+5. Orchestrator Step 3 invokes @reviewer → confirms no conflicts in `findings.md`.
+6. Orchestrator Step 4 generates `_workspace/{plan_name}/final_{output}.md`.
+7. Orchestrator Step 5 delivers a summary report to the user.
+8. **Expected result:** `_workspace/{plan_name}/final_{output}.md` exists, all items in `tasks.md` are `Done`.
+
+### Resume Flow (Persistence Test)
+
+1. @analyst invocation completes, session terminates due to network failure during @coder invocation.
+2. User re-invokes → orchestrator Step 0 finds `checkpoint.json`.
+3. Restore `current_stage`·`current_step` from `checkpoint.json` → confirm entry point for that step.
+4. Confirm @analyst output exists → immediately resume from the @coder step.
+5. **Expected result:** @analyst work is skipped, only @coder and subsequent work is completed.
+
+### Error Flow (Fix Loop)
+
+1. Orchestrator Step 3: @reviewer rejects @coder's output (security vulnerability found).
+2. Orchestrator records rejection reason in `findings.md` [Change Requests].
+3. Orchestrator re-invokes @coder, injecting @reviewer's report.
+4. @coder fixes the vulnerability and generates new output.
+5. @reviewer re-validation passes → orchestrator proceeds to Step 4.
+6. Final report explicitly states "Error recovery: passed after @coder revision following @reviewer rejection".
+
+### expert_pool Scenario — Ambiguous Classification Path
+
+1. User inputs "please review both performance and security" (multiple domains mixed).
+2. Orchestrator Step 2 expert_pool: CLASSIFY result is AMBIGUOUS.
+3. Request user confirmation ("Expert list: which of [@perf-analyst, @security-analyst] would you like to assign this to?").
+4. User responds with "@security-analyst".
+5. Record `"- @security-analyst: directly specified by user"` in findings.md [Routing Rationale].
+6. Invoke @security-analyst → record task file → termination condition satisfied.
+7. **Expected result:** AMBIGUOUS path → user confirmation request triggered, user-specified agent selected.
+
+### handoff Scenario — Standalone Completion Without [NEXT_AGENT]
+
+1. @log-analyzer invoked → analysis complete, no `[NEXT_AGENT]` keyword in response.
+2. Orchestrator enters ELSE branch: records `task_{log-analyzer}_{id}.json` (standalone completion).
+3. Termination condition check → satisfied → step transition.
+4. **Expected result:** handle_handoff not called, task file recorded based on active_agents[0].
+
+---
+
+## Reference Links
+
+- The simplified form of the scoring schema (`grading.json`) is documented in `references/skill-writing-guide.md`.
+- Phase 6 validation procedure follows the workflow Phase 6 section in `SKILL.md`.
+- Stage-Step workflow details: `references/stage-step-guide.md`.
+- **Stage-Step workflow test scenarios** (scenarios 1~6): See `references/stage-step-guide.md`.

--- a/harness/references/skill-writing-guide.md
+++ b/harness/references/skill-writing-guide.md
@@ -1,0 +1,432 @@
+# Skill Writing Guide
+
+A detailed writing guide for improving the quality of skills created in the harness. Supplementary reference for `SKILL.md` Phase 4 (specialized skill and orchestrator creation). Provides a writing style tailored to the Codex CLI sub-agent orchestration environment.
+
+---
+
+## Table of Contents
+
+0. [Skill Directory Structure](#0-skill-directory-structure)
+1. [Description Writing Patterns](#1-description-writing-patterns)
+2. [Body Writing Style](#2-body-writing-style)
+3. [Output Format Definition Patterns](#3-output-format-definition-patterns)
+4. [Example Writing Patterns](#4-example-writing-patterns)
+5. [Progressive Disclosure Pattern](#5-progressive-disclosure-pattern)
+6. [Script Bundling Decision Criteria](#6-script-bundling-decision-criteria)
+7. [Data Brokering & Coordination Patterns (Codex CLI Specific)](#7-data-brokering--coordination-patterns-codex-cli-specific)
+8. [Data Schema Standards](#8-data-schema-standards)
+9. [What Not to Include in a Skill](#9-what-not-to-include-in-a-skill)
+
+---
+
+## 0. Skill Directory Structure
+
+```
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter (name, description required)
+│   └── Markdown body
+└── Bundled Resources (optional)
+    ├── scripts/    - executable code for repetitive/deterministic tasks
+    ├── references/ - reference documents loaded conditionally
+    └── assets/     - files used in output (templates, images)
+```
+
+- `scripts/` — pre-bundle scripts that agents commonly write. Executed directly from the shell.
+- `references/` — separates detailed content that is not frequently triggered. Agents load conditionally via shell `cat`.
+- `assets/` — static files such as templates and images used in output.
+
+---
+
+## 1. Description Writing Patterns
+
+The description is the **only trigger mechanism** for a skill. The Codex CLI trigger router looks only at the `name` + `description` from `.agents/skills/*/SKILL.md` to decide whether to use a skill.
+
+### 1-1. Understanding the Trigger Mechanism
+
+Codex tends not to invoke a skill for simple tasks that can be handled easily with basic tools. A simple request like "read this PDF" may not trigger even with a perfect description. The **more complex, multi-step, and specialized a task**, the higher the probability of triggering a skill.
+
+### 1-2. Writing Principles
+
+1. Describe **both what the skill does and the specific trigger situations**.
+2. Specify **boundary conditions** that distinguish similar cases that should not trigger the skill.
+3. Be slightly **"pushy"** — to compensate for the trigger router's tendency toward conservative judgment.
+4. Always include **follow-up action keywords** (re-run, modify, revise, update, partial re-run). Without them, the skill effectively becomes dead code after the first execution.
+
+### 1-3. Good Examples
+
+```yaml
+description: "Performs all PDF operations including reading PDF files, extracting text
+  and tables, merging, splitting, rotating, watermarking, encrypting, decrypting,
+  and OCR. When a .pdf file is mentioned or a PDF output is requested, this skill
+  MUST be used. Especially useful when conversion, editing, or analysis is needed
+  rather than a simple 'read' request. Also MUST be used when modifying, re-extracting,
+  or regenerating a previously processed PDF."
+```
+
+```yaml
+description: "All spreadsheet operations including adding columns, formula calculations,
+  formatting, charts, and data cleaning for Excel, CSV, and TSV files. Use this skill
+  whenever a user mentions a spreadsheet — even casually ('the xlsx in the downloads
+  folder'). Also covers updating existing results, recalculating columns, and changing
+  sort order."
+```
+
+### 1-4. Bad Examples
+
+- `"A skill that processes data"` — too vague, file type and task are unclear.
+- `"PDF-related tasks"` — no enumeration of specific actions, trigger situations not described.
+- `"Performs X"` — missing follow-up action keywords, so the router ignores it from the second call onward.
+
+---
+
+## 2. Body Writing Style
+
+### 2-1. Why-First Principle
+
+When an LLM understands the reason, it makes correct judgments even in edge cases. Conveying context is more effective than imposing rigid rules.
+
+**Bad example:**
+```markdown
+ALWAYS use pdfplumber for table extraction. NEVER use PyPDF2 for tables.
+```
+
+**Good example:**
+```markdown
+Use pdfplumber for table extraction. PyPDF2 is specialized for text extraction
+and cannot preserve the row/column structure of tables. pdfplumber recognizes
+cell boundaries and returns structured data.
+```
+
+### 2-2. Generalization Principle
+
+When a problem is found in feedback or test results, generalize at the **principle level** rather than making a narrow fix that only fits the specific example.
+
+**Overfitting fix:**
+```markdown
+If there is a column named "Q4 Sales", convert that column to numeric.
+```
+
+**Generalized fix:**
+```markdown
+If a column name contains keywords suggesting numeric values such as "sales",
+"amount", or "quantity", convert that column to a numeric type. If conversion
+fails, preserve the original value.
+```
+
+### 2-3. Imperative Tone
+
+Use the imperative form ("do this", "use this") rather than descriptive forms ("this can be done", "it is possible to"). A skill is a set of instructions.
+
+### 2-4. Context Economy
+
+The context window is a shared resource. Ask whether every sentence justifies its token cost:
+- "Is this something the agent already knows?" → Remove
+- "Will the agent make a mistake without this explanation?" → Keep
+- "Is one concrete example more effective than a long explanation?" → Replace with an example
+
+---
+
+## 3. Output Format Definition Patterns
+
+Use this in skills where the format of the output matters:
+
+```markdown
+## Report Structure
+Follow this template exactly:
+
+# [Title]
+## Summary
+## Key Findings
+## Recommendations
+```
+
+Keep format definitions concise, but including **real examples** makes them more effective. If an orchestrator (main agent) needs to automatically parse the output produced by a sub-agent, strictly fix the format specification using JSON schema or YAML.
+
+---
+
+## 4. Example Writing Patterns
+
+Examples are more effective than long explanations:
+
+```markdown
+## Commit Message Format
+
+**Example 1:**
+Input: Add JWT token-based user authentication
+Output: feat(auth): implement JWT-based authentication
+
+**Example 2:**
+Input: Fix bug where password visibility toggle button doesn't work on login page
+Output: fix(login): fix password visibility toggle button behavior
+```
+
+**Conditions for good examples:**
+- Input and output are presented as **pairs**
+- Include at least 1 edge case or error case
+- Domain-specific terms appear in the examples
+
+---
+
+## 5. Progressive Disclosure Pattern
+
+Keep the `SKILL.md` body to **under 500 lines**, and separate detailed references, large data schemas, and domain-specific knowledge into files under `references/`. Guide the agent to load those files via shell `cat` only when needed.
+
+### 5-1. Pattern 1: Domain-Based Separation
+
+```
+bigquery-skill/
+├── SKILL.md (overview + domain selection guide)
+└── references/
+    ├── finance.md   (revenue, billing metrics)
+    ├── sales.md     (opportunities, pipeline)
+    └── product.md   (API usage, features)
+```
+
+If the user asks about revenue, only `finance.md` is loaded.
+
+### 5-2. Pattern 2: Conditional Detail
+
+```markdown
+# DOCX Processing
+
+## Document Creation
+Create a new document using docx-js. → See [DOCX-JS.md](references/docx-js.md).
+
+## Document Editing
+For simple edits, modify the XML directly.
+**If tracked changes are needed**: See [REDLINING.md](references/redlining.md).
+```
+
+### 5-3. Pattern 3: Large Reference File Structure
+
+Reference files over 300 lines should include a table of contents at the top:
+
+```markdown
+# API Reference
+
+## Table of Contents
+1. [Authentication](#authentication)
+2. [Endpoint List](#endpoint-list)
+3. [Error Codes](#error-codes)
+4. [Rate Limits](#rate-limits)
+
+---
+
+## Authentication
+...
+```
+
+---
+
+## 6. Script Bundling Decision Criteria
+
+Observe agent transcripts during test runs. Bundle when you see the following patterns.
+
+| Signal | Action |
+|---|---|
+| Same helper script created in 3 out of 3 tests | Bundle in `scripts/` |
+| Same `pip install` / `npm install` run every time | Specify dependency installation step in the skill |
+| Same multi-step approach repeated every time | Document as standard procedure in the skill body |
+| Same workaround applied after similar error every time | Document known issues and solutions in the skill |
+
+Bundled scripts must go through an **execution test**. Confirm actual execution results in the shell before including them in the skill.
+
+---
+
+## 7. Data Brokering & Coordination Patterns (Codex CLI Specific)
+
+Write skills on the premise that in the Codex CLI environment, the main agent acts as a **Data Broker**. Since direct communication between sub-agents is not possible, skills follow these principles.
+
+### 7-1. Standardizing Outputs
+
+Strictly define the files generated by sub-agents to have a **structure that is easy for other agents or the main agent to read** (MD, JSON). Free-form output makes orchestration difficult.
+
+### 7-2. Completion and Status Reporting (Completion Signals)
+
+The method for reporting skill execution results to the orchestrator.
+
+1.  **Atomic Status Reporting (Thread-safe):** Agents running in parallel do not directly modify `tasks.md`. Instead, they report by creating a `_workspace/tasks/task_{agent}_{id}.json` file.
+2.  **Dynamic Handoff:** Used when the agent is outside its area of expertise or an additional specialist is needed.
+    - **Format:** `[NEXT_AGENT: @expert-name] Reason: {specific reason}`
+    - **Example:** `[NEXT_AGENT: @security-patcher] Reason: An authentication vulnerability was found during logic analysis, requiring specialized patching.`
+3.  **Visibility:** All intermediate progress is updated in real time in the [Key Insights] section of `findings.md`.
+
+### 7-3. External Input Requires User Confirmation
+
+Do not guess when instructions are ambiguous or data conflicts arise. Explicitly state in the skill body "If X is uncertain, request user confirmation" to fix the user intervention point.
+
+### 7-4. Procedural Skills Are Loaded Explicitly by the Orchestrator
+
+In Codex CLI, a skill is activated by the orchestrator reading it via `cat .agents/skills/{name}/SKILL.md` and injecting it into the prompt. When writing a skill that **references or reuses another skill**, specify the skill name and when it should be loaded.
+
+### 7-5. Orchestrator Skill Writing Rules (Required, drift prevention)
+
+When writing orchestrator skills, **do not fall back to a flat "Step 1~N" list**. Always use the Stage (parent issue / Jira Issue) → Step (child issue / Jira Sub-issue) block format. This rule is mandatory to prevent recurrence of non-standard outputs like `examples/sso-dev-flow`.
+
+| Prohibited | Allowed |
+|------|------|
+| `### Step 0: ...` `### Step 1: ...` flat headers | `### Stage 1: {name}` followed by `#### Step 1: {name}` nesting |
+| Termination conditions like "upon QA approval", "when done", "sufficiently" | `"verdict=PASS in qa_verdict.json"`, `"status=done in task_*.json"` |
+| Pattern unspecified or free notation ("sequentially") | 7 pattern enum (`pipeline`·`fan_out_fan_in`·`expert_pool`·`producer_reviewer`·`supervisor`·`hierarchical`·`handoff`) |
+| Prose description in active agent body | Step block field `Active Agents: [@name1, @name2]` |
+| Missing user approval gate | Stage block `User Approval Gate: required / none` specified |
+| Missing max iteration count (especially producer_reviewer) | Step block `Max Iterations: 3` |
+| Arbitrary sections in findings.md like `[Review: Phase]` | Standard sections like `[Key Insights]`·`[Change Requests]`·`[Shared Variables/Paths]` |
+| Simply checking off tasks.md items | `_workspace/tasks/task_{agent}_{id}.json` persistence + tasks.md table update |
+
+**Orchestrator SKILL.md Body Required Sections (Checklist):**
+
+- [ ] Virtual team (agent · type · role · skill · output table)
+- [ ] Step 0 (context check — checkpoint.json status-based branching)
+- [ ] Step 1 (initialization — simultaneous creation of workflow.md·findings.md·tasks.md·checkpoint.json 5 files + schema validation step 1)
+- [ ] Step 2 (Step execution loop — pattern-based invocation + termination condition check + automatic/approval switching)
+- [ ] Step 3+ (pattern-specific processing — e.g., producer_reviewer loop, supervisor dynamic assignment)
+- [ ] Error handling (Zero-Tolerance: retry ≤2 → Blocked + user confirmation request)
+
+**Orchestrator Skill Directory Required Bundle (at time of creation):**
+
+New orchestrator skills read their own `references/schemas/` at runtime (`harness` is a meta-skill and is not activated at runtime), so the following **9 items** must always be bundled. The SoT is `harness/references/schemas/` — copy as-is when creating new skills.
+
+```
+{project}/.agents/skills/{name}-orchestrator/
+├── SKILL.md
+└── references/
+    └── schemas/
+        ├── task.schema.json                    ← copy from harness/references/schemas/
+        ├── checkpoint.schema.json              ← same
+        ├── workflow.template.md                ← same
+        ├── findings.template.md                ← same
+        ├── tasks.template.md                   ← same
+        ├── models.md                           ← model ID SoT (required reference when creating agents)
+        ├── agent-worker.template.toml            ← worker agent creation standard (TOML)
+        ├── agent-orchestrator.template.md      ← orchestrator skill creation standard
+        └── agent-state-manager.template.toml   ← state manager agent creation standard (optional)
+```
+
+> **Bundle Validation:** Step 1.3 reads all 9 items in `references/schemas/` via shell `cat`, so any missing file causes immediate runtime failure. Immediately after skill creation, confirm all 9 files exist with `ls .agents/skills/{name}/references/schemas/`.
+> **Update Policy:** When `harness` `references/schemas/` changes, propagate the same change to all derived orchestrator skills (drift prevention). The `_workspace/_schemas/` in an in-progress workspace is a snapshot and should be preserved.
+
+> **Full bundle example (case integrating all outputs of one domain):** See `references/examples/full-bundle/sso-style.md`. A canonical package that simultaneously creates all 5 files: orchestrator SKILL.md + workflow.md + findings.md + tasks.md + checkpoint.json.
+
+### 7-6. Flat Step → Stage-Step Migration Guide
+
+The procedure for converting non-standard orchestrator skills previously written with only flat `Step 0~N` headers (e.g., `examples/sso-dev-flow` style) to the current Stage-Step model. **Directly corresponds to drift items #1 and #2 in `expansion-matrix.md`.**
+
+**Identifying Migration Targets (Checklist):**
+
+- [ ] SKILL.md body has 0 `### Stage` headers — only flat Steps exist
+- [ ] workflow.md is not used (or replaced with a simple checklist)
+- [ ] Termination conditions are in natural language ("QA approval", "when done", "sufficiently")
+- [ ] No `_workspace/tasks/task_*.json` persistence (directly modifying tasks.md)
+- [ ] `references/schemas/` directory is absent
+
+**6-Step Migration:**
+
+| Step | Task | Validation | Output |
+|------|------|------|--------|
+| **M1. Inventory** | Group the flat Step 0~N in the existing SKILL.md into domain work units (Work). Each group = candidate Stage. | Number of groups = number of Stage candidates, number of Steps within each group ≥ 1 | `migration_plan.md` draft |
+| **M2. Stage Mapping** | Assign Stage names to each group (based on work meaning: `gather`·`design`·`validate`). Decompose sub-steps within each group into Steps (≡Tasks). | Stage/Step names match `[a-z][a-z0-9-]*` pattern | Stage-Step mapping table |
+| **M3. Pattern Assignment** | Assign 1 of the 7 patterns to each Step (`pipeline`·`fan_out_fan_in`·`expert_pool`·`producer_reviewer`·`supervisor`·`hierarchical`·`handoff`). Free notation ("sequentially") is prohibited. | Passes enum check | Mapping table with pattern column added |
+| **M4. Termination Condition Conversion** | Natural language → verifiable predicate. `"QA approval"` → `verdict=PASS in qa_verdict.json`, `"when done"` → `status=done in task_*.json`, `"sufficiently"` → `iterations ≥ N`. | Passes `orchestrator-template.md` Step 1.8 whitelist | Verified predicate column added |
+| **M5. Create 5 Output Files** | Based on the mapping table, create `workflow.md` + `findings.md` + `tasks.md` + `checkpoint.json`. New SKILL.md body adopts the `references/orchestrator-template.md` skeleton. | `workflow.md` has 0 missing fields out of 6, cycle validation passes | New 5 files |
+| **M6. Bundle schemas/** | Copy 9 items from `harness/references/schemas/` to new skill's `references/schemas/` (task/checkpoint/workflow/findings/tasks schemas + models.md + agent-worker.template.toml + agent-orchestrator.template.md + agent-state-manager.template.toml). | 9 files exist at `ls .agents/skills/{new}/references/schemas/` | Bundle complete |
+
+**Example conversion table (sso-dev-flow → 5-stage Stage-Step):**
+
+| Existing (Flat) | New (Stage-Step + Pattern) | Termination Condition Conversion |
+|------------|--------------------------|---------------|
+| `Step 0: Requirements Gathering` | Stage `discover` / Step `gather` (`fan_out_fan_in`) | 4 `task_*.json status=done` |
+| `Step 1: Design Review` | Stage `discover` / Step `design-review` (`producer_reviewer`) | `review_verdict.json verdict=PASS` |
+| `Step 2: Implementation` | Stage `build` / Step `implement` (`pipeline`) | `_workspace/{plan}/code/*.go` files exist |
+| `Step 3: Pass upon QA Approval` | Stage `validate` / Step `qa-loop` (`producer_reviewer`) | `qa_verdict.json verdict=PASS AND iterations ≤ 3` |
+| `Step 4: Deployment` | Stage `validate` / Step `deploy` (`pipeline`) | `deployment.log status=success` |
+
+**Backward Compatibility Policy:**
+
+- Existing in-progress `_workspace/` is preserved — applied from new runs after migration.
+- If `_schemas/` directory does not exist in the existing `_workspace/`, do not add it automatically (to ensure snapshot integrity). Requires user approval before new runs.
+- Migration must be recorded in AGENTS.md change history: `[YYYY-MM-DD] {skill name}: flat Step → Stage-Step conversion (M1~M6)`.
+
+**Post-Migration Validation:**
+
+- [ ] All drift items #1, #2, #3 in `expansion-matrix.md` (flat Step, natural language termination conditions, required fields) pass
+- [ ] `orchestrator-template.md` Step 1.8 (schema validation) + Step 1.9 (cycle validation) pass
+- [ ] At least 1 test scenario runs successfully (see full-bundle/sso-style.md pattern)
+
+---
+
+## 8. Data Schema Standards
+
+Follow the standard schemas below for consistency in data exchange between skills and evaluation.
+
+### 8-1. eval_metadata.json
+
+Metadata for each test case:
+
+```json
+{
+  "eval_id": 0,
+  "eval_name": "descriptive-name-here",
+  "prompt": "User's task prompt",
+  "assertions": [
+    "Output contains X",
+    "File was created in Y format"
+  ]
+}
+```
+
+### 8-2. grading.json
+
+Assertion-based scoring results:
+
+```json
+{
+  "expectations": [
+    {
+      "text": "Output contains 'Seoul'",
+      "passed": true,
+      "evidence": "Confirmed 'Seoul region data extraction' in step 3"
+    }
+  ],
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "total": 3,
+    "pass_rate": 0.67
+  }
+}
+```
+
+**Field name caution:** The top-level array is `expectations`, and internal fields must use exactly `text`·`passed`·`evidence` (variants like `items`·`name`·`met`·`details` are prohibited). The harness Phase 6 validation and section 4 of `skill-testing-guide.md` assume this schema.
+
+### 8-3. timing.json
+
+Execution time and token measurement:
+
+```json
+{
+  "total_tokens": 84852,
+  "duration_ms": 23332,
+  "total_duration_seconds": 23.3
+}
+```
+
+Save `total_tokens` and `duration_ms` **immediately** from the agent completion notification. This data is only accessible at the time of notification and cannot be recovered afterward.
+
+### 8-4. findings.md / tasks.md
+
+Shared state files for the Codex CLI harness. When a skill updates these two files, it must adhere to the section specifications in `orchestrator-template.md`.
+
+- `findings.md`: `[Key Insights]`, `[Key Keywords]`, `[Shared Variables/Paths]`, `[Data Conflicts]`, `[Change Requests]`, `[Next Step Instructions]` (use only sections needed for the pattern)
+- `tasks.md`: `[ID]`, `[Agent]`, `[Task Description]`, `[Status]`, `[Evidence]`, `[Linked Outputs]`
+
+---
+
+## 9. What Not to Include in a Skill
+
+- Supplementary documents such as `README.md`, `CHANGELOG.md`, `INSTALLATION_GUIDE.md`
+- Meta information from the skill creation process (test results, iteration history, commit messages, etc.)
+- User-facing documentation — a skill is **a set of instructions for an AI agent**.
+- General knowledge that agents already know (language syntax, general CS concepts, etc.)
+- Hardcoded values that only fit a specific test case (violation of the generalization principle)

--- a/harness/references/skill-writing-guide.md
+++ b/harness/references/skill-writing-guide.md
@@ -286,14 +286,14 @@ When writing orchestrator skills, **do not fall back to a flat "Step 1~N" list**
 
 **Orchestrator Skill Directory Required Bundle (at time of creation):**
 
-New orchestrator skills read their own `references/schemas/` at runtime (`codex-harness` is a meta-skill and is not activated at runtime), so the following **10 items** must always be bundled. The SoT is `codex-harness/references/schemas/` — copy as-is when creating new skills.
+New orchestrator skills read their own `references/schemas/` at runtime (`harness` is a meta-skill and is not activated at runtime), so the following **10 items** must always be bundled. The SoT is `harness/references/schemas/` — copy as-is when creating new skills.
 
 ```
 {project}/.codex/skills/{name}-orchestrator/
 ├── SKILL.md
 └── references/
     └── schemas/
-        ├── task.schema.json                    ← copy from codex-harness/references/schemas/
+        ├── task.schema.json                    ← copy from harness/references/schemas/
         ├── checkpoint.schema.json              ← same (SoT parsed by state.py at runtime)
         ├── workflow.template.md                ← same
         ├── findings.template.md                ← same
@@ -306,7 +306,7 @@ New orchestrator skills read their own `references/schemas/` at runtime (`codex-
 ```
 
 > **Bundle Validation:** Step 1.3 reads all 10 items in `references/schemas/` via shell `cat`, so any missing file causes immediate runtime failure. Immediately after skill creation, confirm all 10 files exist with `ls .codex/skills/{name}/references/schemas/`.
-> **Update Policy:** When `codex-harness` `references/schemas/` changes, propagate the same change to all derived orchestrator skills (drift prevention). The `_workspace/_schemas/` in an in-progress workspace is a snapshot and should be preserved.
+> **Update Policy:** When `harness` `references/schemas/` changes, propagate the same change to all derived orchestrator skills (drift prevention). The `_workspace/_schemas/` in an in-progress workspace is a snapshot and should be preserved.
 
 > **Full bundle example (case integrating all outputs of one domain):** See `references/examples/full-bundle/sso-style.md`. A canonical package that simultaneously creates all 5 files: orchestrator SKILL.md + workflow.md + findings.md + tasks.md + checkpoint.json.
 
@@ -331,7 +331,7 @@ The procedure for converting non-standard orchestrator skills previously written
 | **M3. Pattern Assignment** | Assign 1 of the 7 patterns to each Step (`pipeline`·`fan_out_fan_in`·`expert_pool`·`producer_reviewer`·`supervisor`·`hierarchical`·`handoff`). Free notation ("sequentially") is prohibited. | Passes enum check | Mapping table with pattern column added |
 | **M4. Termination Condition Conversion** | Natural language → verifiable predicate. `"QA approval"` → `verdict=PASS in qa_verdict.json`, `"when done"` → `status=done in task_*.json`, `"sufficiently"` → `iterations ≥ N`. | Passes `orchestrator-template.md` Step 1.8 whitelist | Verified predicate column added |
 | **M5. Create 5 Output Files** | Based on the mapping table, create `workflow.md` + `findings.md` + `tasks.md` + `checkpoint.json`. New SKILL.md body adopts the `references/orchestrator-template.md` skeleton. | `workflow.md` has 0 missing fields out of 6, cycle validation passes | New 5 files |
-| **M6. Bundle schemas/** | Copy 10 items from `codex-harness/references/schemas/` to new skill's `references/schemas/` (task + checkpoint schemas + workflow/findings/tasks templates + models.md + agent-worker.template.toml + agent-orchestrator.template.md + agent-state-manager.template.toml + state.py). | 10 files exist at `ls .codex/skills/{new}/references/schemas/` | Bundle complete |
+| **M6. Bundle schemas/** | Copy 10 items from `harness/references/schemas/` to new skill's `references/schemas/` (task + checkpoint schemas + workflow/findings/tasks templates + models.md + agent-worker.template.toml + agent-orchestrator.template.md + agent-state-manager.template.toml + state.py). | 10 files exist at `ls .codex/skills/{new}/references/schemas/` | Bundle complete |
 
 **Example conversion table (sso-dev-flow → 5-stage Stage-Step):**
 

--- a/harness/references/skill-writing-guide.md
+++ b/harness/references/skill-writing-guide.md
@@ -40,7 +40,7 @@ skill-name/
 
 ## 1. Description Writing Patterns
 
-The description is the **only trigger mechanism** for a skill. The Codex CLI trigger router looks only at the `name` + `description` from `.agents/skills/*/SKILL.md` to decide whether to use a skill.
+The description is the **only trigger mechanism** for a skill. The Codex CLI trigger router looks only at the `name` + `description` from `.codex/skills/*/SKILL.md` to decide whether to use a skill.
 
 ### 1-1. Understanding the Trigger Mechanism
 
@@ -258,7 +258,7 @@ Do not guess when instructions are ambiguous or data conflicts arise. Explicitly
 
 ### 7-4. Procedural Skills Are Loaded Explicitly by the Orchestrator
 
-In Codex CLI, a skill is activated by the orchestrator reading it via `cat .agents/skills/{name}/SKILL.md` and injecting it into the prompt. When writing a skill that **references or reuses another skill**, specify the skill name and when it should be loaded.
+In Codex CLI, a skill is activated by the orchestrator reading it via `cat .codex/skills/{name}/SKILL.md` and injecting it into the prompt. When writing a skill that **references or reuses another skill**, specify the skill name and when it should be loaded.
 
 ### 7-5. Orchestrator Skill Writing Rules (Required, drift prevention)
 
@@ -286,26 +286,27 @@ When writing orchestrator skills, **do not fall back to a flat "Step 1~N" list**
 
 **Orchestrator Skill Directory Required Bundle (at time of creation):**
 
-New orchestrator skills read their own `references/schemas/` at runtime (`harness` is a meta-skill and is not activated at runtime), so the following **9 items** must always be bundled. The SoT is `harness/references/schemas/` — copy as-is when creating new skills.
+New orchestrator skills read their own `references/schemas/` at runtime (`codex-harness` is a meta-skill and is not activated at runtime), so the following **10 items** must always be bundled. The SoT is `codex-harness/references/schemas/` — copy as-is when creating new skills.
 
 ```
-{project}/.agents/skills/{name}-orchestrator/
+{project}/.codex/skills/{name}-orchestrator/
 ├── SKILL.md
 └── references/
     └── schemas/
-        ├── task.schema.json                    ← copy from harness/references/schemas/
-        ├── checkpoint.schema.json              ← same
+        ├── task.schema.json                    ← copy from codex-harness/references/schemas/
+        ├── checkpoint.schema.json              ← same (SoT parsed by state.py at runtime)
         ├── workflow.template.md                ← same
         ├── findings.template.md                ← same
         ├── tasks.template.md                   ← same
         ├── models.md                           ← model ID SoT (required reference when creating agents)
-        ├── agent-worker.template.toml            ← worker agent creation standard (TOML)
+        ├── agent-worker.template.toml          ← worker agent creation standard (TOML)
         ├── agent-orchestrator.template.md      ← orchestrator skill creation standard
-        └── agent-state-manager.template.toml   ← state manager agent creation standard (optional)
+        ├── agent-state-manager.template.toml   ← state manager agent creation standard (optional)
+        └── state.py                            ← state manager CLI (deployed to _workspace/state.py at init)
 ```
 
-> **Bundle Validation:** Step 1.3 reads all 9 items in `references/schemas/` via shell `cat`, so any missing file causes immediate runtime failure. Immediately after skill creation, confirm all 9 files exist with `ls .agents/skills/{name}/references/schemas/`.
-> **Update Policy:** When `harness` `references/schemas/` changes, propagate the same change to all derived orchestrator skills (drift prevention). The `_workspace/_schemas/` in an in-progress workspace is a snapshot and should be preserved.
+> **Bundle Validation:** Step 1.3 reads all 10 items in `references/schemas/` via shell `cat`, so any missing file causes immediate runtime failure. Immediately after skill creation, confirm all 10 files exist with `ls .codex/skills/{name}/references/schemas/`.
+> **Update Policy:** When `codex-harness` `references/schemas/` changes, propagate the same change to all derived orchestrator skills (drift prevention). The `_workspace/_schemas/` in an in-progress workspace is a snapshot and should be preserved.
 
 > **Full bundle example (case integrating all outputs of one domain):** See `references/examples/full-bundle/sso-style.md`. A canonical package that simultaneously creates all 5 files: orchestrator SKILL.md + workflow.md + findings.md + tasks.md + checkpoint.json.
 
@@ -330,7 +331,7 @@ The procedure for converting non-standard orchestrator skills previously written
 | **M3. Pattern Assignment** | Assign 1 of the 7 patterns to each Step (`pipeline`·`fan_out_fan_in`·`expert_pool`·`producer_reviewer`·`supervisor`·`hierarchical`·`handoff`). Free notation ("sequentially") is prohibited. | Passes enum check | Mapping table with pattern column added |
 | **M4. Termination Condition Conversion** | Natural language → verifiable predicate. `"QA approval"` → `verdict=PASS in qa_verdict.json`, `"when done"` → `status=done in task_*.json`, `"sufficiently"` → `iterations ≥ N`. | Passes `orchestrator-template.md` Step 1.8 whitelist | Verified predicate column added |
 | **M5. Create 5 Output Files** | Based on the mapping table, create `workflow.md` + `findings.md` + `tasks.md` + `checkpoint.json`. New SKILL.md body adopts the `references/orchestrator-template.md` skeleton. | `workflow.md` has 0 missing fields out of 6, cycle validation passes | New 5 files |
-| **M6. Bundle schemas/** | Copy 9 items from `harness/references/schemas/` to new skill's `references/schemas/` (task/checkpoint/workflow/findings/tasks schemas + models.md + agent-worker.template.toml + agent-orchestrator.template.md + agent-state-manager.template.toml). | 9 files exist at `ls .agents/skills/{new}/references/schemas/` | Bundle complete |
+| **M6. Bundle schemas/** | Copy 10 items from `codex-harness/references/schemas/` to new skill's `references/schemas/` (task + checkpoint schemas + workflow/findings/tasks templates + models.md + agent-worker.template.toml + agent-orchestrator.template.md + agent-state-manager.template.toml + state.py). | 10 files exist at `ls .codex/skills/{new}/references/schemas/` | Bundle complete |
 
 **Example conversion table (sso-dev-flow → 5-stage Stage-Step):**
 

--- a/harness/references/stage-step-guide.md
+++ b/harness/references/stage-step-guide.md
@@ -1,0 +1,234 @@
+# Stage-Step Workflow Guide
+
+A guide defining the workflow structure for all harnesses. Declares the Stage-Step hierarchy in `_workspace/workflow.md` so that the orchestrator executes deterministically. Referenced in SKILL.md Step 2 or Step 5.
+
+---
+
+## Table of Contents
+
+1. [Concept Definitions](#1-concept-definitions)
+2. [workflow.md Specification](#2-workflowmd-specification)
+3. [checkpoint.json Schema](#3-checkpointjson-schema)
+4. [Step and Stage Transition Protocol](#4-step-and-stage-transition-protocol)
+5. [Verifiable Exit Condition Patterns](#5-verifiable-exit-condition-patterns)
+6. [Per-Step Agent Access Control](#6-per-step-agent-access-control)
+7. [Workflow Examples (5 Types)](#7-workflow-examples-5-types)
+8. [Test Scenarios (6 Types)](#8-test-scenarios-6-types)
+
+---
+
+## 1. Concept Definitions
+
+### Three-Level Hierarchy Model (Stage = Parent Issue, Step = Sub-issue)
+
+Every harness is composed of a **Stage → Step → Agent** three-level hierarchy. **This directly borrows from Jira's issue hierarchy (Issue → Sub-issue).**
+
+| Level | Jira Equivalent | Meaning | Transition Authority | Responsibility |
+|------|-----------|------|---------|------|
+| **Stage** | **Parent Issue (Issue / Story)** | A group of work items constituting a deliverable unit | User approval gate | Groups multiple sub-issues (Steps) to complete one deliverable. Transitions to the next Stage only after approval. |
+| **Step** | **Sub-issue (Sub-issue)** | A single work item within a Stage | Orchestrator automatic | **1 Step = 1 pattern**. Holds 1 of the 7 core patterns + active agents + exit condition. Transitions automatically. |
+| **Agent** | Task assignee | Step executor | Called within Step | Performs actual work. Access is controlled by the `active agents` list in the Step. |
+
+> **Core semantics (borrowed from Jira):** Stage is the **parent issue**, Step is the **sub-issue**. A Stage itself is not a direct execution unit; the parent issue (Stage) completes only when all sub-issues (Steps) are done. The user approval gate operates at the parent issue (Stage) level — the same flow as getting PM approval before marking a Jira Story as Done.
+
+> **Workflow ↔ Jira mapping example:**
+> - Jira Story "Payment Module SSO Integration" = one Stage in workflow.md (`Stage 1: integrate-sso`)
+> - Jira Sub-issue "Implement OAuth Callback Handler" = one Step in that Stage (`Step 2: implement-callback`)
+> - Sub-issue assignee = `active agents` in the Step
+
+Declare the Stage·Step structure in `_workspace/workflow.md`. The orchestrator always reads this file to determine the current stage and step.
+
+> **workflow.md is a static declaration.** It is created once in Step 1 and the Stage·Step structure does not change during execution. When agent selection is determined dynamically (e.g., `[@selected_expert]`), that notation is a **runtime symbolic placeholder** — when the orchestrator enters that Step, it reads the `shared_variables.selected_expert` field from `checkpoint.json` and substitutes the actual agent name. The workflow.md file itself is not modified.
+>
+> **Naming convention distinction:** JSON keys in `shared_variables` use `selected_expert` (English snake_case). Symbolic placeholders in workflow.md use `[@selected_expert]` (can be any readable label). The two names do not need to match — the orchestrator reads the `selected_expert` value and substitutes it at the `[@selected_expert]` location, so the name format is at the implementer's discretion.
+
+### Simple vs. Multi-Stage
+
+| Type | Stage (Parent Issue) Count | Step (Sub-issue) Count | Usage Condition |
+|------|---------------------|--------------------|----------|
+| **Simple** | 1 (`main`) | 1 (`main`) | Completed with a single sub-issue and single pattern |
+| **Multi-stage** | 2 or more, or 2+ Steps in one Stage | Multiple | Parent issue is decomposed into multiple sub-issues + exit conditions are verifiable + user can intervene at parent issue (Stage) gates |
+
+---
+
+## 2. workflow.md Specification
+
+`_workspace/workflow.md` is required for all harnesses. Declares the Stage·Step structure; the orchestrator reads it every cycle.
+
+> When writing, substitute variables in `_workspace/_schemas/workflow.template.md` (a copy synchronized in Step 1.3) and `apply_patch` to `_workspace/workflow.md`.
+
+### Simple Workflow Example (1 stage + 1 step)
+
+> **Naming note:** Placeholders like `main` or `step1` are prohibited. Stage and Step names must be kebab-case carrying the deliverable meaning (Jira title convention). No exceptions, even for single Stage and single Step cases.
+
+```markdown
+<!-- Reference pattern: fan_out_fan_in (no effect on execution, for documentation purposes) -->
+
+## Stage Definitions
+
+### Stage 1: blog-post
+- Exit condition: all steps complete
+- Next stage: done
+- User approval gate: none
+
+#### Step 1: parallel-research
+- Pattern: fan_out_fan_in
+- Active agents: [@researcher-a, @researcher-b, @researcher-c]
+- Exit condition: all `_workspace/tasks/task_*.json` have status=done
+- Next step: done
+- Max iterations: 1
+```
+
+### Multi-Stage Workflow Example (2 stages + multiple steps)
+
+```markdown
+<!-- Reference pattern: fan_out_fan_in → producer_reviewer (no effect on execution, for documentation purposes) -->
+
+## Stage Definitions
+
+### Stage 1: gather
+- Exit condition: all steps complete
+- Next stage: refine
+- User approval gate: required
+
+#### Step 1: research
+- Pattern: fan_out_fan_in
+- Active agents: [@researcher-trend, @researcher-data]
+- Exit condition: `_workspace/research/task_trend.json`, `task_data.json` all have status=done
+- Next step: done
+- Max iterations: 1
+
+### Stage 2: refine
+- Exit condition: all steps complete
+- Next stage: done
+- User approval gate: none (last stage)
+
+#### Step 1: draft-review
+- Pattern: producer_reviewer
+- Active agents: [@writer, @editor]
+- Exit condition: verdict=PASS in `_workspace/editor_verdict.json`
+- Next step: done
+- Max iterations: 3
+```
+
+### workflow.md Field Writing Rules
+
+| Field | Writing Rule | Example |
+|------|----------|------|
+| `Active agents` | Declared only in Step blocks. Format `@name`, must match `.codex/agents/{name}.toml` | `[@writer, @editor]` |
+| `Exit condition` | Only verifiable predicates allowed (file existence, JSON field value, numeric threshold) | all `task_*.json` have status=done |
+| `Next step` | Next step name or `done` | `architecture` / `done` |
+| `Next stage` | Next stage name or `done` | `validate` / `done` |
+| `Max iterations` | Required for loop patterns (Producer-Reviewer, etc.) to prevent infinite loops | `3` |
+| Stage `Exit condition` | `all steps complete` or a specific verifiable condition | `all steps complete` |
+
+---
+
+## 3. checkpoint.json Schema
+
+> **The canonical source is `references/orchestrator-template.md` — "Data Persistence Protocol" section.** Refer to that file for full field descriptions and examples.
+
+Additional fields needed in the Stage-Step workflow: `current_stage`, `current_step`, `active_pattern`, `stage_history`, `step_history`, `stage_artifacts`. All are included in the canonical schema.
+
+---
+
+## 4. Step and Stage Transition Protocol
+
+### Step Transition vs. Stage Transition Comparison
+
+| Item | Transition Authority | User Approval | checkpoint.json Update |
+|------|---------|-----------|---------------------|
+| **Step transition** | Orchestrator automatic | Not required | `current_step`, `step_history`, `handoff_chain: []` |
+| **Stage transition** | Orchestrator after user approval | **Required** | `current_stage`, `current_step` (first Step of next Stage), `stage_history`, `handoff_chain: []` |
+
+### Step Transition Protocol (Automatic)
+
+The internal loop the orchestrator performs every cycle. Order must be strictly followed.
+
+1. Read `current_stage`, `current_step` from `checkpoint.json`.
+2. Read the exit condition from the matching step block in `workflow.md`.
+3. Verify the exit condition (file scan, JSON field check).
+4. **Not met** → Call the active agents for the current step pattern, then wait for the next cycle.
+5. **Met** → Check `next step`:
+   - Next step name → update checkpoint.json immediately → allow entry into the next step in the same turn.
+   - `done` → proceed to Stage transition protocol.
+
+### Stage Transition Protocol (Approval Required)
+
+1. Confirm the last step of the current stage is `done`.
+2. Report to the user in the format below.
+3. **Approved:** Update checkpoint.json (current_stage, current_step, stage_history, handoff_chain: []).
+4. **Rejected:** No change to checkpoint.json → ask "Which part would you like to revise?" → ATOMIC rollback to the specified step:
+   - Update checkpoint.json: `current_step` ← specified step, `active_pattern` ← that step's pattern, `handoff_chain: []`, `last_updated` ← NOW().
+   - Delete existing task files for that step's agents: `_workspace/tasks/task_{that_step_agents}_*.json`.
+5. **[Prohibited]** Do not call the next stage agents in the same response turn as the approval.
+6. **Re-entry:** User sends "continue" or similar → orchestrator re-runs Step 0 → detects `status: "in_progress"` + updated `current_stage`·`current_step` → enters Step 2 and immediately starts the first Step of the new Stage.
+
+### User Approval Gate Format
+
+```
+Stage {current stage} complete:
+  Step {step-1}: {exit condition} ✓
+  Step {step-2}: {exit condition} ✓
+
+Next Stage: {next stage}
+  Step list: [{step-1}, {step-2}]
+  First Step active agents: {agent list}
+  First Step exit condition: {condition}
+
+Proceed? [Y/N]
+```
+
+---
+
+## 5. Verifiable Exit Condition Patterns
+
+| Recommended (Verifiable) | Prohibited (LLM Arbitrary Interpretation) |
+|---|---|
+| All `_workspace/tasks/task_*.json` have status=done | "Gathered enough" |
+| verdict=PASS in `_workspace/critic_verdict.json` | "Review is satisfactory" |
+| score ≥ threshold in `_workspace/coverage.json` | "Quality is good" |
+| Specific file exists (`_workspace/integrated.md`) | "Integration is done" |
+| iterations ≥ max_iterations for that step in step_history | "Iterated enough" |
+
+---
+
+## 6. Per-Step Agent Access Control
+
+Codex CLI agent frontmatter does not support custom fields. Access control is performed via the **`active agents` list in the step block of workflow.md**.
+
+```
+Before calling an agent, verify:
+1. Find the current_stage → current_step block in workflow.md.
+2. Read the `active agents` list for that step.
+3. If the target is in the list → allow the call.
+4. If not in the list → hold the call; report to the user if needed:
+   "@writer is not an active agent in the current step ({current_stage}/{current_step})."
+```
+
+---
+
+## 7. Workflow Examples (5 Types)
+
+| # | Domain | Pattern Combination | Stage (Parent Issue) Count | Step (Sub-issue) Count | File |
+|---|--------|----------|---------|---------|------|
+| 1 | Blog post writing | gather=fan_out_fan_in → write=producer_reviewer | 2 | 2 | [examples/step/01-blog-post.md](examples/step/01-blog-post.md) |
+| 2 | Issue triage | triage=(expert_pool+pipeline) → review=producer_reviewer | 2 | 3 | [examples/step/02-issue-triage.md](examples/step/02-issue-triage.md) |
+| 3 | Architecture design | design=pipeline(3 Steps) → validate=fan_out_fan_in | 2 | 4 | [examples/step/03-architecture-design.md](examples/step/03-architecture-design.md) |
+| 4 | Feature implementation (single Stage, multiple Tasks) | feature-build = research(fan_out) → implement(pipeline) → review(producer_reviewer) | 1 | 3 | [examples/step/04-single-stage-multi-task.md](examples/step/04-single-stage-multi-task.md) |
+| 5 | Product lifecycle (multiple Stages, multiple Tasks) | discovery(fan_out+pipeline) → build(pipeline+supervisor+producer_reviewer) → validate(fan_out+pipeline) | 3 | 7 | [examples/step/05-multi-stage-multi-task.md](examples/step/05-multi-stage-multi-task.md) |
+
+---
+
+## 8. Test Scenarios (6 Types)
+
+Detailed configuration, expected behavior, and pass criteria: [examples/step/test-scenarios.md](examples/step/test-scenarios.md)
+
+| # | Purpose | Key Verification Point | Pass Criteria |
+|---|------|----------------|----------|
+| 1 | Simple workflow.md structure verification | Whether Stage 1 + Step 1 are created | No Stage 2 block + `main/main` structure |
+| 2 | Multi-stage workflow trigger | Automatic multi-stage selection from utterance | 2 or more Stage blocks exist |
+| 3 | Step exit condition not met → transition blocked | Prohibit entering the next Step when tasks are incomplete | Stage 2 agent call does not occur |
+| 4 | Step automatic transition (no approval needed) | Transition without user intervention when exit condition is met | Next Step agent is called without an approval request |
+| 5 | Stage transition gate (approval required) | Approval gate activates when Stage is complete | Approval request occurs + next Stage agent not called |
+| 6 | Per-step agent access control | Block calls to agents not in the current Step list | Inactive agent call does not occur |

--- a/harness/references/team-examples.md
+++ b/harness/references/team-examples.md
@@ -1,0 +1,80 @@
+# Subagent Orchestration Real-World Examples (Codex CLI)
+
+Real-world examples for 5 architecture patterns. **In the Codex CLI environment, direct communication between subagents is not possible**, so all team communication is brokered by the main agent via `_workspace/findings.md` and `_workspace/tasks.md`.
+
+> **Note:** Team APIs such as `TeamCreate`, `SendMessage`, and `TaskCreate` from Claude Code do not exist in Codex CLI. Subagent invocation is performed via **@agent-name directives**, and parallel execution is implemented as consecutive calls within a single response turn.
+> **Stage-Step structure required:** The orchestrator in every example reads `checkpoint.json` (`status`, `current_stage`, `current_step`) in Step 0 to determine the execution mode, and creates `workflow.md` in Step 1 (Resume mode reads the existing file). Example 1's orchestrator workflow is the reference implementation; all other examples apply the same pattern.
+
+---
+
+## Example Index
+
+| #   | Pattern               | Domain Example       | Agent Count | Key Characteristics                                                     | File                                                                               |
+| --- | --------------------- | -------------------- | ----------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| 1   | Fan-out/Fan-in        | Research Team        | 4           | Parallel investigation then consolidation, data conflict arbitration    | [examples/team/01-fan-out-fan-in.md](examples/team/01-fan-out-fan-in.md)           |
+| 2   | Producer-Reviewer     | Webtoon Production   | 2           | PASS/FIX/REDO loop, full agent file examples included                   | [examples/team/02-producer-reviewer.md](examples/team/02-producer-reviewer.md)     |
+| 3   | Supervisor            | Code Migration       | 1+N         | Runtime dynamic task assignment, tasks.md claim mechanism               | [examples/team/03-supervisor.md](examples/team/03-supervisor.md)                   |
+| 4   | Hierarchical          | Full-stack App Dev   | 5           | 2-level delegation, team lead intermediate coordination, full agent file examples included | [examples/team/04-hierarchical.md](examples/team/04-hierarchical.md)               |
+| 5   | Handoff + Persistence | System Debugging     | 4           | [NEXT_AGENT] parsing, large log resumption                              | [examples/team/05-handoff-persistence.md](examples/team/05-handoff-persistence.md) |
+
+### Pattern Selection Guide
+
+| Situation                                                            | Recommended Pattern             |
+| -------------------------------------------------------------------- | ------------------------------- |
+| Run independent tasks in parallel then consolidate                   | Fan-out/Fan-in (Example 1)      |
+| Improve generation quality through iterative review                  | Producer-Reviewer (Example 2)   |
+| Process large volumes of homogeneous tasks, track progress in real time | Supervisor (Example 3)       |
+| Heterogeneous domain team, 2-level specialization delegation needed  | Hierarchical (Example 4)        |
+| Unknown root cause, expert selection depends on analysis results     | Handoff (Example 5)             |
+| Processing large data with pause/resume needed                       | Handoff + Persistence (Example 5) |
+
+---
+
+## Output Pattern Summary
+
+### Agent Definition Files
+
+- Path: `.codex/agents/{agent-name}.toml` (project) or `~/.codex/agents/{agent-name}.toml` (user).
+- Required TOML fields: `name`, `description` (assertive, including follow-up keywords), `model` (actual ID: see `references/schemas/models.md`), `sandbox_mode` (per role), `model_reasoning_effort` (per role: `low` · `medium` · `high` · `xhigh` — per `references/schemas/models.md`).
+- Required sections: core role, working principles, input/output protocol, collaboration protocol (Codex CLI), error handling.
+
+### findings.md Standard Section Structure
+
+Standard sections initialized by the orchestrator in Phase 1:
+
+| Section Name          | Purpose                                                           | Primarily Used Pattern              |
+| --------------------- | ----------------------------------------------------------------- | ----------------------------------- |
+| `[Key Insights]`      | Core summary of research and analysis results                     | Fan-out/Fan-in                      |
+| `[Key Keywords]`      | Common keywords for injection into agent prompts                  | Fan-out/Fan-in                      |
+| `[Shared Vars/Paths]` | Shared paths, API contracts, and persistence resume points between agents | All patterns               |
+| `[Data Conflicts]`    | Records conflicting information between agent outputs             | Fan-out/Fan-in, Supervisor, Handoff |
+| `[Change Requests]`   | Rework instructions                                               | Producer-Reviewer                   |
+| `[Next Step Guide]`   | Guide for what the next agent should focus on                     | Pipeline, Hierarchical              |
+
+Initialize only the sections needed for the pattern. Omit unused sections.
+
+### tasks.md Base Schema
+
+Task list format registered by the orchestrator in Phase 1:
+
+```
+| ID | Task Name | Assigned Agent | Priority | Complexity | Status |
+|----|-----------|----------------|----------|------------|--------|
+| 1  | ...       | @migrator-1    | High     | Large      | Todo   |
+```
+
+- **Status values**: `Todo` → `In-Progress` → `Done` | `Blocked`
+- **Main agent updates only**: Workers write only to `task_{agent}_{id}.json`. The main agent collects and atomically updates tasks.md.
+- **Blocked items**: Request user confirmation, then mark the relevant row status as `Blocked`.
+
+### Skill File Structure
+
+- Path: `.agents/skills/{skill-name}/SKILL.md`.
+- Large knowledge bases are split into `references/` (Progressive Disclosure).
+
+### Orchestrator Skill
+
+- Top-level skill that coordinates the entire team. Covers Phase 0 (re-run detection) through Phase 5 (preservation and reporting).
+- Template: see `references/orchestrator-template.md`.
+- No direct communication between subagents — all collaboration is brokered via `findings.md`, `tasks.md`, and `checkpoint.json`.
+- `_workspace/workflow.md` Stage-Step declaration in Phase 1; read every cycle to call only the `active agents` for the current step. On agent failure: maximum 2 retries (3 total) → if unresolved, `Blocked` + request user confirmation. Arbitrary skipping is strictly prohibited.

--- a/harness/references/team-examples.md
+++ b/harness/references/team-examples.md
@@ -69,7 +69,7 @@ Task list format registered by the orchestrator in Phase 1:
 
 ### Skill File Structure
 
-- Path: `.agents/skills/{skill-name}/SKILL.md`.
+- Path: `.codex/skills/{skill-name}/SKILL.md`.
 - Large knowledge bases are split into `references/` (Progressive Disclosure).
 
 ### Orchestrator Skill

--- a/harness/references/usage-examples.md
+++ b/harness/references/usage-examples.md
@@ -1,6 +1,6 @@
-# Use Cases: harness Trigger Utterance → Processing Path Catalog
+# Use Cases: codex-harness Trigger Utterance → Processing Path Catalog
 
-A catalog of **8 practical utterance patterns** and the processing path for each utterance (mode branching → pattern selection → workflow.md structure → artifacts) when calling `harness` to build, extend, or operate a harness. Use this as a reference by matching the closest scenario when a new domain is received.
+A catalog of **8 practical utterance patterns** and the processing path for each utterance (mode branching → pattern selection → workflow.md structure → artifacts) when calling `codex-harness` to build, extend, or operate a harness. Use this as a reference by matching the closest scenario when a new domain is received.
 
 > **Reading order:** §1 Utterance → Mode mapping → §2 8 Scenarios (by domain) → §3 Non-trigger utterances (false-positive prevention) → §4 Phase application guide.
 
@@ -8,7 +8,7 @@ A catalog of **8 practical utterance patterns** and the processing path for each
 
 ## 1. Utterance → Mode Mapping
 
-`harness` branches into a mode at Phase 0 immediately after the trigger (see SKILL.md Phase 0). Mode by utterance pattern:
+`codex-harness` branches into a mode at Phase 0 immediately after the trigger (see SKILL.md Phase 0). Mode by utterance pattern:
 
 | Utterance Pattern                                                               | Mode                   | Entry Phase                                            | Representative Keywords                                |
 | ----------------------------------------------------------------------- | ---------------------- | ----------------------------------------------------- | ------------------------------------------ |
@@ -149,7 +149,7 @@ A catalog of **8 practical utterance patterns** and the processing path for each
 
 ## 3. Non-Trigger Utterances (False-Positive Prevention)
 
-The following utterances **do not call harness**. Respond directly or call another skill.
+The following utterances **do not call codex-harness**. Respond directly or call another skill.
 
 | Utterance                               | Reason                              | Handling                                                                               |
 | ---------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------- |
@@ -167,7 +167,7 @@ The following utterances **do not call harness**. Respond directly or call anoth
 
 | Mode          | Phases Executed                                                 | Key Artifacts                                                                                                                                               |
 | ------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| New Build     | Phase 1 ~ Phase 6 (full)                                   | `.codex/agents/*.toml`, `.agents/skills/{orchestrator}/SKILL.md`, `AGENTS.md`, `_workspace/_schemas/`, workflow.md, findings.md, tasks.md, checkpoint.json |
+| New Build     | Phase 1 ~ Phase 6 (full)                                   | `.codex/agents/*.toml`, `.codex/skills/{orchestrator}/SKILL.md`, `AGENTS.md`, `_workspace/_schemas/`, workflow.md, findings.md, tasks.md, checkpoint.json |
 | Existing Extension     | Determined by expansion-matrix.md matrix (typically Phase 2·3·5·6-6) | Changed files only + `AGENTS.md` change history                                                                                                  |
 | Operations/Maintenance | Phase 0 → evolution-protocol.md                            | Audit report + drift corrections                                                                                                                  |
 | Partial Re-run   | Phase 0 (checkpoint rewind) → from Phase 2                  | Affected artifacts only                                                                                                                         |

--- a/harness/references/usage-examples.md
+++ b/harness/references/usage-examples.md
@@ -1,6 +1,6 @@
-# Use Cases: codex-harness Trigger Utterance → Processing Path Catalog
+# Use Cases: harness Trigger Utterance → Processing Path Catalog
 
-A catalog of **8 practical utterance patterns** and the processing path for each utterance (mode branching → pattern selection → workflow.md structure → artifacts) when calling `codex-harness` to build, extend, or operate a harness. Use this as a reference by matching the closest scenario when a new domain is received.
+A catalog of **8 practical utterance patterns** and the processing path for each utterance (mode branching → pattern selection → workflow.md structure → artifacts) when calling `harness` to build, extend, or operate a harness. Use this as a reference by matching the closest scenario when a new domain is received.
 
 > **Reading order:** §1 Utterance → Mode mapping → §2 8 Scenarios (by domain) → §3 Non-trigger utterances (false-positive prevention) → §4 Phase application guide.
 
@@ -8,7 +8,7 @@ A catalog of **8 practical utterance patterns** and the processing path for each
 
 ## 1. Utterance → Mode Mapping
 
-`codex-harness` branches into a mode at Phase 0 immediately after the trigger (see SKILL.md Phase 0). Mode by utterance pattern:
+`harness` branches into a mode at Phase 0 immediately after the trigger (see SKILL.md Phase 0). Mode by utterance pattern:
 
 | Utterance Pattern                                                               | Mode                   | Entry Phase                                            | Representative Keywords                                |
 | ----------------------------------------------------------------------- | ---------------------- | ----------------------------------------------------- | ------------------------------------------ |
@@ -149,7 +149,7 @@ A catalog of **8 practical utterance patterns** and the processing path for each
 
 ## 3. Non-Trigger Utterances (False-Positive Prevention)
 
-The following utterances **do not call codex-harness**. Respond directly or call another skill.
+The following utterances **do not call harness**. Respond directly or call another skill.
 
 | Utterance                               | Reason                              | Handling                                                                               |
 | ---------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------- |

--- a/harness/references/usage-examples.md
+++ b/harness/references/usage-examples.md
@@ -1,0 +1,187 @@
+# Use Cases: harness Trigger Utterance → Processing Path Catalog
+
+A catalog of **8 practical utterance patterns** and the processing path for each utterance (mode branching → pattern selection → workflow.md structure → artifacts) when calling `harness` to build, extend, or operate a harness. Use this as a reference by matching the closest scenario when a new domain is received.
+
+> **Reading order:** §1 Utterance → Mode mapping → §2 8 Scenarios (by domain) → §3 Non-trigger utterances (false-positive prevention) → §4 Phase application guide.
+
+---
+
+## 1. Utterance → Mode Mapping
+
+`harness` branches into a mode at Phase 0 immediately after the trigger (see SKILL.md Phase 0). Mode by utterance pattern:
+
+| Utterance Pattern                                                               | Mode                   | Entry Phase                                            | Representative Keywords                                |
+| ----------------------------------------------------------------------- | ---------------------- | ----------------------------------------------------- | ------------------------------------------ |
+| "Build/configure/design a codex harness for X domain, create a codex agent team" | **New Build**          | Phase 1 → Phase 6 (full)                                | "configure", "create", "design", "build", "setup" |
+| "Add Y feature/agent to the existing harness"                                | **Existing Extension**          | `expansion-matrix.md` matrix entry → partial Phase execution | "add", "extend", "supplement", "new agent"    |
+| "Inspect/audit/report status of the harness"                                        | **Operations/Maintenance**      | `evolution-protocol.md` workflow                    | "inspect", "audit", "status", "drift", "sync"  |
+| "Revise/re-run/supplement previous results"                                            | **Operations (Partial Re-run)** | Phase 0 branches based on checkpoint.json status               | "re-run", "revise", "previous results", "again"      |
+
+> **Naming convention (Jira title convention) enforced:** Once the domain is determined, all Stage·Step names must be deliverable noun phrase kebab-case (e.g., `sso-integration`, `requirements-gathering`). Placeholders like `main`·`step1` are blocked by the workflow.md schema validator (see orchestrator-template.md).
+
+---
+
+## 2. Eight Scenarios
+
+### Scenario A: SSO Authentication Feature Build (Multi-stage, pipeline + producer_reviewer)
+
+- **Utterance:** "Add SSO authentication to the Go backend. From design through implementation and QA."
+- **Mode:** New Build
+- **Pattern selection rationale:** Analysis → design → implementation are sequentially dependent (pipeline) + quality gate iteration needed for implementation artifacts (producer_reviewer).
+- **Stage/Step structure:**
+  ```
+  Stage 1: research-plan        (user approval gate: required)
+    Step 1: requirements-gathering   pattern=pipeline
+    Step 2: architecture-design      pattern=pipeline
+  Stage 2: implementation-review     (last stage)
+    Step 1: code-and-review-loop     pattern=producer_reviewer (max 3)
+  ```
+- **Agents:** `@sso-researcher`, `@sso-planner`, `@go-developer`, `@qa-reviewer`
+- **Artifacts:** `_workspace/sso-integration/{research.md, plan.md, qa_verdict.json}`, `src/auth/*.go`
+- **Reference example:** `references/examples/full-bundle/sso-style.md`
+
+### Scenario B: Large-Scale Code Migration (Single stage, supervisor)
+
+- **Utterance:** "Python 2 → 3 migration. Batch process 80 files."
+- **Mode:** New Build
+- **Pattern selection rationale:** N homogeneous tasks batched dynamically at runtime → supervisor (main claims from tasks.md).
+- **Stage/Step structure:**
+  ```
+  Stage 1: python3-migration
+    Step 1: batch-migrate    pattern=supervisor    active agents: [@migrator-1, @migrator-2, @migrator-3]
+    Step 2: integration-test pattern=pipeline       active agents: [main]
+  ```
+- **Agents:** `@migration-supervisor` (task registration), `@migrator-{1..N}` (worker pool)
+- **Artifacts:** `_workspace/python3-migration/tasks.md`, migrated files, `final/migration_report.md`
+- **Reference example:** `references/examples/team/03-supervisor.md`
+
+### Scenario C: Content Creation + Review Loop (Single stage, producer_reviewer)
+
+- **Utterance:** "Draw one webtoon episode. Use an artist-editor loop."
+- **Mode:** New Build
+- **Pattern selection rationale:** Single deliverable + quality gate iteration (PASS/FIX/REDO).
+- **Stage/Step structure:**
+  ```
+  Stage 1: webtoon-episode
+    Step 1: produce-and-review   pattern=producer_reviewer (max 3)
+  ```
+- **Agents:** `@webtoon-artist`, `@webtoon-reviewer`
+- **Artifacts:** `_workspace/webtoon-episode/panels/*.png`, `review_report.md`, `final/episode.md`
+- **Reference example:** `references/examples/team/02-producer-reviewer.md`
+
+### Scenario D: Parallel Research + Integrated Report (Single stage, fan_out_fan_in)
+
+- **Utterance:** "Research 4 competitors simultaneously and create an integrated report."
+- **Mode:** New Build
+- **Pattern selection rationale:** N independent investigations in parallel + integration step.
+- **Stage/Step structure:**
+  ```
+  Stage 1: competitor-research
+    Step 1: parallel-scan   pattern=fan_out_fan_in   active agents: [@official, @media, @community, @background]
+    Step 2: synthesize      pattern=pipeline          active agents: [@report-writer]
+  ```
+- **Agents:** `@official`, `@media`, `@community`, `@background`, `@report-writer`
+- **Artifacts:** `_workspace/competitor-research/{task_*.json, final/research_report.md}`
+- **Reference example:** `references/examples/team/01-fan-out-fan-in.md`
+
+### Scenario E: Incident Analysis (handoff + persistence)
+
+- **Utterance:** "Analyze production DB timeouts. We have 100GB of logs."
+- **Mode:** New Build
+- **Pattern selection rationale:** The next specialist is determined dynamically based on analysis results (handoff) + must support interruption and resumption with large-volume logs (persistence).
+- **Stage/Step structure:**
+  ```
+  Stage 1: incident-resolution
+    Step 1: triage            pattern=handoff           active agents: [@incident-triage]
+    Step 2: targeted-fix      pattern=producer_reviewer active agents: [dynamically determined — handoff_chain]
+  ```
+- **Agents:** `@incident-triage`, `@db-fixer`, `@network-fixer`, `@app-fixer`
+- **Artifacts:** `_workspace/incident-resolution/{handoff_chain, final/incident_report.md}`, checkpoint.json `handoff_chain` tracking
+- **Reference example:** `references/examples/team/05-handoff-persistence.md`
+
+### Scenario F: Full-Stack Feature Development (hierarchical)
+
+- **Utterance:** "Add a payment module. Run frontend, backend, and DB simultaneously."
+- **Mode:** New Build
+- **Pattern selection rationale:** Heterogeneous teams (frontend, backend, DB) + 2-level delegation (team lead → worker).
+- **Stage/Step structure:**
+  ```
+  Stage 1: payment-feature       (user approval gate: required — design review)
+    Step 1: cross-team-design    pattern=hierarchical   active agents: [@frontend-team-lead, @backend-team-lead]
+    Step 2: parallel-implement   pattern=hierarchical   active agents: [@ui-designer, @state-engineer, @api-designer, @db-engineer]
+  Stage 2: integration-validate
+    Step 1: cross-check          pattern=pipeline       active agents: [@project-architect]
+  ```
+- **Agents:** `@project-architect` (full design + validation), 2 team leads, 4 workers
+- **Artifacts:** `_workspace/payment-feature/{00_architecture.md, frontend/, backend/, final/integration_report.md}`
+- **Reference example:** `references/examples/team/04-hierarchical.md`
+
+### Scenario G: Adding a Security Validation Stage to an Existing Harness (Extension Mode)
+
+- **Utterance:** "Add a security validation Stage to the existing SSO harness. After QA."
+- **Mode:** Existing Extension
+- **Classification (expansion-matrix.md):** "Stage/Step Addition" — Stage count increases (2 → 3).
+- **Phases executed:** Phase 2 (workflow.md redesign) + Phase 3 (`@security-auditor` agent addition) + Phase 5 (orchestrator modification) + Phase 6-6 (resume flow test).
+- **Change result:**
+  ```
+  Stage 1: research-plan         (existing)
+  Stage 2: implementation-review (existing)
+  Stage 3: security-audit        (new, user approval gate: required)
+    Step 1: vulnerability-scan   pattern=fan_out_fan_in
+    Step 2: pen-test             pattern=pipeline
+  ```
+- **AGENTS.md change history entry is required.**
+- **Reference:** `references/expansion-matrix.md` Case D.
+
+### Scenario H: Partial Re-run of Previous Analysis Results (Operations/Partial Re-run)
+
+- **Utterance:** "Regenerate only plan.md from last week's SSO analysis. Keep research as is."
+- **Mode:** Operations (Partial Re-run)
+- **Phase 0 branching:** `checkpoint.json status: "completed"` detected → partial re-run mode.
+- **Processing:**
+  1. Confirm impact scope with the user (user input request).
+  2. Preserve `research.md` in `_workspace/sso-integration/`, delete `plan.md`.
+  3. Roll back checkpoint.json to `current_stage: "research-plan"`, `current_step: "architecture-design"`, `status: "in_progress"`.
+  4. Re-run from Step 2. Determine whether to re-run subsequent Stages after impact analysis.
+- **Reference:** `references/orchestrator-template.md` Step 0 (resume vs partial vs new) + `references/evolution-protocol.md`.
+
+---
+
+## 3. Non-Trigger Utterances (False-Positive Prevention)
+
+The following utterances **do not call harness**. Respond directly or call another skill.
+
+| Utterance                               | Reason                              | Handling                                                                               |
+| ---------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------- |
+| "Fix the bug in this function"              | Single code edit — no harness needed | Direct code editing                                                                     |
+| "Explain how to use channels in Go"    | Simple question                         | Direct response                                                                          |
+| "Run the tests once"              | Single command                         | Execute shell command directly                                                                  |
+| "Edit just one item in tasks.md"    | Single edit on an existing artifact             | Direct `apply_patch` (but if the main agent is responsible for the update, call the orchestrator) |
+| "Fix one line in the orchestrator code" | Single edit                         | Edit directly. But if the flow changes, enter operations mode (`evolution-protocol.md`)            |
+
+> **Borderline utterances (ambiguous):** "Add one agent" — adding a single agent enters **extension mode** (run only Phase 3·4·5). Determine Phases via the expansion-matrix.md matrix.
+
+---
+
+## 4. Phase Application Guide
+
+| Mode          | Phases Executed                                                 | Key Artifacts                                                                                                                                               |
+| ------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| New Build     | Phase 1 ~ Phase 6 (full)                                   | `.codex/agents/*.toml`, `.agents/skills/{orchestrator}/SKILL.md`, `AGENTS.md`, `_workspace/_schemas/`, workflow.md, findings.md, tasks.md, checkpoint.json |
+| Existing Extension     | Determined by expansion-matrix.md matrix (typically Phase 2·3·5·6-6) | Changed files only + `AGENTS.md` change history                                                                                                  |
+| Operations/Maintenance | Phase 0 → evolution-protocol.md                            | Audit report + drift corrections                                                                                                                  |
+| Partial Re-run   | Phase 0 (checkpoint rewind) → from Phase 2                  | Affected artifacts only                                                                                                                         |
+
+> **Common requirements regardless of mode:** (1) **Plan Mode entry** — `/plan` or `Shift+Tab`; always use Plan Mode first for complex multi-step tasks, (2) Phase 0 status audit, (3) Zero-Tolerance failure protocol (up to 2 retries (3 total) → Blocked + user input request), (4) Stage·Step naming convention validation.
+
+---
+
+## 5. When No Match Is Found
+
+If none of the 8 scenarios closely matches the domain:
+
+1. **Pattern decomposition:** Draw the task's dependency graph and match against the 7 core patterns (parallel / sequential / loop / dynamic assignment / heterogeneous delegation / dynamic routing).
+2. **Stage boundaries:** Set Stage boundaries at points where user approval is needed.
+3. **Combine similar scenarios:** E.g., serially combine scenarios like "parallel research (D) → SSO implementation (A)".
+4. **Agent design:** Apply interaction style + tool mapping from `references/agent-design-patterns.md`.
+5. **Request user input when uncertain.** Do not guess the harness structure — confirm with the user.


### PR DESCRIPTION
## Summary

Adds `harness`, a meta-skill for designing specialized subagent teams in the Codex CLI environment. It generates `.codex/agents/*.toml` agent definitions, `.agents/skills/` skill bundles, and `AGENTS.md` configuration from a user's domain description.

## What it adds

A single line under `### Development & Code Tools`, placed alphabetically between `codebase-recon` and `create-plan/`.

## Why it fits

- Trigger phrases work via the `description` frontmatter (e.g., "set up codex harness", "build codex harness for {domain}")
- Closest peers already listed as external repos: Bernstein, AuraKit, Vibe-Skills
- Self-contained — installs to `~/.codex/skills/` with no external services required

## Notable design points

- 7 orchestration patterns: pipeline, fan-out/fan-in, expert pool, producer-reviewer, supervisor, hierarchical, handoff
- Durable execution: workflows resume after context reset via `_workspace/checkpoint.json`
- Zero-dependency state manager that parses JSON Schema at runtime as the single source of truth
- Verifiable exit conditions — natural-language termination keywords are rejected at validation

## Tested

- Install verified via the standard `skill-installer` flow
- Works with the latest Codex CLI

## Checklist

- [x] Skill description states clearly when Codex should trigger it
- [x] Metadata fits within context limits (description ≤ 1024 chars)
- [x] Install instruction included
- [x] Alphabetical placement within section