### PR TITLE
Add II-Commons skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [competitive-ads-extractor/](./competitive-ads-extractor/) - Analyze competitor ads and extract structured insights.
 - [datadog-logs/](./datadog-logs/) - Filter Datadog logs from the shell via the Composio CLI, with JSON-friendly output and digest workflows.
 - [developer-growth-analysis/](./developer-growth-analysis/) - Analyze Codex chat history for coding patterns and learning gaps.
+- [ii-commons](https://github.com/Intelligent-Internet/II-Commons-Skills/tree/main/skills/ii-commons) - Deterministic arXiv, PubMed, PMC, and policy retrieval with daily-updated corpus cutoffs. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo Intelligent-Internet/II-Commons-Skills --path skills/ii-commons --name ii-commons`
 - [lead-research-assistant/](./lead-research-assistant/) - Research leads and enrich records with firmographic data.
 - [domain-name-brainstormer/](./domain-name-brainstormer/) - Brainstorm available domain names with criteria and checks.
 - [raffle-winner-picker/](./raffle-winner-picker/) - Randomly select winners with audit-friendly logs.


### PR DESCRIPTION
Adds II-Commons to the Data & Analysis section.\n\nII-Commons is a Codex-compatible skill and npm CLI for deterministic retrieval across arXiv, PubMed/PMC, and supported US policy corpora. It supports search, metadata lookup, full-document markdown retrieval, and daily-updated corpus freshness cutoffs.\n\nProject: https://github.com/Intelligent-Internet/II-Commons-Skills