### PR TITLE
Add staff-engineer-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [staff-engineer-mode](https://github.com/sirmarkz/staff-engineer-mode) - Major-outage lessons for Codex engineering work. One router skill sends architecture, reliability, security, delivery, and operations prompts to 54 specialist references. Install: `codex plugin marketplace add https://github.com/sirmarkz/staff-engineer-mode.git && codex plugin add staff-engineer-mode@staff-engineer-mode`
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
Adds Staff Engineer Mode to Development & Code Tools.

Staff Engineer Mode packages major-outage lessons as one Codex-compatible router skill. It routes architecture, reliability, security, delivery, and operations prompts to 54 specialist references, and the entry includes the documented Codex plugin install command.

Validation:
- Checked for an existing Staff Engineer Mode entry
- git diff --check