### PR TITLE
Add skill: blackwell-systems/polywave-codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [webapp-testing/](./webapp-testing/) - Run targeted web app tests and summarize results.
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
+- [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
Adds Polywave to the Development & Code Tools section.

Polywave is a coordination protocol for parallel AI agents that makes merge conflicts structurally impossible. The Codex implementation uses the same protocol as the Claude Code version: Scout decomposes work, Wave agents implement in isolated git worktrees with disjoint file ownership.

- Codex skill repo: https://github.com/blackwell-systems/polywave-codex
- Protocol spec: https://github.com/blackwell-systems/polywave-protocol
- Go engine (polywave-tools CLI): https://github.com/blackwell-systems/polywave-go