### PR TITLE
Add Software Graph Analysis skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [mcp-builder/](./mcp-builder/) - Build and evaluate MCP servers with best practices and an evaluation harness.
 - [pr-review-ci-fix/](./pr-review-ci-fix/) - Automated GitHub/GitLab PR review plus CI auto-fix loop via the Composio CLI.
 - [sentry-triage/](./sentry-triage/) - Diagnose Sentry issues by mapping stack frames to local source — no copy-paste.
+- [software-graph-analysis/](./software-graph-analysis/) - Use Ontoly to build or query a deterministic Software Graph before source search for architecture summaries, route tracing, dependency analysis, configuration usage, and impact analysis.
 - [webapp-testing/](./webapp-testing/) - Run targeted web app tests and summarize results.
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.

--- a/software-graph-analysis/SKILL.md
+++ b/software-graph-analysis/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: software-graph-analysis
+description: Use Ontoly to build or query a deterministic Software Graph before searching files. Use when the user asks to explain a repository, trace a route/request flow, find dependencies, inspect services/controllers/modules, audit configuration or environment variables, analyze impact, or use Ontoly MCP. Do not use for generic architecture advice without repository evidence or for changing compiler behavior.
+metadata:
+  short-description: Analyze codebases with Ontoly's Software Graph
+---
+
+# Software Graph Analysis
+
+Use this skill when a coding task needs repository understanding grounded in Ontoly's deterministic Software Graph.
+
+Ontoly should provide the software knowledge. The agent should provide the workflow: verify the graph, query it, cite evidence, then inspect source only when the graph cannot answer.
+
+## Workflow
+
+1. Check whether the repository already has Ontoly output, such as `.ontoly/`, `SoftwareGraph.json`, diagnostics, statistics, or MCP configuration.
+2. If no usable graph exists, run:
+
+   ```bash
+   ontoly build .
+   ```
+
+3. Check graph trust, diagnostics, graph hash, framework detection, and build timestamp.
+4. Prefer Ontoly MCP capabilities or CLI graph queries before using repository-wide search.
+5. Answer with evidence from the graph: node IDs, node kinds, relationships, source locations, diagnostics, and confidence.
+6. Search files only when graph evidence is missing, stale, ambiguous, or contradicted by diagnostics.
+
+## Common Questions
+
+Use Ontoly for questions like:
+
+- "Explain this repository."
+- "Trace `POST /login`."
+- "Which service owns authentication?"
+- "What depends on `UserRepository`?"
+- "What breaks if I remove this module?"
+- "Where is `DATABASE_URL` used?"
+- "Which packages depend on this package?"
+- "Show unresolved imports, cycles, or dead code."
+
+## Capability Mapping
+
+| Task | Ontoly capability or query |
+| --- | --- |
+| Repository overview | ArchitectureSummary |
+| Route/request trace | TraceExecution |
+| Dependency tree | FindDependencies |
+| Impact analysis | ImpactAnalysis |
+| Configuration usage | FindConfigurationUsage |
+| Authentication flow | FindAuthenticationFlow |
+| Authorization checks | FindAuthorization |
+| Framework coverage | FrameworkReport |
+| Dead code review | FindDeadCode |
+
+If the named capability is unavailable, use the closest deterministic graph query and state the fallback.
+
+## Evidence Rules
+
+Every answer should include:
+
+- The graph artifact or MCP response used.
+- Node IDs and relationship names when available.
+- Source locations when available.
+- Diagnostics that reduce confidence.
+- A clear distinction between measured graph facts and inferred observations.
+
+Do not invent graph facts. If Ontoly cannot answer, say what is missing and what fallback evidence was inspected.
+
+## Troubleshooting
+
+If `ontoly build .` fails, report the command, exit code, and diagnostic summary before falling back to source inspection.
+
+If MCP is unavailable, query the persisted graph JSON or Ontoly CLI output and state that MCP was unavailable.
+
+If multiple graph nodes match the user's target, show candidates with IDs, kinds, and locations rather than silently choosing one.

--- a/software-graph-analysis/agents/openai.yaml
+++ b/software-graph-analysis/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Software Graph Analysis"
+  short_description: "Use Ontoly graph evidence for architecture, dependency, route, and impact questions."
+  default_prompt: "Use Ontoly to build or query the Software Graph, cite graph evidence, and fall back to source search only when the graph is missing or insufficient."


### PR DESCRIPTION
## Summary
- Adds a `software-graph-analysis` Codex skill for Ontoly Software Graph workflows.
- Adds Codex `agents/openai.yaml` metadata.
- Lists the skill under Development & Code Tools.

## Validation
- `python3` smoke check for `SKILL.md` frontmatter and `agents/openai.yaml`
- `git diff --check`

## Notes
The skill instructs agents to use Ontoly graph/MCP evidence before broad repository search and to cite graph nodes, relationships, diagnostics, and confidence.