### PR TITLE
Add meta-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [template-skill/](./template-skill/) - Starter template for building new skills.
 - [skill-installer/](./skill-installer/) - Helper scripts to install skills from curated lists or GitHub paths.
 - [skill-creator/](./skill-creator/) - Guidance for building effective Codex skills with progressive disclosure.
-- [meta-skill](https://github.com/joohw/meta-skill) - Evaluate, differentiate, and design Codex skills with a concise design brief, competitive scan, and distinctive skill identity. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo joohw/meta-skill --path . --name meta-skill`
+- [meta-skill](https://github.com/joohw/meta-skill) - Evaluate, differentiate, and design Agent Skills with a concise design brief, competitive scan, and distinctive skill identity. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo joohw/meta-skill --path . --name meta-skill`
 
 ## Using Skills in Codex
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [template-skill/](./template-skill/) - Starter template for building new skills.
 - [skill-installer/](./skill-installer/) - Helper scripts to install skills from curated lists or GitHub paths.
 - [skill-creator/](./skill-creator/) - Guidance for building effective Codex skills with progressive disclosure.
+- [meta-skill](https://github.com/joohw/meta-skill) - Evaluate, differentiate, and design Codex skills with a concise design brief, competitive scan, and distinctive skill identity. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo joohw/meta-skill --path . --name meta-skill`
 
 ## Using Skills in Codex
 


### PR DESCRIPTION
Adds meta-skill to the Meta & Utilities section.\n\nmeta-skill helps Codex evaluate whether a new skill is warranted, compare nearby alternatives, write a concise design brief, and define a distinctive skill identity before implementation.\n\nSource: https://github.com/joohw/meta-skill