### PR TITLE
Add Imagine — Gemini for Codex & Claude Code (Development & Code Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [Imagine](https://github.com/freestyler-arb/imagine-gemini-for-claude-codex) - Brings Google Gemini into Codex and Claude Code: delegate reasoning, independent code review, deep research, and automatic prompt-engineering. Runs on your Google AI Pro subscription, not your agent's tokens.
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
Adds Imagine under Development & Code Tools. MIT skill pack that lets Codex (and Claude Code) delegate to Google Gemini: gemini-pro (reasoning), gemini-review (independent code review), gemini-research (deep research), gemini-proxy (auto prompt-engineering). Routes through the Antigravity CLI on your Google AI Pro/Ultra subscription, not your agent's API tokens. Repo: https://github.com/freestyler-arb/imagine-gemini-for-claude-codex (my own project).