### PR TITLE
Add codex-ppt skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [support-ticket-triage/](./support-ticket-triage/) - Triage customer support tickets with categories, priority, next actions, and draft replies.
 - [file-organizer/](./file-organizer/) - Organize, rename, and tidy files to keep workspaces clean.
 - [paperjsx/](./paperjsx/) - Generate PPTX presentations, DOCX documents, XLSX spreadsheets, and PDF invoices/reports/charts from structured JSON. Runs locally via `@paperjsx/mcp-server` — no API key, no network calls.
+- [codex-ppt](https://github.com/ningzimu/codex-ppt-skill) - External repo: generate visually unified image-based PPTX decks from articles, reports, papers, course notes, or outlines with `gpt-image-2`, style references, speaker notes, and local PowerPoint assembly. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo ningzimu/codex-ppt-skill --path skills/codex-ppt --name codex-ppt`
 - [skill-share/](./skill-share/) - Share skills and reusable instructions across teammates.
 
 ### Communication & Writing


### PR DESCRIPTION
## Summary

This PR adds [`codex-ppt`](https://github.com/ningzimu/codex-ppt-skill) as an external Codex skill in the Productivity & Collaboration section.

`codex-ppt` turns articles, reports, papers, course notes, and outlines into visually unified PPTX decks. It uses Codex's image generation workflow to create each slide as a full 16:9 image, then assembles those slide images into a PowerPoint file with a local script.

## What the skill does

- Plans a deck outline from source material before slide generation.
- Guides Codex through style selection, including built-in reference styles such as clean professional, scientific defense, e-ink magazine, hand-drawn technical explainer, and dashboard.
- Generates one approved sample slide before producing the full deck.
- Creates one full-slide image per page with consistent visual language and varied layouts.
- Produces supporting `outline.md` and `speech.md` files.
- Assembles `slide_01.png`, `slide_02.png`, and other generated images into a `.pptx` file via `scripts/assemble_ppt.py`.

## Why it is designed specifically for Codex

- The skill is structured around Codex's skill trigger model with precise `SKILL.md` frontmatter and progressive disclosure through `references/`.
- The workflow explicitly uses Codex's built-in `gpt-image-2` image generation and editing capability for slide creation instead of treating Codex as a generic text prompt generator.
- It gives Codex operational steps for a full production loop: source understanding, outline planning, style confirmation, sample approval, batch image generation, visual QA, speaker-note generation, and local PPT assembly.
- It includes deterministic local tooling for the final assembly step, so Codex handles creative generation while the repeatable packaging step stays script-driven.

## Core advantages

- High visual consistency: every slide follows a unified style system rather than isolated one-off prompts.
- Strong presentation quality: the image-based workflow prioritizes finished visual composition over editable but plain PowerPoint objects.
- Reusable style library: reference files provide concrete visual directions while keeping the main skill body lean.
- Practical output: users receive a real `.pptx`, ordered slide images, an outline, and speaker notes.
- Clear installation path: the skill lives under `skills/codex-ppt`, so it can be installed with the standard `install-skill-from-github.py` command.

## Why it fits this list

This repository curates practical, reusable Codex skills. `codex-ppt` is not a single prompt or demo; it is a complete skill package with a standard `SKILL.md`, reference documents, requirements, and a local assembly script. It also complements existing document-generation entries such as `paperjsx`: `paperjsx` focuses on structured JSON-to-document generation, while `codex-ppt` focuses on visually rich, image-based presentation decks generated through Codex's native workflow.

## Validation

- Verified the install command works against `ningzimu/codex-ppt-skill` with a temporary destination.
- Confirmed the installed skill contains `SKILL.md`, `requirements.txt`, `scripts/assemble_ppt.py`, and style reference files.
