### PR TITLE
Add linked-notes (Obsidian project notes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [file-organizer/](./file-organizer/) - Organize, rename, and tidy files to keep workspaces clean.
 - [paperjsx/](./paperjsx/) - Generate PPTX presentations, DOCX documents, XLSX spreadsheets, and PDF invoices/reports/charts from structured JSON. Runs locally via `@paperjsx/mcp-server` — no API key, no network calls.
 - [skill-share/](./skill-share/) - Share skills and reusable instructions across teammates.
+- [linked-notes](https://github.com/tpklo/claude-note) - Creates Obsidian project notes from agent sessions, wired into the vault's knowledge graph.
 
 ### Communication & Writing
 - [codex-sms-verification](https://github.com/virtualsms-io/codex-sms-verification) - External repo: real-SIM SMS verification for AI agents via VirtualSMS MCP. 145+ countries, 2000+ services, both hosted (mcp.virtualsms.io) and local stdio transports.


### PR DESCRIPTION
Adds `linked-notes`, an Agent Skill that creates Obsidian project notes from an agent session and wires them into the vault's knowledge graph (wikilinks, backlinks, hub-note registration, machine-readable `related` frontmatter). One-time setup auto-detects vaults from Obsidian's registry, with optional Notion sync. Cross-platform SKILL.md works with Claude Code, Codex CLI, Gemini CLI, and Cursor.

Repo: https://github.com/tpklo/claude-note