### PR TITLE
Add h5i to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [h5i](https://github.com/h5i-dev/h5i) - Rust CLI that runs multiple coding agents (Claude Code, Codex) on the same task in isolated git worktrees, has them peer-review each other, then a neutral verifier replays and tests each candidate and merges the one that passes. Run metadata is versioned in the repo under refs/h5i/*.
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
This adds [h5i](https://github.com/h5i-dev/h5i) to the **Development & Code Tools** section.

h5i is an open-source Rust CLI that runs several coding agents (Claude Code, Codex) on the same task in isolated sandboxes, has them peer-review each other, then a neutral verifier replays and tests each candidate and merges the one that passes. Run metadata is versioned in the repo under refs/h5i/*.

The entry follows the existing format and ordering of the list.