### PR TITLE
Add codex-pet-generator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [agent-deep-links/](./agent-deep-links/) - Build and validate deep links for Codex, Cursor, and VS Code with Slack-safe formatting and fallback guidance.
 - [canvas-design/](./canvas-design/) - Generate structured canvas layouts and design artifacts.
 - [image-enhancer/](./image-enhancer/) - Upscale and refine images with configurable presets.
+- [codex-pet-generator/](./codex-pet-generator/) - Generate Codex desktop pet packages from reference images, producing normalized 8x9 spritesheets and `pet.json` metadata ready for `$CODEX_HOME/pets`.
 - [slack-gif-creator/](./slack-gif-creator/) - Generate GIFs for Slack with captions and styling.
 - [theme-factory/](./theme-factory/) - Create reusable theme tokens and palettes.
 - [video-downloader/](./video-downloader/) - Download and prepare videos for offline review.

--- a/codex-pet-generator/SKILL.md
+++ b/codex-pet-generator/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: codex-pet-generator
+description: Generate Codex desktop pet packages from one or more reference images. Use when a user wants a pet, mascot, or character reference turned into a folder named myPet containing a transparent 1536x1872 WebP spritesheet named spritesheet.webp plus pet.json metadata, with an 8x9 grid, 192x208 centered cells, and rows for idle, run right, run left, waving, jumping, failed, waiting, running, and review animations.
+---
+
+# Codex Pet Generator
+
+## Output Contract
+
+Create a final folder named `myPet` unless the user names another destination.
+The folder must contain:
+
+- `spritesheet.webp`
+- `pet.json`
+
+Optional debug output may include `spritesheet.png` when `--png` is used.
+
+The final image must be:
+
+- `1536x1872`
+- transparent background
+- `8` columns by `9` rows
+- `192x208` per cell
+- at most `8` frames per row
+- one complete pet/mascot frame per cell
+- centered consistently inside each cell
+- consistent visual pet size across all rows/states; no state row should suddenly look much smaller or larger than the others
+
+Rows from top to bottom:
+
+1. `idle`
+2. `run right` - the character should face/move toward screen right
+3. `run left` - must be the horizontal mirror of row 2 by default
+4. `waving`
+5. `jumping`
+6. `failed`
+7. `waiting`
+8. `running`
+9. `review`
+
+Direction is strict: do not swap rows 2 and 3. If the image generator outputs
+them reversed, keep row 2 as the desired right-facing run source and let the
+build script mirror row 2 into row 3.
+
+`pet.json` must use this schema:
+
+```json
+{
+  "id": "xxx-xxx",
+  "displayName": "xxxxxx",
+  "description": "xxxxx.",
+  "spritesheetPath": "spritesheet.webp",
+  "kind": "animal/person"
+}
+```
+
+Infer `id`, `displayName`, `description`, and `kind` from the user's reference
+image. Use `kind: "animal"` for animals, creatures, mascots, and non-human pets;
+use `kind: "person"` for human or humanoid character pets. Do not change
+`spritesheetPath`; it must always be exactly `"spritesheet.webp"`.
+
+## Workflow
+
+1. Use the `imagegen` skill or built-in image generation tool to create a green-screen source sheet from the user's reference image.
+2. Save the generated source PNG in the working directory, for example `spritesheet-source.png`.
+3. Infer `pet.json` metadata from the reference image.
+4. Run `scripts/build_spritesheet.py` from this skill to remove the green background, normalize the sheet, and write the pet package.
+5. Inspect the final WebP, a bottom-row crop, and the script's `body_width_range` / `body_height_range` metrics before finishing.
+6. If any frame is clipped, visibly off-center, or a state row still looks much smaller/larger than the others, regenerate the source with stronger padding and consistent-scale requirements, then rerun the script.
+
+## Generation Prompt Pattern
+
+Use this prompt shape with the user's reference image:
+
+```text
+Use the uploaded reference image as broad character reference. Create a new original cute desktop pet mascot sprite sheet, not an exact copy of any existing copyrighted character unless the user owns it or explicitly supplied it as their own asset.
+
+Create a single sprite sheet on a perfectly flat solid #00ff00 chroma-key background for background removal.
+
+Sprite sheet layout: exactly 8 columns by 9 rows. Each cell contains one complete full-body mascot sprite, fully visible and centered, with very generous padding. Keep at least 20% empty green margin above the top of the character, below the feet, left, and right in every cell. Keep the character's main body at the same visual size in every row/state; do not draw idle tiny, running large, jumping tiny, or review/failed at a different scale. No sprite, ear, hair, foot, tail, motion line, prop, puff, or effect may touch or approach the cell edge. No grid lines, no labels, no text, no watermark, no extra characters, no shadows, no floor.
+
+Rows from top to bottom, 8 frames per row:
+1. idle: subtle breathing/standing frames.
+2. run right: running toward screen right, right-facing/right-moving, 8-frame loop, fully contained. This is the authoritative run source.
+3. run left: running toward screen left, left-facing/left-moving, 8-frame loop, fully contained. The build script will replace this row with a horizontal mirror of row 2 unless explicitly disabled.
+4. waving: standing and waving one paw/hand, 8-frame loop.
+5. jumping: crouch, lift, airborne, landing, 8-frame loop, fully contained.
+6. failed: disappointed/failure reaction, drooping or dizzy expression, 8 frames.
+7. waiting: waiting/thinking, small fidget, 8-frame loop.
+8. running: energetic run loop, 8 frames, fully contained.
+9. review: inspecting/reviewing a small checklist or magnifier-like cue, 8 frames, fully contained.
+
+Style constraints: simple cute desktop pet mascot, clean outline, transparent-ready cutout, consistent scale across frames and across all 9 animation rows, no typography, no UI, no complex background, no gradients, no texture. The background must be exactly one uniform #00ff00 and #00ff00 must not appear inside the character or props.
+```
+
+If the generated bottom rows are clipped or too close to the row boundary, regenerate only rows 8 and 9 as an `8x2` green-screen source with the same padding language, then merge manually or rerun the script on a complete regenerated sheet.
+
+## Build Script
+
+Run:
+
+```bash
+python ~/.codex/skills/codex-pet-generator/scripts/build_spritesheet.py \
+  --source spritesheet-source.png \
+  --out-dir myPet \
+  --pet-id yellow-rabbit \
+  --display-name "Yellow Rabbit" \
+  --description "A cheerful yellow rabbit Codex pet." \
+  --kind animal \
+  --png
+```
+
+The script:
+
+- removes a green chroma-key background using border color sampling
+- detects row gaps and frame groups from alpha projection/connected components
+- crops each frame independently
+- centers the main mascot component at the center of its `192x208` cell
+- normalizes each animation row toward the same median main-body size by default, preventing state-to-state size jumps
+- keeps props/effects inside the same cell when they fall within that frame group
+- mirrors row 3 from row 2 by default, so row 2 is always `run right` and row 3 is always `run left`
+- writes `spritesheet.webp` and `pet.json` into the output folder
+- writes `spritesheet.png` only when `--png` is passed
+- prints validation metrics including row scales, body width/height range, edge hits, and center error
+
+The default `--scale-mode normalized` keeps row/state size consistent. Use
+`--scale-mode fit-row` only when intentionally preserving the older behavior
+where each row is independently enlarged to its maximum safe size.
+
+Do not use `--no-mirror-run-left` for normal Codex pet generation. It exists only
+for rare cases where the user explicitly wants to preserve a hand-authored row
+3 that has already been verified as `run left`.
+
+If metadata flags are omitted, the script writes a conservative default:
+`id: "my-pet"`, `displayName: "My Pet"`, `description: "A custom Codex pet generated from a reference image."`, and `kind: "animal"`.
+
+## Validation
+
+Before answering:
+
+- Confirm `spritesheet.webp` exists.
+- Confirm `pet.json` exists in the same folder.
+- Confirm `pet.json.spritesheetPath` is exactly `"spritesheet.webp"`.
+- Confirm dimensions are exactly `1536x1872`.
+- Confirm alpha extrema include `0` and `255`.
+- Confirm script output reports `edge_hits 0`.
+- Confirm `body_width_range` and `body_height_range` do not show a large spread, and visually check that no state row suddenly changes pet size.
+- Open or render a preview of the full sheet.
+- Verify row 2 is `run right` and row 3 is `run left`; if in doubt, rerun the script without `--no-mirror-run-left`.
+- Also inspect rows 8 and 9; these are the most likely to be clipped.

