### PR TITLE
Add Codex Small Business skills collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [notion-meeting-intelligence/](./notion-meeting-intelligence/) - Prepare meeting materials with Notion context plus Codex research.
 - [notion-research-documentation/](./notion-research-documentation/) - Synthesize multiple Notion sources into briefs, comparisons, or reports with citations.
 - [notion-spec-to-implementation/](./notion-spec-to-implementation/) - Turn Notion specs into implementation plans, tasks, and progress tracking.
+- [codex-small-business-skills](https://github.com/simongonzalezdc/codex-small-business-skills) - Apache-2.0 Codex port of Anthropic's Small Business skills: 31 owner-operator workflows for cash flow, invoices, CRM hygiene, support, marketing, hiring, and weekly business rhythm. Install: `git clone https://github.com/simongonzalezdc/codex-small-business-skills && cd codex-small-business-skills && ./scripts/install-codex-skills.sh`
 - [support-ticket-triage/](./support-ticket-triage/) - Triage customer support tickets with categories, priority, next actions, and draft replies.
 - [file-organizer/](./file-organizer/) - Organize, rename, and tidy files to keep workspaces clean.
 - [paperjsx/](./paperjsx/) - Generate PPTX presentations, DOCX documents, XLSX spreadsheets, and PDF invoices/reports/charts from structured JSON. Runs locally via `@paperjsx/mcp-server` — no API key, no network calls.


### PR DESCRIPTION
## Summary
- add the public Codex Small Business skills collection to the Productivity & Collaboration section
- list it as an external Codex repo with an install command for the full collection
- make provenance explicit: Apache-2.0 Codex port of Anthropic's Small Business skills

## Validation
- README-only change
- local commit hook passed README validation
