### PR TITLE
Add gcf-proxy skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [create-plan/](./create-plan/) - Quickly draft concise execution plans for coding tasks.
 - [deploy-pipeline/](./deploy-pipeline/) - End-to-end Stripe → Supabase → Vercel release pipelines with verify and rollback.
 - [Emdash Skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS: CF Workers + Hono + Angular + D1 + Stripe. One-line prompts to deployed SaaS with 94 reference docs, 18 agents, and Codex-native `.agents/skills/` support.
+- [gcf-proxy](https://github.com/blackwell-systems/gcf-codex-plugin) - Save 71% on MCP tool call tokens by wrapping any server with GCF encoding. Setup and stats skills plus session savings hook. 100% comprehension across 1,700+ LLM evaluations.
 - [gh-address-comments/](./gh-address-comments/) - Address review or issue comments on the open GitHub PR for the current branch using `gh`.
 - [gh-fix-ci/](./gh-fix-ci/) - Inspect failing GitHub Actions checks, summarize failures, and propose fixes.
 - [mcp-builder/](./mcp-builder/) - Build and evaluate MCP servers with best practices and an evaluation harness.


### PR DESCRIPTION
## Summary
Adds gcf-proxy to Development & Code Tools. Wraps any MCP server with GCF encoding, saving 71% on tool call tokens.

Two skills:
- `/gcf-proxy:setup <server>` - wrap any MCP server
- `/gcf-proxy:stats` - show session token savings

100% comprehension accuracy across 1,700+ LLM evaluations, 10+ models, 3 providers.

- [Plugin repo](https://github.com/blackwell-systems/gcf-codex-plugin)
- [GCF Proxy](https://github.com/blackwell-systems/gcf-proxy)
- [Benchmarks](https://gcformat.com/guide/benchmarks.html)