### PR TITLE
Add harmony-next.skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [Emdash Skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS: CF Workers + Hono + Angular + D1 + Stripe. One-line prompts to deployed SaaS with 94 reference docs, 18 agents, and Codex-native `.agents/skills/` support.
 - [gh-address-comments/](./gh-address-comments/) - Address review or issue comments on the open GitHub PR for the current branch using `gh`.
 - [gh-fix-ci/](./gh-fix-ci/) - Inspect failing GitHub Actions checks, summarize failures, and propose fixes.
+- [harmony-next.skills](https://github.com/linhay/harmony-next.skills) - HarmonyOS NEXT developer skill for Codex and other coding agents. Provides local ArkTS/ArkUI/API references, DevEco Studio and Emulator automation workflows, HDC evidence capture, offline UI/UX audit, trace audit tooling, and an Empty Ability smoke-test template.
 - [mcp-builder/](./mcp-builder/) - Build and evaluate MCP servers with best practices and an evaluation harness.
 - [pr-review-ci-fix/](./pr-review-ci-fix/) - Automated GitHub/GitLab PR review plus CI auto-fix loop via the Composio CLI.
 - [sentry-triage/](./sentry-triage/) - Diagnose Sentry issues by mapping stack frames to local source — no copy-paste.


### PR DESCRIPTION
Adds harmony-next.skills, a HarmonyOS NEXT developer skill for Codex and other coding agents.

It provides local ArkTS/ArkUI/API references, DevEco Studio and Emulator automation workflows, HDC evidence capture, offline UI/UX audit, trace audit tooling, and an Empty Ability smoke-test template.
