### PR TITLE
Add companion-memory skill plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [brand-guidelines/](./brand-guidelines/) - Apply OpenAI/Codex brand colors and typography to artifacts.
 - [agent-deep-links/](./agent-deep-links/) - Build and validate deep links for Codex, Cursor, and VS Code with Slack-safe formatting and fallback guidance.
 - [canvas-design/](./canvas-design/) - Generate structured canvas layouts and design artifacts.
+- [companion-memory](https://github.com/zhyue365/companion-memory) - External repo: local-first Codex relationship memory plugin with MCP stdio tools, SQLite + FTS5/vector recall, sensitive recall opt-in, and dry-run forgetting.
 - [image-enhancer/](./image-enhancer/) - Upscale and refine images with configurable presets.
 - [slack-gif-creator/](./slack-gif-creator/) - Generate GIFs for Slack with captions and styling.
 - [theme-factory/](./theme-factory/) - Create reusable theme tokens and palettes.


### PR DESCRIPTION
Adds companion-memory, a local-first Codex relationship memory plugin/skill bundle.\n\nHighlights:\n- MCP stdio tools for persona and relationship memory operations\n- SQLite local storage with FTS5 and lightweight vector recall\n- Sensitive memories hidden from normal recall by default\n- Dry-run forgetting and soft delete\n- No external service required\n\nNote: this is listed as an external repo because the full capability includes a Codex plugin, MCP server, skill, and local SQLite service rather than a standalone SKILL.md-only folder.