### PR TITLE
Add Diffmode Growth Tactics (growth-strategy pipeline for Codex)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [file-organizer/](./file-organizer/) - Organize, rename, and tidy files to keep workspaces clean.
 - [paperjsx/](./paperjsx/) - Generate PPTX presentations, DOCX documents, XLSX spreadsheets, and PDF invoices/reports/charts from structured JSON. Runs locally via `@paperjsx/mcp-server` — no API key, no network calls.
 - [skill-share/](./skill-share/) - Share skills and reusable instructions across teammates.
+- [Diffmode Growth Tactics](https://github.com/acogood/diffmode_free) - Growth-strategy research pipeline for Codex: a competitor read, a buyer jobs-to-be-done map, and 7-9 unconventional acquisition tactics written to `synthesis.md`. Mines growth mechanisms from fresh case studies and fuses 2-3 per tactic. Run: `python3 codex/orchestrate.py --url <site>`. Free, Apache-2.0, Perplexity-optional.
 
 ### Communication & Writing
 - [codex-sms-verification](https://github.com/virtualsms-io/codex-sms-verification) - External repo: real-SIM SMS verification for AI agents via VirtualSMS MCP. 145+ countries, 2000+ services, both hosted (mcp.virtualsms.io) and local stdio transports.


### PR DESCRIPTION
Adds **Diffmode Growth Tactics** under *Productivity & Collaboration* — a free growth-strategy research pipeline that runs on Codex (and Claude Code off the same skill files).

Point it at a product URL and it researches the market and writes a `synthesis.md`:
- a **competitor read** (who you're up against + the channels each rival leans on),
- a **buyer jobs-to-be-done map**, and
- **7–9 unconventional acquisition tactics** built for the founder's constraints — each fuses 2–3 growth mechanisms mined fresh from public case studies.

**Run on Codex**
```
python3 codex/orchestrate.py --url https://your-product.com
```
Runs via a small stdlib-only Python orchestrator; Perplexity-optional with Codex's native web-search fallback. Free, Apache-2.0, no account/API key.

- Repo: https://github.com/acogood/diffmode_free

Added as an external-link entry with the run command inline, matching the format of other entries.