### PR TITLE
Add internet-court skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [internet-court](https://github.com/internet-court/internet-court-skill) - Trust layer for agent-to-agent commerce: natural-language mandates, ERC-7710 delegated permissions, x402 payments, escrow, and dispute resolution as one open, catch-all skill. Works in Codex, Claude Code, and other harnesses.
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
Adds [internet-court](https://github.com/internet-court/internet-court-skill) under **Development & Code Tools** — a cross-harness Agent Skill (works in Codex via `$skill-installer`, also a Claude Code plugin) for agent-to-agent commerce: natural-language mandates, ERC-7710 delegated permissions, x402 payments, escrow, and dispute resolution. MIT licensed. Public repo with a valid root `SKILL.md`.