### PR TITLE
Add app-it to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [app-it](https://github.com/Christian-Katzmann/app-it) - Turn a local web app into a native desktop app with its own icon. No Electron. (Claude Code + Codex skill, macOS stable / Windows beta.)
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
Adds **app-it** to the *Development & Code Tools* section.

[app-it](https://github.com/Christian-Katzmann/app-it) turns a local web app into a native desktop app with its own icon — native window, no Electron. It works as both a Claude Code and Codex skill (macOS stable, Windows beta), and is MIT licensed.

The entry follows the format of the existing external-repo entries in the section (`[name](url) - Description.`) and is appended after the most recent community submissions. No other changes.