### PR TITLE
Add ppt-image-share-builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [support-ticket-triage/](./support-ticket-triage/) - Triage customer support tickets with categories, priority, next actions, and draft replies.
 - [file-organizer/](./file-organizer/) - Organize, rename, and tidy files to keep workspaces clean.
 - [paperjsx/](./paperjsx/) - Generate PPTX presentations, DOCX documents, XLSX spreadsheets, and PDF invoices/reports/charts from structured JSON. Runs locally via `@paperjsx/mcp-server` — no API key, no network calls.
+- [ppt-image-share-builder](https://github.com/uuoov/ppt-image-share-builder) - External repo: image2-first workflow that turns course topics, source files, and reference PPT styles into slide-image prompts, generated PPT page images, contact-sheet QA, full-bleed PPTX assembly, and timed presentation scripts.
 - [skill-share/](./skill-share/) - Share skills and reusable instructions across teammates.
 
 ### Communication & Writing


### PR DESCRIPTION
Adds ppt-image-share-builder, an image2-first Codex skill for turning course topics, source files, and reference PPT styles into slide-image prompts, generated PPT page images, contact-sheet QA, full-bleed PPTX assembly, and timed presentation scripts.