### PR TITLE
Add gitcode issue fix skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [Emdash Skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS: CF Workers + Hono + Angular + D1 + Stripe. One-line prompts to deployed SaaS with 94 reference docs, 18 agents, and Codex-native `.agents/skills/` support.
 - [gh-address-comments/](./gh-address-comments/) - Address review or issue comments on the open GitHub PR for the current branch using `gh`.
 - [gh-fix-ci/](./gh-fix-ci/) - Inspect failing GitHub Actions checks, summarize failures, and propose fixes.
+- [gitcode-issue-fix](https://github.com/OSS-AIE/gitcode-issue-fix) - Fix GitCode issues and PR CI with `gc`, minimal-change scope guards, and engineering issue archetypes.
 - [mcp-builder/](./mcp-builder/) - Build and evaluate MCP servers with best practices and an evaluation harness.
 - [pr-review-ci-fix/](./pr-review-ci-fix/) - Automated GitHub/GitLab PR review plus CI auto-fix loop via the Composio CLI.
 - [sentry-triage/](./sentry-triage/) - Diagnose Sentry issues by mapping stack frames to local source — no copy-paste.


### PR DESCRIPTION
Adds OSS-AIE/gitcode-issue-fix to the Development & Code Tools section.\n\nThe skill supports GitCode issue triage, PR repair, CI follow-up, minimal-change scope guards, and engineering issue archetypes for build/test/architecture cleanup work.