### PR TITLE
add remote openclaw to resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ PRs welcome. Add real, reusable skills, keep descriptions precise, and include a
 ## Resources
 
 - [Top Codex Skills](https://composio.dev/content/top-codex-skills)
+- [Remote OpenClaw](https://www.remoteopenclaw.com/skills/codex) - directory of codex, claude code and openclaw skills plus mcp servers, browsable by ecosystem and category
 
 ---
 


### PR DESCRIPTION
thanks for maintaining the codex skills list. dropped remote openclaw into resources, it's a directory of codex, claude code and openclaw skills plus mcp servers you can filter by ecosystem and category. figured it'd help people browsing for skills here. no worries if you'd rather place it elsewhere.