### PR TITLE
Add remote-gpu-trainer to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [remote-gpu-trainer](https://github.com/Hanyuyuan6/remote-gpu-trainer) - "Survival ops for long GPU jobs on rented/remote instances (AutoDL, RunPod, vast.ai, Lambda, Slurm, K8s): teardown/billing safety, spot-preemption resilience, resumable checkpointing, plus OOM/NCCL-hang/NaN/throughput debugging."
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
Adds one external-repo entry under **Development & Code Tools**.

**Skill:** [remote-gpu-trainer](https://github.com/Hanyuyuan6/remote-gpu-trainer) — a SKILL.md-format Agent Skill (MIT) for running long GPU jobs on **rented/remote instances you don't own** (AutoDL, RunPod, vast.ai, Lambda, Paperspace, bare SSH, Slurm, K8s). It covers the ops failure modes that lose money or work on metered boxes: teardown/billing safety (stop-vs-terminate), spot-preemption resilience, resumable checkpointing under a full data disk, plus a DL-debug layer (CUDA OOM, NCCL multi-GPU hang, NaN/loss-spike, throughput, convergence, dataloader bugs).

**Why it fits:** it's Codex-runnable operational tooling (shell + SSH driven; scripts are bash/python), complementing the deploy/CI-oriented skills already in this category — it targets the remote-GPU lifecycle those don't cover.

Single line added; description states the Codex trigger conditions. No folder vendored since the skill is maintained in its own repo, matching the existing external-link entries (brooks-lint, codebase-recon, AuraKit, polywave, etc.).