### PR TITLE
docs: add github-issue-fix skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [Emdash Skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS: CF Workers + Hono + Angular + D1 + Stripe. One-line prompts to deployed SaaS with 94 reference docs, 18 agents, and Codex-native `.agents/skills/` support.
 - [gh-address-comments/](./gh-address-comments/) - Address review or issue comments on the open GitHub PR for the current branch using `gh`.
 - [gh-fix-ci/](./gh-fix-ci/) - Inspect failing GitHub Actions checks, summarize failures, and propose fixes.
+- [github-issue-fix](https://github.com/OSS-AIE/github-issue-fix) - Fix upstream GitHub issues and PR CI/review failures with `gh`, including conflict repair, review comment handling, and reviewer-friendly PR handoff. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo OSS-AIE/github-issue-fix --path . --name github-issue-fix`
 - [mcp-builder/](./mcp-builder/) - Build and evaluate MCP servers with best practices and an evaluation harness.
 - [pr-review-ci-fix/](./pr-review-ci-fix/) - Automated GitHub/GitLab PR review plus CI auto-fix loop via the Composio CLI.
 - [sentry-triage/](./sentry-triage/) - Diagnose Sentry issues by mapping stack frames to local source — no copy-paste.


### PR DESCRIPTION
## Summary\n\nAdd OSS-AIE/github-issue-fix to the Development & Code Tools section.\n\nThe skill helps Codex triage upstream GitHub issues, fix PR CI/review failures, resolve conflicts, and prepare reviewer-friendly PR handoffs with GitHub CLI.\n\n## Validation\n\n- README-only change\n- Verified the target repository contains a top-level SKILL.md