### PR TITLE
Add skill-guide to Meta & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [theme-factory/](./theme-factory/) - Create reusable theme tokens and palettes.
 - [video-downloader/](./video-downloader/) - Download and prepare videos for offline review.
 - [template-skill/](./template-skill/) - Starter template for building new skills.
+- [skill-guide](https://github.com/gtskevin/skill-guide) - Zero-dependency CLI that scans Claude Code, Codex, cc-switch, and plugin skill directories, then generates HTML slide presentations showing what skills are installed. Works as both an npm package and a Claude Code/Codex skill.
 - [skill-installer/](./skill-installer/) - Helper scripts to install skills from curated lists or GitHub paths.
 - [skill-creator/](./skill-creator/) - Guidance for building effective Codex skills with progressive disclosure.
 


### PR DESCRIPTION
## Skill Submission

**Name:** skill-guide
**Repository:** https://github.com/gtskevin/skill-guide

### What it does

skill-guide is a zero-dependency CLI that scans Claude Code, Codex, cc-switch, and plugin skill directories, then generates HTML slide presentations showing what skills are installed.

**Works as both a Codex skill and standalone npm package:**
- `npx skill-guide --open` — scan and visualize all installed skills
- Scans 6 source directories including Codex skills, OpenAI system skills, and Codex plugin cache
- Auto-categorizes into 9 categories
- Supports search, deep-dive, and diagnostics (--doctor)
- Zero npm dependencies

### Installation for Codex
```bash
git clone https://github.com/gtskevin/skill-guide.git
mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills"
ln -s "$(pwd)/skill-guide" "${CODEX_HOME:-$HOME/.codex}/skills/skill-guide"
```

### License
MIT