### PR TITLE
Add Remote OpenClaw Codex skills directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ PRs welcome. Add real, reusable skills, keep descriptions precise, and include a
 ## Resources
 
 - [Top Codex Skills](https://composio.dev/content/top-codex-skills)
+- [Remote OpenClaw Codex Skills](https://www.remoteopenclaw.com/skills/codex) - Codex skills directory and guides for browsing Codex-compatible workflows and related resources
 
 ---
 


### PR DESCRIPTION
Adding the Codex-specific hub because it is the most direct fit for a Codex skills list.