### PR TITLE
Security: Path Traversal in package_skill.py

### DIFF
--- a/skill-creator/scripts/package_skill.py
+++ b/skill-creator/scripts/package_skill.py
@@ -70,6 +70,16 @@ def package_skill(skill_path, output_dir=None):
             # Walk through the skill directory
             for file_path in skill_path.rglob("*"):
                 if file_path.is_file():
+                    # Resolve the real path to handle symlinks and prevent path traversal
+                    real_path = file_path.resolve()
+
+                    # Verify the resolved path is within the skill directory
+                    try:
+                        real_path.relative_to(skill_path.parent)
+                    except ValueError:
+                        print(f"  Skipped (outside allowed directory): {file_path}")
+                        continue
+
                     # Calculate the relative path within the zip
                     arcname = file_path.relative_to(skill_path.parent)
                     zipf.write(file_path, arcname)


### PR DESCRIPTION
## Problem

The script creates a zip file from a skill folder using rglob and relative_to. If a malicious symlink exists outside the skill folder, it could be followed, allowing path traversal attacks (zip slip).

**Severity**: `high`
**File**: `skill-creator/scripts/package_skill.py`

## Solution

Add validation to ensure all extracted paths are within the target directory. Use os.path.realpath() to resolve symlinks and verify the resolved path is within the skill_path.parent directory.

## Changes

- `skill-creator/scripts/package_skill.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
