### PR TITLE
Add Honeydew: Semantic Layer for AI and BI

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [raffle-winner-picker/](./raffle-winner-picker/) - Randomly select winners with audit-friendly logs.
 - [langsmith-fetch/](./langsmith-fetch/) - Pull LangSmith project/test data for analysis.
 - [helium-mcp/](./helium-mcp/) - Search real-time news with bias scoring, get live market data, ML options pricing, and balanced news synthesis via MCP.
+- [Honeydew Semantic Layer](https://github.com/honeydew-ai/honeydew-ai-coding-agents-plugins) - 11 skills + MCP server for building and querying a governed semantic layer over Snowflake, Databricks, and BigQuery. Same trusted model serves BI tools and AI agents. Plugins are Apache 2.0.
 
 ### Meta & Utilities
 


### PR DESCRIPTION
Honeydew is a semantic layer that lives in your data warehouse and serves both BI tools and AI agents from the same governed model. The linked honeydew-ai-coding-agents-plugins repo (Apache 2.0) is a multi-vendor marketplace covering Claude Code, Codex, Cursor, GitHub Copilot CLI, Gemini CLI plus raw MCP, with 11 skills (model exploration, entity/ relation/attribute/metric/context/domain creation, validation, query, filtering, workspace branching). Warehouses: Snowflake, Databricks, BigQuery.