### PR TITLE
Add onequery-cli skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [domain-name-brainstormer/](./domain-name-brainstormer/) - Brainstorm available domain names with criteria and checks.
 - [raffle-winner-picker/](./raffle-winner-picker/) - Randomly select winners with audit-friendly logs.
 - [langsmith-fetch/](./langsmith-fetch/) - Pull LangSmith project/test data for analysis.
+- [onequery-cli](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - Agent-ready CLI/skill for bounded, auditable queries against approved data sources through centralized credentials, read-only validation, limits, and audit logs.
 - [helium-mcp/](./helium-mcp/) - Search real-time news with bias scoring, get live market data, ML options pricing, and balanced news synthesis via MCP.
 
 ### Meta & Utilities

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [domain-name-brainstormer/](./domain-name-brainstormer/) - Brainstorm available domain names with criteria and checks.
 - [raffle-winner-picker/](./raffle-winner-picker/) - Randomly select winners with audit-friendly logs.
 - [langsmith-fetch/](./langsmith-fetch/) - Pull LangSmith project/test data for analysis.
-- [onequery-cli](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - CLI skill for safe, auditable agent queries against approved data sources.
+- [onequery-cli](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - CLI skill for safe, auditable queries for agents against approved data sources.
 - [helium-mcp/](./helium-mcp/) - Search real-time news with bias scoring, get live market data, ML options pricing, and balanced news synthesis via MCP.
 
 ### Meta & Utilities

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [domain-name-brainstormer/](./domain-name-brainstormer/) - Brainstorm available domain names with criteria and checks.
 - [raffle-winner-picker/](./raffle-winner-picker/) - Randomly select winners with audit-friendly logs.
 - [langsmith-fetch/](./langsmith-fetch/) - Pull LangSmith project/test data for analysis.
-- [onequery-cli](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - Agent-ready CLI/skill for bounded, auditable queries against approved data sources through centralized credentials, read-only validation, limits, and audit logs.
+- [onequery-cli](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - CLI skill for safe, auditable agent queries against approved data sources.
 - [helium-mcp/](./helium-mcp/) - Search real-time news with bias scoring, get live market data, ML options pricing, and balanced news synthesis via MCP.
 
 ### Meta & Utilities


### PR DESCRIPTION
Adds onequery-cli to Data & Analysis.

OneQuery CLI is a Codex-compatible skill for safe, auditable queries for agents against approved data sources.

Guideline check:
- Solves a concrete data-access workflow for agents.
- Uses the existing README entry format and category.
- Link works and no duplicate OneQuery entry was found before submission.
- Disclosure: I am affiliated with Wordbricks/OneQuery.