### PR TITLE
Add fast-codex-workflow to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [create-plan/](./create-plan/) - Quickly draft concise execution plans for coding tasks.
 - [deploy-pipeline/](./deploy-pipeline/) - End-to-end Stripe → Supabase → Vercel release pipelines with verify and rollback.
 - [Emdash Skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS: CF Workers + Hono + Angular + D1 + Stripe. One-line prompts to deployed SaaS with 94 reference docs, 18 agents, and Codex-native `.agents/skills/` support.
+- [fast-codex-workflow](https://github.com/Ridwannurudeen/fast-codex-workflow) - Operating loop for fast, focused coding — first-minute triage, narrow reads, smallest correct change, targeted verification. Replaces broad exploration and full-suite runs with explicit stop conditions and a short final-answer contract. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo Ridwannurudeen/fast-codex-workflow --path skills/fast-codex-workflow --name fast-codex-workflow`
 - [gh-address-comments/](./gh-address-comments/) - Address review or issue comments on the open GitHub PR for the current branch using `gh`.
 - [gh-fix-ci/](./gh-fix-ci/) - Inspect failing GitHub Actions checks, summarize failures, and propose fixes.
 - [mcp-builder/](./mcp-builder/) - Build and evaluate MCP servers with best practices and an evaluation harness.


### PR DESCRIPTION
## Summary

Adds [fast-codex-workflow](https://github.com/Ridwannurudeen/fast-codex-workflow) to the Development & Code Tools list. It is an operating-loop skill that enforces first-minute triage, narrow reads, smallest correct change, and targeted verification — i.e., the situations where Codex over-explores, runs the full suite too early, or drifts into adjacent cleanup on routine tasks.

## Where the entry sits

In `### Development & Code Tools`, alphabetically between `Emdash Skills` and `gh-address-comments`, matching the existing externally-hosted format (`[name](url) - description. Install: <python skill-installer command>`).

## Skill highlights

- v0.2.1 release, MIT licensed
- CI green on `ubuntu-latest` + `windows-latest`: schema validator, shellcheck, end-to-end install/uninstall smoke tests with sha256 idempotency, no-BOM, and stale-file assertions
- Description (~370 chars) lists explicit positive **and** negative triggers so it does not crowd out other skills (skips full audits, security reviews, production migrations)
- `references/playbook.md` (lazy-loaded task recipes + verification budget) and `references/examples.md` (three concrete before/after transcripts) keep `SKILL.md` lean inside Codex's ~8000-char initial-list budget
- Default install does not modify `AGENTS.md`; an opt-in `--integrate-global` flag is available for users who want always-on fast mode

## Test plan

- [ ] List entry renders correctly under Development & Code Tools
- [ ] Repo link resolves to https://github.com/Ridwannurudeen/fast-codex-workflow
- [ ] Install command pattern matches sibling entries (`brooks-lint`, `codebase-recon`, etc.)