### PR TITLE
Add Timeline Studio video editing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [slack-gif-creator/](./slack-gif-creator/) - Generate GIFs for Slack with captions and styling.
 - [theme-factory/](./theme-factory/) - Create reusable theme tokens and palettes.
 - [video-downloader/](./video-downloader/) - Download and prepare videos for offline review.
+- [edit-timeline-studio](https://github.com/MartinDelophy/ai-video-editor/tree/main/skills/edit-timeline-studio) - Create editable video timelines from local media with AI voiceover, synchronized captions, overlays, deterministic browser rendering, and `.timeline` plus MP4/WebM deliverables. Install: `gh skill install MartinDelophy/ai-video-editor edit-timeline-studio --agent codex --scope user`
 - [template-skill/](./template-skill/) - Starter template for building new skills.
 - [skill-installer/](./skill-installer/) - Helper scripts to install skills from curated lists or GitHub paths.
 - [skill-creator/](./skill-creator/) - Guidance for building effective Codex skills with progressive disclosure.


### PR DESCRIPTION
## Summary

Adds the external `edit-timeline-studio` skill to the Meta & Utilities catalog with a direct Codex installation command.

The skill teaches Codex and other Agent Skills-compatible hosts to:

- assemble editable video projects from explicit local media;
- generate and synchronize AI voiceover and captions;
- preserve overlays and multi-track timing;
- save `.timeline` as the editable source of truth;
- export and verify deterministic MP4/WebM browser renders.

## Why this belongs in the catalog

Timeline Studio is an open-source, browser-based AI video editor. The skill is maintained in the product repository, follows the Agent Skills directory convention, and is already installable through both `gh skill` and `npx skills`.

Keeping the catalog entry pointed at the canonical repository prevents version drift across Codex, GitHub Copilot, and Claude Code.

## Validation

- Confirmed the public `SKILL.md` URL resolves
- Confirmed `gh skill install MartinDelophy/ai-video-editor edit-timeline-studio --agent codex --scope user`
- Ran `git diff --check`
