### PR TITLE
docs: add Your Prompt Engineer

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [theme-factory/](./theme-factory/) - Create reusable theme tokens and palettes.
 - [video-downloader/](./video-downloader/) - Download and prepare videos for offline review.
 - [template-skill/](./template-skill/) - Starter template for building new skills.
+- [Your Prompt Engineer](https://github.com/polychrome7/your-prompt-engineer) - External repo: prompt handoff layer that turns rough requests into dispatch-ready prompts for Codex and Claude Code agents, with target validation, explorer/worker routing, confirmation, and safety gates.
 - [skill-installer/](./skill-installer/) - Helper scripts to install skills from curated lists or GitHub paths.
 - [skill-creator/](./skill-creator/) - Guidance for building effective Codex skills with progressive disclosure.
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [theme-factory/](./theme-factory/) - Create reusable theme tokens and palettes.
 - [video-downloader/](./video-downloader/) - Download and prepare videos for offline review.
 - [template-skill/](./template-skill/) - Starter template for building new skills.
-- [Your Prompt Engineer](https://github.com/polychrome7/your-prompt-engineer) - External repo: prompt handoff layer that turns rough requests into dispatch-ready prompts for Codex and Claude Code agents, with target validation, explorer/worker routing, confirmation, and safety gates.
+- [Your Prompt Engineer](https://github.com/polychrome7/your-prompt-engineer) - External repo: prompt handoff layer for Codex, Claude Code, and compatible agent hosts, with target validation, explorer/worker routing, confirmation, and safety gates.
 - [skill-installer/](./skill-installer/) - Helper scripts to install skills from curated lists or GitHub paths.
 - [skill-creator/](./skill-creator/) - Guidance for building effective Codex skills with progressive disclosure.
 


### PR DESCRIPTION
## What changed

Adds Your Prompt Engineer to the Meta & Utilities section as an external Codex skill repo.

## Why

Your Prompt Engineer helps turn rough natural-language requests into dispatch-ready prompts for Codex and Claude Code agents. It focuses on target validation, explorer/worker routing, confirmation before dispatch, and safety gates for risky tasks.

## Notes

The project includes a public README, MIT license, release tag, and a standard skill folder under `skills/your-prompt-engineer`.
