### PR TITLE
Add karpathy-guidelines skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [Emdash Skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS: CF Workers + Hono + Angular + D1 + Stripe. One-line prompts to deployed SaaS with 94 reference docs, 18 agents, and Codex-native `.agents/skills/` support.
 - [gh-address-comments/](./gh-address-comments/) - Address review or issue comments on the open GitHub PR for the current branch using `gh`.
 - [gh-fix-ci/](./gh-fix-ci/) - Inspect failing GitHub Actions checks, summarize failures, and propose fixes.
+- [karpathy-guidelines](https://github.com/swarmclawai/andrej-karpathy-skills) - Karpathy-inspired coding-agent guidelines packaged for Codex, Claude Code, Cursor, Gemini CLI, OpenCode, Aider, GitHub Copilot, OpenClaw, and Agent Skills-compatible agents. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo swarmclawai/andrej-karpathy-skills --path skills/karpathy-guidelines --name karpathy-guidelines`
 - [mcp-builder/](./mcp-builder/) - Build and evaluate MCP servers with best practices and an evaluation harness.
 - [pr-review-ci-fix/](./pr-review-ci-fix/) - Automated GitHub/GitLab PR review plus CI auto-fix loop via the Composio CLI.
 - [sentry-triage/](./sentry-triage/) - Diagnose Sentry issues by mapping stack frames to local source — no copy-paste.


### PR DESCRIPTION
Adds the external karpathy-guidelines skill entry linking to swarmclawai/andrej-karpathy-skills. The listed install command targets the canonical Codex skill at skills/karpathy-guidelines.\n\nValidation: git diff --check