### PR TITLE
Add ax workflow extraction skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [competitive-ads-extractor/](./competitive-ads-extractor/) - Analyze competitor ads and extract structured insights.
 - [datadog-logs/](./datadog-logs/) - Filter Datadog logs from the shell via the Composio CLI, with JSON-friendly output and digest workflows.
 - [developer-growth-analysis/](./developer-growth-analysis/) - Analyze Codex chat history for coding patterns and learning gaps.
+- [ax-extract-workflow](https://github.com/Necmttn/ax/tree/main/skills/ax-extract-workflow) - Reconstruct shipped workflows from local ax sessions, commits, tool calls, and skill usage. Install: `npx skills add Necmttn/ax`
 - [lead-research-assistant/](./lead-research-assistant/) - Research leads and enrich records with firmographic data.
 - [domain-name-brainstormer/](./domain-name-brainstormer/) - Brainstorm available domain names with criteria and checks.
 - [raffle-winner-picker/](./raffle-winner-picker/) - Randomly select winners with audit-friendly logs.


### PR DESCRIPTION
Adds ax-extract-workflow to Data & Analysis.

The skill reconstructs how a shipped change happened from local ax sessions, commits, tool calls, and skill usage. It is useful when reviewing what worked in a Codex/Claude coding workflow and turning that into a repeatable process.

---

_Generated with [ax](https://github.com/Necmttn/ax)._