### PR TITLE
Add COMPASS Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [file-organizer/](./file-organizer/) - Organize, rename, and tidy files to keep workspaces clean.
 - [paperjsx/](./paperjsx/) - Generate PPTX presentations, DOCX documents, XLSX spreadsheets, and PDF invoices/reports/charts from structured JSON. Runs locally via `@paperjsx/mcp-server` — no API key, no network calls.
 - [skill-share/](./skill-share/) - Share skills and reusable instructions across teammates.
+- [COMPASS Skills](https://github.com/dongshuyan/compass-skills) - Local-first task clarification, repo-local task forests, and user-profile context for long-running Codex work. Install: `npx skills add dongshuyan/compass-skills --skill '*' -a codex`
 
 ### Communication & Writing
 - [codex-sms-verification](https://github.com/virtualsms-io/codex-sms-verification) - External repo: real-SIM SMS verification for AI agents via VirtualSMS MCP. 145+ countries, 2000+ services, both hosted (mcp.virtualsms.io) and local stdio transports.


### PR DESCRIPTION
Adds COMPASS Skills to the Productivity & Collaboration section.

Repo:
https://github.com/dongshuyan/compass-skills

COMPASS Skills is a local-first SKILL.md suite for long-running Codex-style work. It includes:

- task-clarifier: aligns ambiguous or risky work before execution
- task-forest: keeps a repo-local task forest / DAG across sessions
- user-profile-keeper: stores local collaboration preferences and risk boundaries

Install:
npx skills add dongshuyan/compass-skills --skill '*' -a codex

Safety model:
- no profile upload
- no credential access
- no browser-cookie access
- local files / local SQLite only
- explicit confirmation for destructive or externally visible actions