### PR TITLE
Add recsys-pipeline-architect (Development & Code Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [recsys-pipeline-architect](https://github.com/mturac/recsys-pipeline-architect) - Designs composable recommendation, ranking, and feed pipelines using the six-stage Source→Hydrator→Filter→Scorer→Selector→SideEffect framework popularized by xAI's open-sourced X For You algorithm. Walks through use case → sources → hydrations → filters → scorers → selector → side effects → scaffold, and emits runnable scaffolds for Strapi v5 (TypeScript), Go, or Python/FastAPI. Install: `git clone https://github.com/mturac/recsys-pipeline-architect.git ~/.codex/skills/recsys-pipeline-architect`
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
Adds **[recsys-pipeline-architect](https://github.com/mturac/recsys-pipeline-architect)** under *Development & Code Tools*.

**What it is**
A vendor-agnostic Codex skill (agentskills.io standard) for designing composable recommendation, ranking, and feed pipelines using the six-stage **Source → Hydrator → Filter → Scorer → Selector → SideEffect** framework popularized by xAI's open-sourced [For You algorithm](https://github.com/xai-org/x-algorithm) (Apache 2.0; this skill is MIT and is an independent reimplementation of the pattern).

**Why it fits**
Most "recommendation systems" in production aren't exotic ML — they're pipelines. This skill encodes the pattern, walks Codex through eight clarifying steps (use case → sources → hydrations → filters → scorers → selector → side effects → scaffold), surfaces architectural trade-offs (multi-action vs single-score, candidate isolation vs joint, online vs offline batch), and emits a runnable scaffold in the user's stack.

**Codex install**
```bash
git clone https://github.com/mturac/recsys-pipeline-architect.git \
  ~/.codex/skills/recsys-pipeline-architect
```
Or via skills.sh one-liner: `npx skills add mturac/recsys-pipeline-architect` (also installs to Claude Code, Cursor, Gemini CLI, and 14 more agents).

**Repo contents**
- `SKILL.md` + 5 load-on-demand reference docs (interfaces in 4 languages, multi-action scoring, candidate isolation, filter cookbook with 12 patterns, scorer cookbook)
- 3 runnable example scaffolds, every one green on its test suite:
  - Strapi v5 plugin — TypeScript / Jest, 3/3 pass
  - Zentra-compatible pipeline — Go with generics, 3/3 pass
  - PMAI task prioritizer — Python / FastAPI / pytest, 3/3 pass
- MIT license, attribution to the xAI pattern in README and LICENSE
- v0.1.0 GitHub release tagged

Sister PR for `awesome-claude-skills`: ComposioHQ/awesome-claude-skills#850. Inserted alphabetically in *Development & Code Tools*. Happy to revise the description, move sections, or adjust the install snippet — let me know.