### PR TITLE
Add reviewing-code-modularity-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [reviewing-code-modularity-skill](https://github.com/tyshkovskii/reviewing-code-modularity-skill) - Review code structure for module boundaries, coupling, public APIs, dependency direction, and over-engineered abstractions. Install: `npx skills add tyshkovskii/reviewing-code-modularity-skill`
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
Adds a Codex-compatible skill for reviewing code modularity and structure.

The skill helps coding agents review:

- module boundaries
- coupling and cohesion
- public APIs and exports
- dependency direction
- shallow/pass-through abstractions
- over-engineered architecture

Repository: https://github.com/tyshkovskii/reviewing-code-modularity-skill

Install:

```bash
npx skills add tyshkovskii/reviewing-code-modularity-skill