### PR TITLE
Add postmortemthis (multi-agent fan-out review)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [postmortemthis](https://github.com/Softeria/postmortemthis) - Fan one prompt across every coding agent on your machine (Claude Code, Codex, Gemini, Qwen, Vibe) at once, read-only and in parallel, then synthesize their replies — a multi-agent second opinion on a diff, a design, or an idea. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo Softeria/postmortemthis --path skills/postmortemthis --name postmortemthis`
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
Adds **postmortemthis** to *Development & Code Tools*.

It fans one prompt across every coding-agent CLI installed on your machine (Claude Code, Codex, Gemini, Qwen, Vibe) at once — read-only, in parallel — then synthesizes their replies into one second opinion. Not limited to diffs: the target can be a design, a plan, or an idea (even in an empty folder).

- Skill: `skills/postmortemthis/SKILL.md` (installable via the skill-installer path used by other entries)
- Repo: https://github.com/Softeria/postmortemthis
- License: MIT