### PR TITLE
Add youtube-full skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 
 ### Data & Analysis
 
+- [youtube-full](https://github.com/ZeroPointRepo/youtube-skills) - Fetch YouTube transcripts, search videos/channels, and pull playlist or channel data via TranscriptAPI. No yt-dlp, works from any cloud server.
 - [spreadsheet-formula-helper/](./spreadsheet-formula-helper/) - Write and debug spreadsheet formulas, pivots, and array formulas.
 - [competitive-ads-extractor/](./competitive-ads-extractor/) - Analyze competitor ads and extract structured insights.
 - [datadog-logs/](./datadog-logs/) - Filter Datadog logs from the shell via the Composio CLI, with JSON-friendly output and digest workflows.


### PR DESCRIPTION
Adds `youtube-full` to the Data & Analysis section.

`youtube-full` is a Codex skill for pulling structured data out of YouTube — transcripts, video/channel search, channel browsing, and playlists — backed by TranscriptAPI instead of `yt-dlp` or `youtube-transcript-api`. Useful for research and content-analysis workflows where a video is the source, not a text page.

- Skill repo: https://github.com/ZeroPointRepo/youtube-skills
- Install: `npx skills add ZeroPointRepo/youtube-skills --skill youtube-full`

### README diff

```diff
### Data & Analysis

+ [youtube-full](https://github.com/ZeroPointRepo/youtube-skills) - Fetch YouTube transcripts, search videos/channels, and pull playlist or channel data via TranscriptAPI. No yt-dlp, works from any cloud server.
- [spreadsheet-formula-helper/](./spreadsheet-formula-helper/) - Write and debug spreadsheet formulas, pivots, and array formulas.
```
