### PR TITLE
Add aave-respect skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [email-draft-polish/](./email-draft-polish/) - Draft, rewrite, or condense emails for the right tone and audience.
 - [changelog-generator/](./changelog-generator/) - Create clear changelogs from commits or summaries.
 - [content-research-writer/](./content-research-writer/) - Research and draft content with sourced citations.
+- [aave-respect](https://github.com/MinistaJazz/aave-respect) - External repo: respect-layer skill for recognizing African American Vernacular English accurately, preserving meaning, avoiding correction, and preventing mimicry.
 - [diasporic-intelligence](https://github.com/MinistaJazz/diasporic-intelligence) - External repo: source-credit skill for consent-governed lineage AI with attribution, provenance, revocation, and non-impersonation boundaries.
 - [novel-writing](https://github.com/wgwtest/novel-writing) - External repo: public Codex skill for fiction planning, chapter drafting, scene continuation, and revision.
 - [tailored-resume-generator/](./tailored-resume-generator/) - Tailor resumes to job descriptions with quantified impact.


### PR DESCRIPTION
Adds aave-respect, an external public Codex-compatible skill for recognizing and respecting African American Vernacular English without correction, flattening, or mimicry.\n\nRepo: https://github.com/MinistaJazz/aave-respect\n\nThe skill includes recognition, response, transcription, editing, generation guidance, red-team prompts, and developer resources for AAVE-aware AI behavior.