--- a/codex-pet-generator/agents/openai.yaml
+++ b/codex-pet-generator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Codex Pet Generator"
+  short_description: "Generate Codex pet packages."
+  default_prompt: "Use $codex-pet-generator to generate a Codex pet package from this reference image."

--- a/codex-pet-generator/scripts/build_spritesheet.py
+++ b/codex-pet-generator/scripts/build_spritesheet.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""Build a centered transparent Codex pet spritesheet from a green-screen source.
+
+Expected source: an 8x9 generated sprite sheet on a flat green chroma-key
+background. Output folder: myPet by default, containing spritesheet.webp and
+pet.json. The image is 1536x1872, transparent, 8 columns x 9 rows, 192x208 cells.
+Row 2 is the authoritative run-right row; row 3 is generated as a horizontal
+mirror of row 2 by default so run-left/run-right do not get swapped.
+By default, each animation row is normalized toward the same main-body size so
+state changes do not make the pet suddenly shrink or grow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import median
+
+from PIL import Image
+
+
+COLS = 8
+ROWS = 9
+CELL_W = 192
+CELL_H = 208
+OUT_W = COLS * CELL_W
+OUT_H = ROWS * CELL_H
+DEFAULT_TARGET_BODY_W = 132.0
+DEFAULT_TARGET_BODY_H = 156.0
+
+
+@dataclass
+class FrameSpec:
+    content: Image.Image
+    main_cx: float
+    main_cy: float
+    main_w: float
+    main_h: float
+    fit_limit: float
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", required=True, help="Green-screen source PNG/WebP.")
+    parser.add_argument("--out-dir", default="myPet", help="Output pet folder. Default: myPet.")
+    parser.add_argument("--png", action="store_true", help="Also write a PNG copy.")
+    parser.add_argument("--pet-id", default=None, help="pet.json id. Default: slugified display name or my-pet.")
+    parser.add_argument("--display-name", default="My Pet", help="pet.json displayName.")
+    parser.add_argument(
+        "--description",
+        default="A custom Codex pet generated from a reference image.",
+        help="pet.json description.",
+    )
+    parser.add_argument("--kind", choices=["animal", "person"], default="animal", help="pet.json kind.")
+    parser.add_argument(
+        "--no-mirror-run-left",
+        action="store_true",
+        help="Keep source row 3 instead of mirroring row 2. Avoid for normal Codex pet generation.",
+    )
+    parser.add_argument("--transparent-threshold", type=float, default=12.0)
+    parser.add_argument("--opaque-threshold", type=float, default=220.0)
+    parser.add_argument("--component-threshold", type=int, default=250)
+    parser.add_argument("--margin", type=int, default=18, help="Minimum cell margin for fitted content.")
+    parser.add_argument(
+        "--scale-mode",
+        choices=["normalized", "fit-row"],
+        default="normalized",
+        help="normalized keeps body size consistent across rows; fit-row preserves the legacy per-row fit behavior.",
+    )
+    parser.add_argument(
+        "--target-body-width",
+        type=float,
+        default=DEFAULT_TARGET_BODY_W,
+        help="Target final median main-body width for each animation row.",
+    )
+    parser.add_argument(
+        "--target-body-height",
+        type=float,
+        default=DEFAULT_TARGET_BODY_H,
+        help="Target final median main-body height for each animation row.",
+    )
+    parser.add_argument("--max-scale", type=float, default=2.0, help="Maximum upscale factor.")
+    return parser.parse_args()
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "my-pet"
+
+
+def border_key_color(im: Image.Image) -> tuple[int, int, int]:
+    rgb = im.convert("RGB")
+    width, height = rgb.size
+    pixels = rgb.load()
+    samples: list[tuple[int, int, int]] = []
+    step = max(1, min(width, height) // 300)
+
+    for x in range(0, width, step):
+        samples.append(pixels[x, 0])
+        samples.append(pixels[x, height - 1])
+    for y in range(0, height, step):
+        samples.append(pixels[0, y])
+        samples.append(pixels[width - 1, y])
+
+    # Group nearly-identical generated greens; then average the winning bucket.
+    def bucket(color: tuple[int, int, int]) -> tuple[int, int, int]:
+        return tuple((channel // 8) * 8 for channel in color)
+
+    winner = Counter(bucket(color) for color in samples).most_common(1)[0][0]
+    grouped = [color for color in samples if bucket(color) == winner]
+    return tuple(round(sum(color[i] for color in grouped) / len(grouped)) for i in range(3))  # type: ignore[return-value]
+
+
+def remove_chroma(
+    im: Image.Image,
+    transparent_threshold: float,
+    opaque_threshold: float,
+) -> Image.Image:
+    rgba = im.convert("RGBA")
+    key = border_key_color(rgba)
+    out = Image.new("RGBA", rgba.size, (0, 0, 0, 0))
+    src = rgba.load()
+    dst = out.load()
+    width, height = rgba.size
+
+    for y in range(height):
+        for x in range(width):
+            r, g, b, a = src[x, y]
+            d = math.sqrt((r - key[0]) ** 2 + (g - key[1]) ** 2 + (b - key[2]) ** 2)
+            if d <= transparent_threshold:
+                alpha = 0
+            elif d >= opaque_threshold:
+                alpha = a
+            else:
+                t = (d - transparent_threshold) / max(1.0, opaque_threshold - transparent_threshold)
+                alpha = round(a * t)
+
+            if alpha:
+                # Simple green despill for antialiased edges.
+                max_rb = max(r, b)
+                if g > max_rb:
+                    g = round(max_rb + (g - max_rb) * 0.35)
+            dst[x, y] = (r, g, b, alpha)
+
+    print(f"key_color #{key[0]:02x}{key[1]:02x}{key[2]:02x}")
+    return out
+
+
+def alpha_bbox(region: Image.Image, threshold: int = 10) -> tuple[int, int, int, int] | None:
+    alpha = region.getchannel("A")
+    pix = alpha.load()
+    width, height = region.size
+    min_x, min_y, max_x, max_y = width, height, -1, -1
+    for y in range(height):
+        for x in range(width):
+            if pix[x, y] > threshold:
+                min_x = min(min_x, x)
+                min_y = min(min_y, y)
+                max_x = max(max_x, x)
+                max_y = max(max_y, y)
+    if max_x < min_x:
+        return None
+    return (min_x, min_y, max_x + 1, max_y + 1)
+
+
+def components_in_region(
+    alpha: Image.Image,
+    x0: int,
+    y0: int,
+    x1: int,
+    y1: int,
+    threshold: int = 10,
+) -> list[dict[str, object]]:
+    crop = alpha.crop((x0, y0, x1, y1))
+    pix = crop.load()
+    width, height = crop.size
+    seen: set[tuple[int, int]] = set()
+    output: list[dict[str, object]] = []
+
+    for yy in range(height):
+        for xx in range(width):
+            if pix[xx, yy] <= threshold or (xx, yy) in seen:
+                continue
+            queue = [(xx, yy)]
+            seen.add((xx, yy))
+            area = 0
+            min_x = max_x = xx
+            min_y = max_y = yy
+            sum_x = 0
+            sum_y = 0
+            for qx, qy in queue:
+                area += 1
+                sum_x += qx
+                sum_y += qy
+                min_x = min(min_x, qx)
+                max_x = max(max_x, qx)
+                min_y = min(min_y, qy)
+                max_y = max(max_y, qy)
+                for nx, ny in ((qx + 1, qy), (qx - 1, qy), (qx, qy + 1), (qx, qy - 1)):
+                    if 0 <= nx < width and 0 <= ny < height and (nx, ny) not in seen and pix[nx, ny] > threshold:
+                        seen.add((nx, ny))
+                        queue.append((nx, ny))
+            output.append(
+                {
+                    "area": area,
+                    "bbox": (min_x + x0, min_y + y0, max_x + x0 + 1, max_y + y0 + 1),
+                    "center": (sum_x / area + x0, sum_y / area + y0),
+                }
+            )
+    return output
+
+
+def row_breaks(im: Image.Image) -> list[int]:
+    alpha = im.getchannel("A")
+    pix = alpha.load()
+    width, height = im.size
+    counts = [sum(1 for x in range(width) if pix[x, y] > 10) for y in range(height)]
+    breaks = [0]
+    for i in range(1, ROWS):
+        expected = round(i * height / ROWS)
+        band = max(30, round(height / ROWS * 0.3))
+        lo = max(0, expected - band)
+        hi = min(height, expected + band)
+        breaks.append(min(range(lo, hi), key=lambda y: counts[y]))
+    breaks.append(height)
+    return breaks
+
+
+def extract_frame_specs(im: Image.Image, component_threshold: int, margin: int) -> list[list[FrameSpec]]:
+    alpha = im.getchannel("A")
+    width, _ = im.size
+    breaks = row_breaks(im)
+    rows: list[list[FrameSpec]] = []
+
+    for row_index in range(ROWS):
+        y0, y1 = breaks[row_index], breaks[row_index + 1]
+        comps = [c for c in components_in_region(alpha, 0, y0, width, y1) if int(c["area"]) > component_threshold]
+        mains = sorted(comps, key=lambda c: int(c["area"]), reverse=True)[:COLS]
+        mains = sorted(mains, key=lambda c: c["center"][0])  # type: ignore[index]
+        if len(mains) != COLS:
+            raise RuntimeError(f"row {row_index + 1}: expected {COLS} main components, found {len(mains)}")
+
+        centers = [c["center"][0] for c in mains]  # type: ignore[index]
+        bounds = [0] + [round((centers[i - 1] + centers[i]) / 2) for i in range(1, COLS)] + [width]
+
+        frames: list[FrameSpec] = []
+        for col in range(COLS):
+            gx0, gx1 = bounds[col], bounds[col + 1]
+            group = im.crop((gx0, y0, gx1, y1))
+            bbox = alpha_bbox(group)
+            if bbox is None:
+                raise RuntimeError(f"row {row_index + 1} col {col + 1}: empty frame")
+
+            pad = 4
+            left = max(0, bbox[0] - pad)
+            top = max(0, bbox[1] - pad)
+            right = min(group.size[0], bbox[2] + pad)
+            bottom = min(group.size[1], bbox[3] + pad)
+            content = group.crop((left, top, right, bottom))
+
+            main_bbox = mains[col]["bbox"]  # type: ignore[index]
+            main_cx = ((main_bbox[0] + main_bbox[2]) / 2) - gx0 - left
+            main_cy = ((main_bbox[1] + main_bbox[3]) / 2) - y0 - top
+            main_w = main_bbox[2] - main_bbox[0]
+            main_h = main_bbox[3] - main_bbox[1]
+
+            spans = [
+                main_cx,
+                content.size[0] - main_cx,
+                main_cy,
+                content.size[1] - main_cy,
+            ]
+            limits = []
+            if spans[0] > 0:
+                limits.append((CELL_W / 2 - margin) / spans[0])
+            if spans[1] > 0:
+                limits.append((CELL_W - margin - CELL_W / 2) / spans[1])
+            if spans[2] > 0:
+                limits.append((CELL_H / 2 - margin) / spans[2])
+            if spans[3] > 0:
+                limits.append((CELL_H - margin - CELL_H / 2) / spans[3])
+            frames.append(
+                FrameSpec(
+                    content=content,
+                    main_cx=main_cx,
+                    main_cy=main_cy,
+                    main_w=main_w,
+                    main_h=main_h,
+                    fit_limit=min(limits),
+                )
+            )
+        rows.append(frames)
+
+    return rows
+
+
+def row_scales(
+    specs: list[list[FrameSpec]],
+    scale_mode: str,
+    target_body_width: float,
+    target_body_height: float,
+    max_scale: float,
+) -> list[float]:
+    scales: list[float] = []
+    print(f"scale_mode {scale_mode}")
+
+    for row_index, frames in enumerate(specs):
+        fit_limit = min(frame.fit_limit for frame in frames)
+        median_body_w = median(frame.main_w for frame in frames)
+        median_body_h = median(frame.main_h for frame in frames)
+        if scale_mode == "fit-row":
+            scale = min(max_scale, fit_limit)
+        else:
+            desired = min(target_body_width / median_body_w, target_body_height / median_body_h)
+            scale = min(max_scale, desired, fit_limit)
+
+        final_body_w = median_body_w * scale
+        final_body_h = median_body_h * scale
+        limited_by = []
+        if scale == max_scale and scale < fit_limit:
+            limited_by.append("max-scale")
+        if scale == fit_limit:
+            limited_by.append("fit-limit")
+        if not limited_by:
+            limited_by.append("target")
+        print(
+            "row_scale "
+            f"row={row_index + 1} scale={scale:.4f} "
+            f"median_body={final_body_w:.1f}x{final_body_h:.1f} "
+            f"limited_by={'+'.join(limited_by)}"
+        )
+        scales.append(scale)
+
+    body_widths = [median(frame.main_w for frame in frames) * scales[index] for index, frames in enumerate(specs)]
+    body_heights = [median(frame.main_h for frame in frames) * scales[index] for index, frames in enumerate(specs)]
+    print(f"body_width_range {min(body_widths):.1f}..{max(body_widths):.1f}px")
+    print(f"body_height_range {min(body_heights):.1f}..{max(body_heights):.1f}px")
+    return scales
+
+
+def render_cells(specs: list[list[FrameSpec]], scales: list[float]) -> tuple[list[list[Image.Image]], float, int]:
+    rows: list[list[Image.Image]] = []
+    max_center_error = 0.0
+    edge_hits = 0
+
+    for row_index, frames in enumerate(specs):
+        scale = scales[row_index]
+        row_cells: list[Image.Image] = []
+        for frame in frames:
+            resized = frame.content.resize(
+                (
+                    max(1, round(frame.content.size[0] * scale)),
+                    max(1, round(frame.content.size[1] * scale)),
+                ),
+                Image.Resampling.NEAREST,
+            )
+            paste_x = round(CELL_W / 2 - frame.main_cx * scale)
+            paste_y = round(CELL_H / 2 - frame.main_cy * scale)
+            cell = Image.new("RGBA", (CELL_W, CELL_H), (0, 0, 0, 0))
+            cell.alpha_composite(resized, (paste_x, paste_y))
+            bbox = alpha_bbox(cell)
+            if bbox and (bbox[0] <= 0 or bbox[1] <= 0 or bbox[2] >= CELL_W or bbox[3] >= CELL_H):
+                edge_hits += 1
+            max_center_error = max(
+                max_center_error,
+                abs(paste_x + frame.main_cx * scale - CELL_W / 2),
+                abs(paste_y + frame.main_cy * scale - CELL_H / 2),
+            )
+            row_cells.append(cell)
+        rows.append(row_cells)
+
+    return rows, max_center_error, edge_hits
+
+
+def build_cells(
+    im: Image.Image,
+    component_threshold: int,
+    margin: int,
+    max_scale: float,
+    scale_mode: str,
+    target_body_width: float,
+    target_body_height: float,
+) -> tuple[list[list[Image.Image]], float, int]:
+    specs = extract_frame_specs(im, component_threshold, margin)
+    scales = row_scales(specs, scale_mode, target_body_width, target_body_height, max_scale)
+    return render_cells(specs, scales)
+
+
+def write_outputs(rows: list[list[Image.Image]], out_dir: Path, also_png: bool) -> Path:
+    canvas = Image.new("RGBA", (OUT_W, OUT_H), (0, 0, 0, 0))
+    for row, cells in enumerate(rows):
+        for col, cell in enumerate(cells):
+            canvas.alpha_composite(cell, (col * CELL_W, row * CELL_H))
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    png_path = out_dir / "spritesheet.png"
+    webp_path = out_dir / "spritesheet.webp"
+    if also_png:
+        canvas.save(png_path, format="PNG", optimize=True)
+    canvas.save(webp_path, format="WEBP", lossless=False, quality=95, method=6, exact=True)
+    return webp_path
+
+
+def write_pet_json(out_dir: Path, pet_id: str | None, display_name: str, description: str, kind: str) -> Path:
+    manifest = {
+        "id": pet_id or slugify(display_name),
+        "displayName": display_name,
+        "description": description,
+        "spritesheetPath": "spritesheet.webp",
+        "kind": kind,
+    }
+    json_path = out_dir / "pet.json"
+    json_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return json_path
+
+
+def main() -> int:
+    args = parse_args()
+    source = Path(args.source)
+    if not source.exists():
+        print(f"source not found: {source}", file=sys.stderr)
+        return 2
+
+    chroma_removed = remove_chroma(
+        Image.open(source),
+        transparent_threshold=args.transparent_threshold,
+        opaque_threshold=args.opaque_threshold,
+    )
+    rows, max_center_error, edge_hits = build_cells(
+        chroma_removed,
+        component_threshold=args.component_threshold,
+        margin=args.margin,
+        max_scale=args.max_scale,
+        scale_mode=args.scale_mode,
+        target_body_width=args.target_body_width,
+        target_body_height=args.target_body_height,
+    )
+    if not args.no_mirror_run_left:
+        rows[2] = [cell.transpose(Image.Transpose.FLIP_LEFT_RIGHT) for cell in rows[1]]
+        print("direction_rows row2=run-right row3=mirror(row2)-run-left")
+    else:
+        print("direction_rows row2=run-right row3=source-row3 (--no-mirror-run-left)")
+
+    out_dir = Path(args.out_dir)
+    webp_path = write_outputs(rows, out_dir, args.png)
+    json_path = write_pet_json(out_dir, args.pet_id, args.display_name, args.description, args.kind)
+    print(f"wrote {webp_path} {OUT_W}x{OUT_H}")
+    if args.png:
+        print(f"wrote {out_dir / 'spritesheet.png'} {OUT_W}x{OUT_H}")
+    print(f"wrote {json_path}")
+    print("pet_json_spritesheetPath spritesheet.webp")
+    print(f"edge_hits {edge_hits}")
+    print(f"max_center_error {max_center_error:.2f}px")
+    return 0 if edge_hits == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds `codex-pet-generator`, a Codex skill for generating desktop pet packages from reference images. The skill outputs normalized 8x9 spritesheets and `pet.json` metadata ready for Codex pet usage.

## Validation

- Checked README entry and skill structure.
- Verified there are no non-English instructions.
- Ran Python syntax validation for the build script.