### PR TITLE
Add skill: gooseworks-ai/goose-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [raffle-winner-picker/](./raffle-winner-picker/) - Randomly select winners with audit-friendly logs.
 - [langsmith-fetch/](./langsmith-fetch/) - Pull LangSmith project/test data for analysis.
 - [helium-mcp/](./helium-mcp/) - Search real-time news with bias scoring, get live market data, ML options pricing, and balanced news synthesis via MCP.
+- [goose-skills](https://github.com/gooseworks-ai/goose-skills) - Lead research, data scraping, and competitive-intel skill library: 125 growth/GTM skills spanning ads analysis, outreach, content, monitoring, and SEO. Works in Codex, Claude Code, and Cursor.
 
 ### Meta & Utilities
 


### PR DESCRIPTION
Adds [goose-skills](https://github.com/gooseworks-ai/goose-skills) to the end of **Data & Analysis**, alongside the existing competitive-ads-extractor and lead-research-assistant entries it complements.

**What it is:** external repo — an open-source (MIT) library of 125 growth/GTM skills for lead research, data scraping, competitive intelligence, ads analysis, outreach, content, monitoring, and SEO. Works in Codex, Claude Code, and Cursor; installable via CLI, each skill ships SKILL.md with trigger-oriented descriptions per the repo's metadata contract.

**Real and reusable:** 1,000+ stars, MIT licensed, in production use since early 2026.

— Himanshu Bamoria, co-founder @ [GooseWorks](https://gooseworks.ai)

🤖 Generated with [Claude Code](https://claude.com/claude-code)