### PR TITLE
Add mechanical engineering research skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [email-draft-polish/](./email-draft-polish/) - Draft, rewrite, or condense emails for the right tone and audience.
 - [changelog-generator/](./changelog-generator/) - Create clear changelogs from commits or summaries.
 - [content-research-writer/](./content-research-writer/) - Research and draft content with sourced citations.
+- [mechanical-engineering-research](https://github.com/hanhuark/mechanical-engineering-research-skill) - External repo: thermal-fluid mechanical engineering research skill for technical writing, literature reviews, figure discussion, hypothesis-driven DOE, proposals, presentations, research coding, and mentor-style first-pass feedback. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo hanhuark/mechanical-engineering-research-skill --path skills/mechanical-engineering-research --name mechanical-engineering-research`
 - [diasporic-intelligence](https://github.com/MinistaJazz/diasporic-intelligence) - External repo: source-credit skill for consent-governed lineage AI with attribution, provenance, revocation, and non-impersonation boundaries.
 - [novel-writing](https://github.com/wgwtest/novel-writing) - External repo: public Codex skill for fiction planning, chapter drafting, scene continuation, and revision.
 - [tailored-resume-generator/](./tailored-resume-generator/) - Tailor resumes to job descriptions with quantified impact.


### PR DESCRIPTION
﻿## Summary

Adds the external `mechanical-engineering-research` Codex skill to the Communication & Writing section.

The skill supports thermal-fluid mechanical engineering research workflows, including technical writing, literature review, figure discussion, hypothesis-driven DOE, proposals, presentations, research coding, and mentor-style first-pass feedback.

## Validation

- README-only listing change
- `git diff --check`
