### PR TITLE
Add repo-showcase to Meta & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [template-skill/](./template-skill/) - Starter template for building new skills.
 - [skill-installer/](./skill-installer/) - Helper scripts to install skills from curated lists or GitHub paths.
 - [skill-creator/](./skill-creator/) - Guidance for building effective Codex skills with progressive disclosure.
+- [repo-showcase](https://github.com/gtskevin/repo-showcase) - Transform any GitHub repo into a professional, star-attracting showcase. Auto-generates conversion-optimized README, SVG assets (logo, banner, og:image), shields.io badges, and 7 community files. Includes 15-point quality self-check. Install: `curl -fsSL https://raw.githubusercontent.com/gtskevin/repo-showcase/main/install.sh | bash`
 
 ## Using Skills in Codex
 


### PR DESCRIPTION
A Codex/Claude Code Skill that transforms any GitHub repo into a professional showcase. Auto-generates README, SVG assets, badges, and community files. Repo: https://github.com/gtskevin/repo-showcase