### PR TITLE
feat: add TWZRD Agent Intel — Solana x402 trust scoring MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [helium-mcp/](./helium-mcp/) - Search real-time news with bias scoring, get live market data, ML options pricing, and balanced news synthesis via MCP.
 
 ### Meta & Utilities
+- [twzrd-agent-intel](https://intel.twzrd.xyz) - Trust-score Solana agent wallets before x402 micropayments. Free MCP: `score_agent(wallet)`, `preflight_check(wallet)`. Paid: `get_trust_receipt(wallet)`. Config: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 
 - [brand-guidelines/](./brand-guidelines/) - Apply OpenAI/Codex brand colors and typography to artifacts.
 - [agent-deep-links/](./agent-deep-links/) - Build and validate deep links for Codex, Cursor, and VS Code with Slack-safe formatting and fallback guidance.


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Meta & Utilities** section.

TWZRD Agent Intel is a live MCP server that lets Codex agents trust-score Solana wallets before x402 micropayments — useful for any Codex skill that interacts with on-chain agent services.

**Tools:**
- `score_agent(wallet)` — free agent trust score
- `preflight_check(wallet)` — free pre-payment safety check  
- `get_trust_receipt(wallet)` — paid signed receipt (x402 micropayment)

**Config:**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

Live endpoint: https://intel.twzrd.xyz/mcp (Streamable HTTP)