### PR TITLE
Add research portfolio + single-project iteration skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [file-organizer/](./file-organizer/) - Organize, rename, and tidy files to keep workspaces clean.
 - [paperjsx/](./paperjsx/) - Generate PPTX presentations, DOCX documents, XLSX spreadsheets, and PDF invoices/reports/charts from structured JSON. Runs locally via `@paperjsx/mcp-server` — no API key, no network calls.
 - [skill-share/](./skill-share/) - Share skills and reusable instructions across teammates.
+- [manage-research-portfolio](https://github.com/jiangjin1999/codex-research-project-skills) - Manage a multi-project research portfolio: synced dashboard board, project registry, data governance, and cross-project handoffs. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo jiangjin1999/codex-research-project-skills --path skills/manage-research-portfolio --name manage-research-portfolio`
+- [iterate-research-project](https://github.com/jiangjin1999/codex-research-project-skills) - Iterate one research project with evidence — attempts, docs, data, literature, and a synced project board. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo jiangjin1999/codex-research-project-skills --path skills/iterate-research-project --name iterate-research-project`
 
 ### Communication & Writing
 - [codex-sms-verification](https://github.com/virtualsms-io/codex-sms-verification) - External repo: real-SIM SMS verification for AI agents via VirtualSMS MCP. 145+ countries, 2000+ services, both hosted (mcp.virtualsms.io) and local stdio transports.


### PR DESCRIPTION
Adds two related, hand-crafted Codex skills for research work to **Productivity & Collaboration**:

- **manage-research-portfolio** — manage a multi-project research portfolio with a synced dashboard board (看板), a project registry (owner/priority/status/next-action/evidence), shared data governance, and cross-project AI handoffs.
- **iterate-research-project** — iterate a single research project with evidence: attempts, docs, data notes, literature, project-local skills, AI working memory, and a five-view project board kept in sync markdown-first. Works standalone or inside the portfolio.

Both live in their own public repo (MIT), each with `SKILL.md` + `references/` + `agents/openai.yaml`, precise trigger `description`s, and a full runnable example under `examples/llm-reasoning-portfolio/` built from public LLM-reasoning papers/benchmarks only.

Repo: https://github.com/jiangjin1999/codex-research-project-skills

Entries follow the external-repo format with install commands. Links verified.