### PR TITLE
feat: add EGC - persistent memory MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [codebase-recon](https://github.com/yujiachen-y/codebase-recon-skill) - Analyze git history to understand a codebase before reading any code — surfaces hotspots, bug magnets, bus factor, momentum, and high-risk files (hotspot ∩ bug-magnet) via auto-scaled analysis. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo yujiachen-y/codebase-recon-skill --path skills/codebase-recon --name codebase-recon`
 - [create-plan/](./create-plan/) - Quickly draft concise execution plans for coding tasks.
 - [deploy-pipeline/](./deploy-pipeline/) - End-to-end Stripe → Supabase → Vercel release pipelines with verify and rollback.
+- [EGC](https://github.com/Fmarzochi/EGC) - Persistent cross-session memory MCP server for Codex and 12 other AI coding tools. SQLite-backed state survives context resets. Install: `npm install -g @egchq/egc`
 - [Emdash Skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS: CF Workers + Hono + Angular + D1 + Stripe. One-line prompts to deployed SaaS with 94 reference docs, 18 agents, and Codex-native `.agents/skills/` support.
 - [gh-address-comments/](./gh-address-comments/) - Address review or issue comments on the open GitHub PR for the current branch using `gh`.
 - [gh-fix-ci/](./gh-fix-ci/) - Inspect failing GitHub Actions checks, summarize failures, and propose fixes.


### PR DESCRIPTION
## Summary

Adds [EGC](https://github.com/Fmarzochi/EGC) to the Development & Code Tools section in alphabetical order.

EGC is a persistent cross-session memory MCP server for Codex and 12 other AI coding tools (Claude Code, Cursor, Gemini CLI, Windsurf, Amp, Kiro, VS Code Copilot, Trae, and more). SQLite-backed, MIT licensed. Install: `npm install -g @egchq/egc`.