### PR TITLE
Add pluginpool (10 productivity helpers, stdlib only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [pluginpool](https://github.com/mturac/pluginpool) - Ten focused developer productivity plugins (commit-narrator, pr-storyteller, test-gap, deps-doctor, env-lint, secret-guard, standup-gen, todo-harvest, flaky-detector, changelog-forge). Each plugin's core is a deterministic Python helper (stdlib only) — usable as a plain CLI from inside any Codex session. 89 hermetic tests across the suite, MIT. Install each plugin via: `git clone https://github.com/mturac/pluginpool-<plugin> ~/.codex/skills/<plugin>`
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
Adds [pluginpool](https://github.com/mturac/pluginpool) under *Development & Code Tools*.

Ten focused developer productivity helpers — each one a deterministic Python script that does exactly one thing and emits structured output. Use as plain CLIs from any Codex session, or install as Claude Code slash commands.

- **commit-narrator** — semantic commit message from `git diff --cached`, with the *why*
- **pr-storyteller** — PR title + body + test plan from commits and diff vs base
- **test-gap** — lines in diff lacking test coverage (Cobertura / lcov / coverage.json)
- **deps-doctor** — multi-ecosystem dependency audit (npm, pip, cargo, go)
- **env-lint** — `.env` vs `.env.example` key parity (never prints values)
- **secret-guard** — pre-commit secret scanner (pattern + entropy, redacted output)
- **standup-gen** — daily standup notes from git activity across repos
- **todo-harvest** — TODO/FIXME/HACK scan with git blame author + age
- **flaky-detector** — run a test command N times, report per-test flakiness %
- **changelog-forge** — conventional commits → CHANGELOG section + semver bump

89 hermetic tests across the suite, Python stdlib only at runtime, MIT.