### PR TITLE
Add x-insight-cards skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [novel-writing](https://github.com/wgwtest/novel-writing) - External repo: public Codex skill for fiction planning, chapter drafting, scene continuation, and revision.
 - [tailored-resume-generator/](./tailored-resume-generator/) - Tailor resumes to job descriptions with quantified impact.
 - [unslop](https://github.com/MohamedAbdallah-14/unslop) - External repo: CLI and MCP server that removes AI writing patterns from text: tricolons, em-dash overuse, hedging stacks, and sycophancy openers. Works with Codex, Claude Code, Gemini CLI, and Cursor. Five intensity levels and a lint-only audit mode.
+- [x-insight-cards](https://github.com/ljunnan24-hash/x-insight-cards) - External repo: source-auditable Codex skill that discovers, verifies, ranks, deduplicates, translates, renders, and quality-checks recent X posts as bilingual creator-ready content for Douyin and Xiaohongshu, with manual publishing review. Install: `npx skills add ljunnan24-hash/x-insight-cards`
 
 ### Data & Analysis
 


### PR DESCRIPTION
## What

Add `x-insight-cards` to the Communication & Writing section as an external Codex skill.

## Why

The skill provides a reusable, source-auditable workflow for discovering, verifying, ranking, deduplicating, translating, rendering, and quality-checking recent X posts for Douyin and Xiaohongshu creator review. It includes a one-command installer, deterministic scripts, tests, and a manual-publishing safety boundary.

## Checks

- `git diff --check`
- Repository link returns HTTP 200
- Upstream skill CI passes
