### PR TITLE
Add Paper and Book to Visual Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [support-ticket-triage/](./support-ticket-triage/) - Triage customer support tickets with categories, priority, next actions, and draft replies.
 - [file-organizer/](./file-organizer/) - Organize, rename, and tidy files to keep workspaces clean.
 - [paperjsx/](./paperjsx/) - Generate PPTX presentations, DOCX documents, XLSX spreadsheets, and PDF invoices/reports/charts from structured JSON. Runs locally via `@paperjsx/mcp-server` — no API key, no network calls.
+- [Paper and Book to Visual Learning](https://github.com/YIYANG-hakimide/paper-and-book-to-visual-learning) - Turn papers, books, and reports into model-generated learning albums, editable presentation reports, or interactive bilingual readers for non-specialist learners. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo YIYANG-hakimide/paper-and-book-to-visual-learning --path . --name paper-and-book-to-visual-learning`
 - [skill-share/](./skill-share/) - Share skills and reusable instructions across teammates.
 
 ### Communication & Writing


### PR DESCRIPTION
Adds an external Codex Skill for turning difficult papers, books, and reports into one of three guided outputs:

- model-generated visual learning albums
- editable presentation reports with PDF delivery
- interactive bilingual HTML readers

The project includes progressive-disclosure references, deterministic audit scripts, installation validation, and public examples. The linked repository is MIT licensed and can be installed with the standard Codex Skill installer.