### PR TITLE
Add agent-engineering-toolkit skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [agent-engineering-toolkit](https://github.com/AdvancingTitans/agent-engineering-toolkit/tree/main/skills/agent-engineering-toolkit) - Audit agent instructions, constrain approved diff scope, and record workspace-bound execution evidence. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo AdvancingTitans/agent-engineering-toolkit --path skills/agent-engineering-toolkit --name agent-engineering-toolkit`
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
## Summary

- Add the external `agent-engineering-toolkit` skill under Development & Code Tools.
- Link directly to the reusable skill directory.
- Provide the standard Codex skill-installer command.

## Why it fits

The skill has explicit trigger metadata, progressive-disclosure references and scripts, and a default-off activation policy. It helps Codex audit agent instructions, constrain approved diff scope, and record execution evidence tied to workspace bytes.

Disclosure: I maintain Agent Engineering Toolkit.

## Checks

- `git diff --check`
- Skill path and install target exist on the default branch
- Current skill version: v1.11.1