### PR TITLE
Add RuleDoctor skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [gh-fix-ci/](./gh-fix-ci/) - Inspect failing GitHub Actions checks, summarize failures, and propose fixes.
 - [mcp-builder/](./mcp-builder/) - Build and evaluate MCP servers with best practices and an evaluation harness.
 - [pr-review-ci-fix/](./pr-review-ci-fix/) - Automated GitHub/GitLab PR review plus CI auto-fix loop via the Composio CLI.
+- [RuleDoctor](https://github.com/syf2211/ruledoctor/tree/main/skills/ruledoctor) - Agent skill that reads CLAUDE.md, AGENTS.md, and required_reads before coding. Optional CLI audit and hooks. Install: `npx skills add syf2211/ruledoctor@ruledoctor -g -y`
 - [sentry-triage/](./sentry-triage/) - Diagnose Sentry issues by mapping stack frames to local source — no copy-paste.
 - [webapp-testing/](./webapp-testing/) - Run targeted web app tests and summarize results.
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`


### PR DESCRIPTION
## Summary

Adds RuleDoctor to the Development & Code Tools section.

RuleDoctor is an installable Codex-compatible Agent Skill that makes coding agents read project rules such as CLAUDE.md, AGENTS.md, .cursorrules, and configured required_reads before coding. It also includes optional CLI audit and hook support for teams that want post-session reports or command guards.

## Link

https://github.com/syf2211/ruledoctor/tree/main/skills/ruledoctor