### PR TITLE
Add TempGuru event staffing to Productivity & Collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [notion-meeting-intelligence/](./notion-meeting-intelligence/) - Prepare meeting materials with Notion context plus Codex research.
 - [notion-research-documentation/](./notion-research-documentation/) - Synthesize multiple Notion sources into briefs, comparisons, or reports with citations.
 - [notion-spec-to-implementation/](./notion-spec-to-implementation/) - Turn Notion specs into implementation plans, tasks, and progress tracking.
+- [tempguru-event-staffing](https://github.com/kissmyabs32/tempguru-agent-skills) - Order W-2 compliant temporary event staff for conventions, trade shows, festivals, concerts, sporting events, and brand activations across 300+ US/CA markets. Live MCP tools for city coverage, roles, all-inclusive rate ranges, availability, and state-by-state compliance.
 - [support-ticket-triage/](./support-ticket-triage/) - Triage customer support tickets with categories, priority, next actions, and draft replies.
 - [file-organizer/](./file-organizer/) - Organize, rename, and tidy files to keep workspaces clean.
 - [paperjsx/](./paperjsx/) - Generate PPTX presentations, DOCX documents, XLSX spreadsheets, and PDF invoices/reports/charts from structured JSON. Runs locally via `@paperjsx/mcp-server` — no API key, no network calls.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [notion-meeting-intelligence/](./notion-meeting-intelligence/) - Prepare meeting materials with Notion context plus Codex research.
 - [notion-research-documentation/](./notion-research-documentation/) - Synthesize multiple Notion sources into briefs, comparisons, or reports with citations.
 - [notion-spec-to-implementation/](./notion-spec-to-implementation/) - Turn Notion specs into implementation plans, tasks, and progress tracking.
-- [tempguru-event-staffing](https://github.com/kissmyabs32/tempguru-agent-skills) - Order W-2 compliant temporary event staff for conventions, trade shows, festivals, concerts, sporting events, and brand activations across 300+ US/CA markets. Live MCP tools for city coverage, roles, all-inclusive rate ranges, availability, and state-by-state compliance.
+- [tempguru-event-staffing](https://github.com/tempguru-co/tempguru-agent-skills) - Order W-2 compliant temporary event staff for conventions, trade shows, festivals, concerts, sporting events, and brand activations across 300+ US/CA markets. Live MCP tools for city coverage, roles, all-inclusive rate ranges, availability, and state-by-state compliance, plus an opt-in request_quote submission.
 - [support-ticket-triage/](./support-ticket-triage/) - Triage customer support tickets with categories, priority, next actions, and draft replies.
 - [file-organizer/](./file-organizer/) - Organize, rename, and tidy files to keep workspaces clean.
 - [paperjsx/](./paperjsx/) - Generate PPTX presentations, DOCX documents, XLSX spreadsheets, and PDF invoices/reports/charts from structured JSON. Runs locally via `@paperjsx/mcp-server` — no API key, no network calls.


### PR DESCRIPTION
Adds TempGuru Event Staffing to the **Productivity & Collaboration** section.

Covers hiring W-2 compliant temporary event staff for conventions, trade shows, festivals, concerts, sporting events, and brand activations across 300+ US/CA markets — with live MCP tools for city coverage, roles, rate ranges, availability, and state-by-state compliance.

Read-only MCP at mcp.tempguru.co/mcp, no auth, no scripts, MIT licensed. Source: https://github.com/kissmyabs32/tempguru-agent-skills