### PR TITLE
Add Linked API linkedin-growth skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [tailored-resume-generator/](./tailored-resume-generator/) - Tailor resumes to job descriptions with quantified impact.
 - [unslop](https://github.com/MohamedAbdallah-14/unslop) - External repo: CLI and MCP server that removes AI writing patterns from text: tricolons, em-dash overuse, hedging stacks, and sycophancy openers. Works with Codex, Claude Code, Gemini CLI, and Cursor. Five intensity levels and a lint-only audit mode.
 
+- [linkedin-growth](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin-growth) - Import leads from LinkedIn or Sales Navigator searches, qualify them against an ideal-customer profile, schedule safe connection invites across accounts, track acceptances, and withdraw stale pending requests.
 ### Data & Analysis
 
 - [spreadsheet-formula-helper/](./spreadsheet-formula-helper/) - Write and debug spreadsheet formulas, pivots, and array formulas.


### PR DESCRIPTION
Adds Linked API skill listing for `linkedin-growth`.

- Skill: Lead pipeline (import → qualify → invites)
- Listing name: linkedin-growth
- Source: https://github.com/Linked-API/linkedin-skills/tree/main/linkedin-growth
- Docs: https://linkedapi.io/skills/linkedin-growth-skill
- Install runbook: https://linkedapi.io/skills/linkedin-growth/install.md
- Description: Import leads from LinkedIn or Sales Navigator searches, qualify them against an ideal-customer profile, schedule safe connection invites across accounts, track acceptances, and withdraw stale pending requests.
- Tags: LinkedIn, lead-generation, growth, agent-skill
- Catalog state: /Users/kiril/Documents/Work/LinkedAPI/.claude/skills/publish-skills/catalogs/composiohq-awesome-codex-skills.md

Publication copy:
LinkedIn Growth is an agent skill for hands-off, controlled LinkedIn network growth. The user defines a LinkedIn or Sales Navigator search plus an ideal-lead profile; the skill imports candidates, qualifies every lead with recorded reasoning, stores the pipeline locally, assigns leads across one or more accounts, sends connection invites during active hours, tracks acceptances, and withdraws unanswered requests. It is built for steady qualified growth rather than one-off blasting.

Assets:
- Logo: assets/logo.png (https://linkedapi.io/logo.png)
- Social card: assets/social-card.png (https://linkedapi.io/opengraph-image?b7d7037e63c6122a)
- Screenshot: assets/screenshots/linkedin-growth-skill.png (https://linkedapi.io/skills/linkedin-growth-skill)