### PR TITLE
Add restorative-repair skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [content-research-writer/](./content-research-writer/) - Research and draft content with sourced citations.
 - [diasporic-intelligence](https://github.com/MinistaJazz/diasporic-intelligence) - External repo: source-credit skill for consent-governed lineage AI with attribution, provenance, revocation, and non-impersonation boundaries.
 - [novel-writing](https://github.com/wgwtest/novel-writing) - External repo: public Codex skill for fiction planning, chapter drafting, scene continuation, and revision.
+- [restorative-repair](https://github.com/MinistaJazz/restorative-repair) - External repo: response-layer repair skill for AI agents that names output errors, offers proportionate repair, routes crisis safely, and avoids apology loops.
 - [tailored-resume-generator/](./tailored-resume-generator/) - Tailor resumes to job descriptions with quantified impact.
 - [unslop](https://github.com/MohamedAbdallah-14/unslop) - External repo: CLI and MCP server that removes AI writing patterns from text: tricolons, em-dash overuse, hedging stacks, and sycophancy openers. Works with Codex, Claude Code, Gemini CLI, and Cursor. Five intensity levels and a lint-only audit mode.
 


### PR DESCRIPTION
Adds restorative-repair, an external public Codex-compatible skill for response-layer repair when AI agents make output errors.\n\nRepo: https://github.com/MinistaJazz/restorative-repair\n\nThe skill includes trigger taxonomy, severity tiers, crisis suppression rules, bounded loop-exit behavior, and auditable benchmark prompts.