### PR TITLE
Add skill: heyneuron/flowhunt-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 
 - [connect/](./connect/) - Connect Codex to 1000+ apps via the Composio CLI for real actions (Slack, GitHub, Notion, etc.).
 - [connect-apps/](./connect-apps/) - Wire up Composio CLI connections for Claude and kick off app workflows from the shell.
+- [flowhunt-skill](https://github.com/heyneuron/flowhunt-skill) - Automation discovery audit: walks through a 5-question workflow intake then audits Gmail, Calendar, Slack, and task trackers to surface automation opportunities with effort/impact scores. Install: `npx skills add heyneuron/flowhunt-skill`
 - [issue-triage/](./issue-triage/) - Triage Linear or Jira backlogs and run bug sweeps from the terminal.
 - [linear/](./linear/) - Manage issues, projects, and team workflows in Linear.
 - [meeting-insights-analyzer/](./meeting-insights-analyzer/) - Analyze meeting transcripts for themes, risks, and follow-ups.


### PR DESCRIPTION
FlowHunt Skill - automation discovery audit. Walks through 5-question workflow intake and audits Gmail/Calendar/Slack/task trackers to identify automation opportunities.

Install: `npx skills add heyneuron/flowhunt-skill`