### PR TITLE
docs: add AI Router examples repo resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ PRs welcome. Add real, reusable skills, keep descriptions precise, and include a
 ## Resources
 
 - [Top Codex Skills](https://composio.dev/content/top-codex-skills)
+- [AI Router OpenAI-Compatible Examples](https://github.com/airouter-dev/ai-router-openai-compatible-examples) - OpenAI-compatible setup examples for cURL, Python, Node.js, Cursor, Continue, LiteLLM, Open WebUI, plus BYOK smoke-test and localized landing page references.
 
 ---
 


### PR DESCRIPTION
Adds the open-source `ai-router-openai-compatible-examples` repository under Resources.

Why it fits:
- free/open GitHub resource
- relevant to Codex users configuring OpenAI-compatible endpoints
- includes SDK, editor, LiteLLM, Open WebUI, BYOK smoke-test, and localized landing page references

This intentionally adds the examples repo asset rather than the commercial service itself.