### PR TITLE
Add obsidian-high-recall skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [notion-meeting-intelligence/](./notion-meeting-intelligence/) - Prepare meeting materials with Notion context plus Codex research.
 - [notion-research-documentation/](./notion-research-documentation/) - Synthesize multiple Notion sources into briefs, comparisons, or reports with citations.
 - [notion-spec-to-implementation/](./notion-spec-to-implementation/) - Turn Notion specs into implementation plans, tasks, and progress tracking.
+- [obsidian-high-recall](https://github.com/ToussaintKnight/obsidian-high-recall-skill) - External repo: local-first high-recall search over Obsidian vaults for Codex. Reuses Smart Connections vectors when available, falls back to local hybrid search, and returns recall packs without uploading raw notes. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo ToussaintKnight/obsidian-high-recall-skill --path skills/obsidian-high-recall --name obsidian-high-recall`
 - [support-ticket-triage/](./support-ticket-triage/) - Triage customer support tickets with categories, priority, next actions, and draft replies.
 - [file-organizer/](./file-organizer/) - Organize, rename, and tidy files to keep workspaces clean.
 - [paperjsx/](./paperjsx/) - Generate PPTX presentations, DOCX documents, XLSX spreadsheets, and PDF invoices/reports/charts from structured JSON. Runs locally via `@paperjsx/mcp-server` — no API key, no network calls.


### PR DESCRIPTION
Adds `obsidian-high-recall` to the Productivity & Collaboration section.

Why it fits:
- It is a Codex skill for local Obsidian vault retrieval.
- It targets private knowledge workflows where recall matters more than a short precision-ranked list.
- It runs local-first: raw notes stay on the user's machine, using Smart Connections vectors when present and local hybrid search as fallback.

The entry links to the external repo and includes an installer command matching the existing list style.