### PR TITLE
Add nightly-closeout to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [nightly-closeout](https://github.com/Xinnygh/nightly-closeout-skill) - Turn leftover end-of-day token/model capacity into safe overnight Codex/Claude work loops: triage active projects, score high-value low-risk tasks, generate separate Codex (strategy/review) and Claude (execution/research) loop prompts, and use Codex Goals to hold a durable objective. Conservative by default — will not message, publish, spend, sign, or delete unattended. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo Xinnygh/nightly-closeout-skill --path skill --name nightly-closeout`
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
Adds **nightly-closeout** to **Skills → Development & Code Tools**.

- Repo: https://github.com/Xinnygh/nightly-closeout-skill
- License: MIT
- What it is: a Codex skill that turns leftover end-of-day token/model capacity into safe overnight Codex/Claude work loops. It triages the user's currently active projects, scores high-value low-risk overnight tasks, generates separate Codex (strategy/review) and Claude (execution/research) loop prompts, and uses Codex Goals to hold a durable objective on real long runs. Conservative by default: it will not send, publish, spend, sign, or delete unattended.

The `SKILL.md` lives in `skill/` (with `name` + a trigger-focused `description` in the frontmatter), so the `Install:` command uses `--path skill`. I'm the author; new project, no adoption claims. Thanks!
