### PR TITLE
Add ditto to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [codebase-recon](https://github.com/yujiachen-y/codebase-recon-skill) - Analyze git history to understand a codebase before reading any code — surfaces hotspots, bug magnets, bus factor, momentum, and high-risk files (hotspot ∩ bug-magnet) via auto-scaled analysis. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo yujiachen-y/codebase-recon-skill --path skills/codebase-recon --name codebase-recon`
 - [create-plan/](./create-plan/) - Quickly draft concise execution plans for coding tasks.
 - [deploy-pipeline/](./deploy-pipeline/) - End-to-end Stripe → Supabase → Vercel release pipelines with verify and rollback.
+- [ditto](https://github.com/ohad6k/ditto) - Mines your own Codex and Claude Code session logs into a you.md working profile your agent reads before every task: what you reject, what "done" means to you, when you ask for proof, how you actually work. Install: `npx skills add ohad6k/ditto`
 - [Emdash Skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS: CF Workers + Hono + Angular + D1 + Stripe. One-line prompts to deployed SaaS with 94 reference docs, 18 agents, and Codex-native `.agents/skills/` support.
 - [gh-address-comments/](./gh-address-comments/) - Address review or issue comments on the open GitHub PR for the current branch using `gh`.
 - [gh-fix-ci/](./gh-fix-ci/) - Inspect failing GitHub Actions checks, summarize failures, and propose fixes.


### PR DESCRIPTION
ditto mines your own Codex and Claude Code session logs into a you.md working profile your agent reads before every task.

It reads your local logs, keeps only the messages you wrote, redacts secrets, and has agents pull the patterns you never wrote down: what you reject, what "done" means to you, when you ask for proof, how you actually work. Then it merges them into one you.md that Codex/Claude load before each task instead of starting cold.

- Works with Codex, Claude Code, Cursor, Copilot CLI, OpenCode
- Local-first, MIT, zero-dependency single Python file
- Install: `npx skills add ohad6k/ditto`
- Repo: https://github.com/ohad6k/ditto

Added it under Development & Code Tools.