### PR TITLE
Add workorai (talent marketplace skill, external repo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [file-organizer/](./file-organizer/) - Organize, rename, and tidy files to keep workspaces clean.
 - [paperjsx/](./paperjsx/) - Generate PPTX presentations, DOCX documents, XLSX spreadsheets, and PDF invoices/reports/charts from structured JSON. Runs locally via `@paperjsx/mcp-server` — no API key, no network calls.
 - [skill-share/](./skill-share/) - Share skills and reusable instructions across teammates.
+- [workorai](https://github.com/work0r-ai/agent-kit/tree/main/skills/workorai) - External repo: talent-marketplace skill for candidates (job search, applications) and employers (job lifecycle, ranked candidate discovery with white-box match explanations) via the WorkorAI MCP server. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo work0r-ai/agent-kit --path skills/workorai --name workorai`
 
 ### Communication & Writing
 - [codex-sms-verification](https://github.com/virtualsms-io/codex-sms-verification) - External repo: real-SIM SMS verification for AI agents via VirtualSMS MCP. 145+ countries, 2000+ services, both hosted (mcp.virtualsms.io) and local stdio transports.


### PR DESCRIPTION
Adds WorkorAI as an external-repo entry under Productivity & Collaboration.

- Skill: https://github.com/work0r-ai/agent-kit/tree/main/skills/workorai (SKILL.md with name/description frontmatter, trigger conditions stated in the description, references/ for detail so metadata stays lean)
- What it does: candidate workflows (job search, applications) and employer workflows (job lifecycle, ranked candidate discovery with white-box match explanations) via the WorkorAI MCP server (streamable HTTP at https://workorai.com/mcp, also on the official MCP Registry as io.github.work0r-ai/workorai)
- Install command included in the entry, matching the skill-installer format used by other external entries
- MIT licensed, npm: @workorai/agent-kit
