### PR TITLE
Add watchvideo evidence-first video analysis skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [raffle-winner-picker/](./raffle-winner-picker/) - Randomly select winners with audit-friendly logs.
 - [langsmith-fetch/](./langsmith-fetch/) - Pull LangSmith project/test data for analysis.
 - [helium-mcp/](./helium-mcp/) - Search real-time news with bias scoring, get live market data, ML options pricing, and balanced news synthesis via MCP.
+- [watchvideo](https://github.com/Dunteng/watch-video-skill) - Evidence-first video understanding for Codex: local transcription, keyframes, optional OCR, and grounded reports. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo Dunteng/watch-video-skill --path . --name watch-video`
 
 ### Meta & Utilities
 


### PR DESCRIPTION
This PR adds watchvideo, a Codex skill + local CLI for evidence-first video analysis.

It helps Codex summarize videos only after producing evidence: downloaded/local video, subtitles or local transcription, keyframes, optional OCR, and structured reports. If video evidence cannot be produced, it writes a failure report and instructs the agent not to summarize from title/description/search results.

Repository: https://github.com/Dunteng/watch-video-skill