### PR TITLE
Add routerbase agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [gh-fix-ci/](./gh-fix-ci/) - Inspect failing GitHub Actions checks, summarize failures, and propose fixes.
 - [mcp-builder/](./mcp-builder/) - Build and evaluate MCP servers with best practices and an evaluation harness.
 - [pr-review-ci-fix/](./pr-review-ci-fix/) - Automated GitHub/GitLab PR review plus CI auto-fix loop via the Composio CLI.
+- [routerbase-agent-skills](https://github.com/zenlee123/routerbase-agent-skills) - Three Codex skills for using [routerbase](https://routerbase.com/) as an OpenAI-compatible API gateway, model routing layer, and media generation interface.
 - [sentry-triage/](./sentry-triage/) - Diagnose Sentry issues by mapping stack frames to local source — no copy-paste.
 - [webapp-testing/](./webapp-testing/) - Run targeted web app tests and summarize results.
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`


### PR DESCRIPTION
Adds the public routerbase-agent-skills repository to the Development & Code Tools section.\n\nThe repo includes three Codex-compatible SKILL.md packages for using routerbase as an OpenAI-compatible API gateway, model routing layer, and media generation interface:\n\n- routerbase-api-integration\n- routerbase-model-routing\n- routerbase-media-generation\n\nSource: https://github.com/zenlee123/routerbase-agent-skills\nWebsite: https://routerbase.com/