### PR TITLE
Add Everything OpenAI Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [create-plan/](./create-plan/) - Quickly draft concise execution plans for coding tasks.
 - [deploy-pipeline/](./deploy-pipeline/) - End-to-end Stripe → Supabase → Vercel release pipelines with verify and rollback.
 - [Emdash Skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS: CF Workers + Hono + Angular + D1 + Stripe. One-line prompts to deployed SaaS with 94 reference docs, 18 agents, and Codex-native `.agents/skills/` support.
+- [Everything OpenAI Codex](https://github.com/mturac/everything-openai-codex) - Open-source Codex workflow bundle with 230 skills plus agents, commands, hooks, memory patterns, install profiles, and validation checks.
 - [gh-address-comments/](./gh-address-comments/) - Address review or issue comments on the open GitHub PR for the current branch using `gh`.
 - [gh-fix-ci/](./gh-fix-ci/) - Inspect failing GitHub Actions checks, summarize failures, and propose fixes.
 - [mcp-builder/](./mcp-builder/) - Build and evaluate MCP servers with best practices and an evaluation harness.


### PR DESCRIPTION
Adds Everything OpenAI Codex, an MIT-licensed OpenAI Codex workflow system with agents, skills, commands, hooks, memory patterns, install profiles, and validation checks for repeatable coding sessions.\n\nProject: https://github.com/mturac/everything-openai-codex

Everything OpenAI Codex is an MIT-licensed Codex workflow system, not a prompt dump: it packages a repeatable Intake -> Route -> Plan -> Execute -> Verify -> Capture -> Resume loop with agents, skills, hooks, install profiles, memory/status capture, validation checks, and cross-harness adapters.

Project: https://github.com/mturac/everything-openai-codex
README execution model: https://github.com/mturac/everything-openai-codex#eoc-execution-model