### PR TITLE
fix: update default branch from 'main' to 'master' in install script

### DIFF
--- a/skill-installer/scripts/install-skill-from-github.py
+++ b/skill-installer/scripts/install-skill-from-github.py
@@ -15,7 +15,7 @@ import urllib.parse
 import zipfile
 
 from github_utils import github_request
-DEFAULT_REF = "main"
+DEFAULT_REF = "master"
 
 
 @dataclass


### PR DESCRIPTION
## Summary
Updates the DEFAULT_REF variable in the skill installer script to match the repository's actual primary branch.

## Context
The current ```install-skill-from-github.py``` script is hardcoded to use ```main``` as the default git reference. However, this repository uses ```master```, which causes the installer to fail with the following error:

```Error: error: pathspec 'main' did not match any file(s) known to git```

### Screenshot
<img width="563" height="173" alt="image" src="https://github.com/user-attachments/assets/75b46870-fde9-4c04-b75e-d3fc5fd416aa" />

## Changes
Changed DEFAULT_REF = "main" to DEFAULT_REF = "master" in ```skill-installer/scripts/install-skill-from-github.py```.

## Verification Results
Manual Test: Verified that running ```python skill-installer/scripts/install-skill-from-github.py --repo ComposioHQ/awesome-codex-skills --path [skill-name]``` now correctly fetches and installs the skill.