### PR TITLE
Add Developer Marketing Skills section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [skill-installer/](./skill-installer/) - Helper scripts to install skills from curated lists or GitHub paths.
 - [skill-creator/](./skill-creator/) - Guidance for building effective Codex skills with progressive disclosure.
 
+### Developer Marketing Skills
+- [Infrasity-Labs/dev-gtm-claude-skills](https://github.com/Infrasity-Labs/dev-gtm-claude-skills) - Open-source, cross-platform agent skills for Claude Code and agentskills.io-compatible platforms. These skills are for SEO, GEO (Generative Engine Optimization), AI discoverability, and developer marketing. 
+
 ## Using Skills in Codex
 
 - Skills live in `$CODEX_HOME/skills` (default `~/.codex/skills`). Each subfolder needs a `SKILL.md` with `name` and `description` frontmatter.


### PR DESCRIPTION
Added developer marketing skills to the readme section. These skills are made for AEO, GEO, and AI Visibility

Add the dev-gtm-claude-skills repo to your community skills. These are agent skills for developer marketing workflows, AEO, GEO and AI Visibility

# Pull Request: Add Skill

## Skill Information

- **Skill Name:** dev-gtm-claude-skills
- **Category:** Developer Marketing
- **Repository URL:** https://github.com/Infrasity-Labs/dev-gtm-claude-skills
- **I am the author of this skill:** [x] Yes [ ] No

## Quality Checklist

Please verify that your submission meets these requirements:

- [x] Has working `SKILL.md` file with YAML frontmatter
- [x] Clear, concise documentation
- [x] Active maintenance (commits within last 6 months)
- [x] Relevant to Codex workflows
- [x] No security vulnerabilities or malicious code
- [x] All links are valid and working
- [x] Includes specific use case

## Skill Entry
### Developer Marketing Skills
- [Infrasity-Labs/dev-gtm-claude-skills](https://github.com/Infrasity-Labs/dev-gtm-claude-skills)  - Open-source, cross-platform agent skills for Claude Code and agentskills.io-compatible platforms. These skills are for SEO, GEO (Generative Engine Optimization), AI discoverability, and developer marketing. 

## Why This Skill is Valuable

These skills automate the tedious, repetitive parts of developer GTM work like auditing doc metadata, checking AI discoverability, and validating content structure, freeing developer marketing teams to focus on strategy instead of manually checking hundreds of pages.

## Testing

- [x] I have tested this skill with Codex
- [x] The skill works as described
- [x] Installation instructions are clear

---

**By submitting this PR, I confirm that:**
- This contribution is my own work or I have the right to submit it