### PR TITLE
Add Thoth skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [Thoth](https://github.com/SeeleAI/Thoth/tree/main/plugins/thoth/skills/thoth) - Codex skill surface for the Thoth dashboard-first runtime, with one `$thoth` entrypoint for durable runs, locked work items, visible ledgers, and reviewable verdicts. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo SeeleAI/Thoth --path plugins/thoth/skills/thoth --name thoth`
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
## Summary

Adds the Thoth Codex skill surface to the Development & Code Tools section.

Thoth exposes one `$thoth` entrypoint for a dashboard-first runtime that turns agent work into durable runs, locked work items, visible ledgers, and reviewable verdicts.

## Validation

- `git diff --check`

## Notes

This lists the Codex skill surface at `plugins/thoth/skills/thoth` and includes an explicit skill-installer command. It does not imply that the skill alone is the full Thoth runtime; it is the Codex public surface for the Thoth project.