### PR TITLE
Add web typography skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [pr-review-ci-fix/](./pr-review-ci-fix/) - Automated GitHub/GitLab PR review plus CI auto-fix loop via the Composio CLI.
 - [sentry-triage/](./sentry-triage/) - Diagnose Sentry issues by mapping stack frames to local source — no copy-paste.
 - [webapp-testing/](./webapp-testing/) - Run targeted web app tests and summarize results.
+- [web-typography](https://github.com/simongonzalezdc/web-typography-skill) - Apply expert web typography in front-end projects: font choice, fluid type scales, readable measure, font loading, CLS prevention, and WCAG-oriented text accessibility. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo simongonzalezdc/web-typography-skill --path . --name web-typography`
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.


### PR DESCRIPTION
## Summary
- Adds `web-typography` to Development & Code Tools.
- The skill gives Codex a practical workflow for front-end web typography: font choice, fluid type scales, readable measure, vertical rhythm, font loading, CLS prevention, modern CSS type features, and WCAG-oriented text accessibility.

## Why it fits Codex
- The repo is a Codex-compatible root-level skill with `SKILL.md` frontmatter.
- The README entry includes a tested Codex installer command using `install-skill-from-github.py`.
- It is useful during front-end implementation and UI polishing work, especially HTML/CSS/JSX/Tailwind projects.

## Validation
- Tested install command into a temporary Codex skills directory:
  `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo simongonzalezdc/web-typography-skill --path . --name web-typography`
- Installed skill passed `quick_validate.py`.
- Source repo passed `./scripts/validate.sh` including gitleaks with no leaks.
- License endpoint detects Apache-2.0.
