### PR TITLE
Add html2link-publish skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [Emdash Skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS: CF Workers + Hono + Angular + D1 + Stripe. One-line prompts to deployed SaaS with 94 reference docs, 18 agents, and Codex-native `.agents/skills/` support.
 - [gh-address-comments/](./gh-address-comments/) - Address review or issue comments on the open GitHub PR for the current branch using `gh`.
 - [gh-fix-ci/](./gh-fix-ci/) - Inspect failing GitHub Actions checks, summarize failures, and propose fixes.
+- [html2link-publish/](./html2link-publish/) - Publish HTML, docs, decks, spreadsheets, and static sites to short share links. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo joohw/html2link-skill --path html2link-publish --name html2link-publish`
 - [mcp-builder/](./mcp-builder/) - Build and evaluate MCP servers with best practices and an evaluation harness.
 - [pr-review-ci-fix/](./pr-review-ci-fix/) - Automated GitHub/GitLab PR review plus CI auto-fix loop via the Composio CLI.
 - [sentry-triage/](./sentry-triage/) - Diagnose Sentry issues by mapping stack frames to local source — no copy-paste.

--- a/html2link-publish/SKILL.md
+++ b/html2link-publish/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: html2link-publish
+description: Publish generated artifacts to html2link.dev and return short shareable URLs. Use when Codex or another agent creates an HTML file, static site ZIP, PDF, Markdown document, spreadsheet, DOCX, or PPTX and needs to give the user a browser-friendly link instead of only a local file path or attachment.
+---
+
+# html2link Publish
+
+## Overview
+
+Use html2link to turn local artifacts into short links that open directly in a browser. Prefer this skill after creating a report, prototype, dashboard, presentation, document, static site, or other deliverable that the user may want to view or share.
+
+## Supported Inputs
+
+- `.html`, `.htm`
+- `.zip` static sites that contain `index.html`; archives with one top-level folder are normalized by html2link
+- `.pdf`
+- `.md`, `.markdown`
+- `.xlsx`, `.xls`, `.csv`
+- `.docx`
+- `.pptx`
+
+## Publish Workflow
+
+1. Write the artifact to a stable local file path.
+2. If the artifact is a static site, package it as a ZIP with `index.html` at the root when possible.
+3. Upload the file with `scripts/publish-html2link.mjs` or an equivalent `curl` request.
+4. Return only the public `url` field to the user unless they ask for API details.
+5. Treat `updateToken` as private. Store or show it only when the user explicitly wants to update or delete the same link later.
+
+## Script
+
+Run the bundled script from the skill directory or with an absolute path:
+
+```bash
+node scripts/publish-html2link.mjs /absolute/path/to/report.html
+```
+
+The script prints the JSON API response. It reads these optional environment variables:
+
+- `HTML2LINK_BASE_URL`: Defaults to `https://html2link.dev`
+- `HTML2LINK_API_TOKEN`: Bearer token for files over the anonymous limit
+
+Update an existing link:
+
+```bash
+node scripts/publish-html2link.mjs /absolute/path/to/report.html --slug a1B2c3D4 --update-token keep-this-private
+```
+
+Delete a link:
+
+```bash
+node scripts/publish-html2link.mjs --delete --slug a1B2c3D4 --update-token keep-this-private
+```
+
+## Direct API
+
+Upload with multipart field `file`:
+
+```bash
+curl -F "file=@/absolute/path/to/report.html" https://html2link.dev/api/upload
+```
+
+For files above 1 MB, include a signed-in user's API token:
+
+```bash
+curl -H "Authorization: Bearer $HTML2LINK_API_TOKEN" -F "file=@/absolute/path/to/report.pptx" https://html2link.dev/api/upload
+```
+
+Successful response:
+
+```json
+{
+  "slug": "a1B2c3D4",
+  "updateToken": "keep-this-private",
+  "url": "https://html2link.dev/x/a1B2c3D4",
+  "kind": "html",
+  "size": "42 KB",
+  "updated": false
+}
+```
+
+Update an existing link:
+
+```bash
+curl -F "slug=a1B2c3D4" -F "updateToken=keep-this-private" -F "file=@/absolute/path/to/report.html" https://html2link.dev/api/upload
+```
+
+Delete an existing link:
+
+```bash
+curl -X DELETE -H "Content-Type: application/json" -d '{"slug":"a1B2c3D4","updateToken":"keep-this-private"}' https://html2link.dev/api/upload
+```
+
+## Limits And Errors
+
+- Anonymous uploads are free up to 1 MB.
+- Authenticated uploads are supported up to 100 MB.
+- If the API returns `requiresLogin: true`, tell the user the file is over the anonymous limit and needs authenticated publishing with `HTML2LINK_API_TOKEN`.
+- If upload fails, report the HTTP status and response body. Do not invent a link.
+- If publishing sensitive or private material, confirm that the user wants a public share link before uploading.
+
+## User Response
+
+Keep the response concise:
+
+```text
+Published: https://html2link.dev/x/a1B2c3D4
+```
+
+Mention the local file path only when it is useful for follow-up work.

--- a/html2link-publish/agents/openai.yaml
+++ b/html2link-publish/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "html2link Publish"
+  short_description: "Publish agent artifacts as shareable html2link.dev URLs."
+  default_prompt: "Use $html2link-publish to publish this artifact as a shareable link."

--- a/html2link-publish/scripts/publish-html2link.mjs
+++ b/html2link-publish/scripts/publish-html2link.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const usage = `Usage:
+  node scripts/publish-html2link.mjs <file> [--slug <slug> --update-token <token>]
+  node scripts/publish-html2link.mjs --delete --slug <slug> --update-token <token>
+
+Environment:
+  HTML2LINK_BASE_URL   Defaults to https://html2link.dev
+  HTML2LINK_API_TOKEN  Optional bearer token for authenticated uploads
+`;
+
+function readArgs(argv) {
+  const args = {
+    file: null,
+    slug: null,
+    updateToken: null,
+    delete: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const value = argv[i];
+    if (value === "--help" || value === "-h") {
+      args.help = true;
+    } else if (value === "--delete") {
+      args.delete = true;
+    } else if (value === "--slug") {
+      args.slug = argv[++i] ?? null;
+    } else if (value === "--update-token") {
+      args.updateToken = argv[++i] ?? null;
+    } else if (!args.file) {
+      args.file = value;
+    } else {
+      throw new Error(`Unexpected argument: ${value}`);
+    }
+  }
+
+  return args;
+}
+
+async function requestJson(url, options) {
+  const response = await fetch(url, options);
+  const text = await response.text();
+  let body;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+
+  if (!response.ok) {
+    const detail = typeof body === "string" ? body : JSON.stringify(body);
+    throw new Error(`html2link request failed (${response.status}): ${detail}`);
+  }
+
+  return body;
+}
+
+async function upload({ file, slug, updateToken, baseUrl, apiToken }) {
+  if (!file) {
+    throw new Error("Missing file path.");
+  }
+
+  const absolutePath = path.resolve(file);
+  const bytes = await readFile(absolutePath);
+  const form = new FormData();
+  form.append("file", new Blob([bytes]), path.basename(absolutePath));
+
+  if (slug) {
+    form.append("slug", slug);
+  }
+  if (updateToken) {
+    form.append("updateToken", updateToken);
+  }
+
+  const headers = {};
+  if (apiToken) {
+    headers.Authorization = `Bearer ${apiToken}`;
+  }
+
+  return requestJson(`${baseUrl}/api/upload`, {
+    method: "POST",
+    headers,
+    body: form,
+  });
+}
+
+async function deleteLink({ slug, updateToken, baseUrl, apiToken }) {
+  if (!slug || !updateToken) {
+    throw new Error("Deleting a link requires --slug and --update-token.");
+  }
+
+  const headers = { "Content-Type": "application/json" };
+  if (apiToken) {
+    headers.Authorization = `Bearer ${apiToken}`;
+  }
+
+  return requestJson(`${baseUrl}/api/upload`, {
+    method: "DELETE",
+    headers,
+    body: JSON.stringify({ slug, updateToken }),
+  });
+}
+
+async function main() {
+  const args = readArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(usage);
+    return;
+  }
+
+  const baseUrl = (process.env.HTML2LINK_BASE_URL || "https://html2link.dev").replace(/\/+$/, "");
+  const apiToken = process.env.HTML2LINK_API_TOKEN || "";
+  const result = args.delete
+    ? await deleteLink({ ...args, baseUrl, apiToken })
+    : await upload({ ...args, baseUrl, apiToken });
+
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.message}\n\n${usage}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds html2link-publish, a Codex-compatible Agent Skill for publishing generated artifacts to short html2link.dev share links.

## Use case

Codex often creates HTML reports, prototypes, static site ZIPs, Markdown files, spreadsheets, PDFs, DOCX, and PPTX deliverables. This skill gives Codex a repeatable publishing workflow and a bundled Node script so users can receive a public browser link.

## Canonical repo

https://github.com/joohw/html2link-skill

## Tested

- Ran the skill validator against html2link-publish
- Checked the bundled Node upload script with --help
- Published a Markdown artifact through html2link.dev successfully: https://html2link.dev/x/yeiEwrKr