### PR TITLE
add authsome under Development &amp; Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [authsome](https://github.com/agentrhq/authsome) - Local credential broker. Log in once via OAuth2 or API key, encrypted vault stores credentials, local proxy injects them at request time so Codex never sees raw secrets. 45 providers bundled (14 OAuth2, 31 API key). Install: `npx skills add agentrhq/authsome`.
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
hey, opening this to add authsome under Development & Code Tools.

authsome is a local credential broker for AI agents (Codex included). log in once via OAuth2 or API key, encrypted vault stores credentials, a local proxy injects them at request time so Codex never touches raw secrets. 45 providers bundled (14 OAuth2, 31 API key) including github, google, openai, linear, slack, notion, resend, stripe.

ships an agentskills.io SKILL.md at skills/authsome/ that installs into codex via the standard `npx skills add agentrhq/authsome` flow, or the local install script. tested with the codex CLI and the [Codex integration docs](https://authsome.ai/docs/integrations/agents/codex) cover the setup.

heads-up that authsome and composio sit in adjacent categories. composio is hosted and orchestrates 1000+ apps with managed auth, authsome is local-first and handles 45 providers with no SaaS dependency. they complement well for users who want a local credential layer.

repo: https://github.com/agentrhq/authsome
website: https://authsome.ai
license: MIT
pypi: https://pypi.org/project/authsome/