### PR TITLE
Add Super Review Council skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [gh-fix-ci/](./gh-fix-ci/) - Inspect failing GitHub Actions checks, summarize failures, and propose fixes.
 - [mcp-builder/](./mcp-builder/) - Build and evaluate MCP servers with best practices and an evaluation harness.
 - [pr-review-ci-fix/](./pr-review-ci-fix/) - Automated GitHub/GitLab PR review plus CI auto-fix loop via the Composio CLI.
+- [super-review-council](https://github.com/molang163/super-review-council) - Heavy multi-agent review council for Codex. Freezes the target, runs several AI reviewers, triages findings, verifies fixes, and repeats until no actionable findings remain. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo molang163/super-review-council --path skills/super-review-council --name super-review-council`
 - [sentry-triage/](./sentry-triage/) - Diagnose Sentry issues by mapping stack frames to local source — no copy-paste.
 - [webapp-testing/](./webapp-testing/) - Run targeted web app tests and summarize results.
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`


### PR DESCRIPTION
Adds Super Review Council, a heavy multi-agent review workflow for Codex.

Source repo: https://github.com/molang163/super-review-council
Release: https://github.com/molang163/super-review-council/releases/tag/v0.1.1

The entry includes a skill-installer command pointing to skills/super-review-council.