### PR TITLE
Add skill: O0000-code/paper-search-pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [raffle-winner-picker/](./raffle-winner-picker/) - Randomly select winners with audit-friendly logs.
 - [langsmith-fetch/](./langsmith-fetch/) - Pull LangSmith project/test data for analysis.
 - [helium-mcp/](./helium-mcp/) - Search real-time news with bias scoring, get live market data, ML options pricing, and balanced news synthesis via MCP.
+- [paper-search-pro](https://github.com/O0000-code/paper-search-pro) - External repo: multi-source academic literature search across OpenAlex, Semantic Scholar, CrossRef, PubMed and arXiv, with four depth tiers, PRISMA-S logging, and single-file HTML plus BibTeX/RIS/CSV reports. Triggers when the user wants to find papers, gather references, or scope a literature review; runs in Codex and any SKILL.md agent.
 
 ### Meta & Utilities
 


### PR DESCRIPTION
## Skill: paper-search-pro (external repo)
A multi-source academic literature search skill, compatible with Codex and any agent that loads SKILL.md.

## When Codex should trigger it
When the user asks to find papers, run a literature search, gather references, or scope a research topic for a review (English or Chinese trigger phrasing both supported).

## What it does
Searches five sources — OpenAlex, Semantic Scholar, CrossRef, PubMed, arXiv — classifies relevance via up to five parallel SubAgents (no third-party LLM key — the agent is the LLM), and writes a single-file HTML report plus BibTeX/RIS/CSV and a PRISMA-S disclosure log. Four depth tiers (5 min → 3 hr).

## Details
- Repo: https://github.com/O0000-code/paper-search-pro (Apache-2.0)
- Live demo: https://o0000-code.github.io/paper-search-pro/
- Added as an "External repo" entry under Data & Analysis, matching the existing external-repo entries in the list.
- The SKILL.md metadata (name + one-line description) is compact and well within Codex context limits; the step body loads only after the skill fires.
- No third-party LLM key. Scholarly-API setup: a free OpenAlex API key and an NCBI email are the only required credentials (~15 min); Semantic Scholar and CrossRef are optional free add-ons; arXiv needs none.
