### PR TITLE
Add green-screen cutout assets skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [agent-deep-links/](./agent-deep-links/) - Build and validate deep links for Codex, Cursor, and VS Code with Slack-safe formatting and fallback guidance.
 - [canvas-design/](./canvas-design/) - Generate structured canvas layouts and design artifacts.
 - [image-enhancer/](./image-enhancer/) - Upscale and refine images with configurable presets.
+- [green-screen-cutout-assets](https://github.com/ACT-chao/green-screen-cutout-assets-skill) - Generate green-screen foreground assets and batch-convert them into transparent PNGs for apps, games, and UI products. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo ACT-chao/green-screen-cutout-assets-skill --path green-screen-cutout-assets --name green-screen-cutout-assets`
 - [slack-gif-creator/](./slack-gif-creator/) - Generate GIFs for Slack with captions and styling.
 - [theme-factory/](./theme-factory/) - Create reusable theme tokens and palettes.
 - [video-downloader/](./video-downloader/) - Download and prepare videos for offline review.


### PR DESCRIPTION
Adds an external Codex skill for generating green-screen foreground assets and converting them into transparent PNGs for app, game, and UI product workflows.\n\nRepository: https://github.com/ACT-chao/green-screen-cutout-assets-skill