### PR TITLE
Add network-optimizer-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [slack-gif-creator/](./slack-gif-creator/) - Generate GIFs for Slack with captions and styling.
 - [theme-factory/](./theme-factory/) - Create reusable theme tokens and palettes.
 - [video-downloader/](./video-downloader/) - Download and prepare videos for offline review.
+- [network-optimizer-skill](https://github.com/6Kmfi6HP/network-optimizer-skill) - External repo: safe cross-platform network diagnostics and reversible tuning for Codex, Claude Code, and Agent Skills. Includes macOS/Linux/Windows audits plus Linux BBR and BBR+FQ plan/apply/restore helpers. Install: `codex plugin marketplace add 6Kmfi6HP/network-optimizer-skill && codex plugin add network-optimizer-skill@network-optimizer-skill`
 - [template-skill/](./template-skill/) - Starter template for building new skills.
 - [skill-installer/](./skill-installer/) - Helper scripts to install skills from curated lists or GitHub paths.
 - [skill-creator/](./skill-creator/) - Guidance for building effective Codex skills with progressive disclosure.


### PR DESCRIPTION
Adds network-optimizer-skill, an external Codex/Agent Skills repo for safe cross-platform network diagnostics and reversible tuning.

Why it fits:
- Ships as a Codex plugin and Agent Skill.
- Supports macOS, Linux, and Windows before/after network audits.
- Includes Linux BBR and BBR+FQ diagnose/plan/apply/restore helpers with backups and explicit approval.
- Useful as a Meta & Utilities skill for agent-assisted system troubleshooting.

Repo: https://github.com/6Kmfi6HP/network-optimizer-skill