### PR TITLE
Add gptskin-theme to Meta & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [template-skill/](./template-skill/) - Starter template for building new skills.
 - [skill-installer/](./skill-installer/) - Helper scripts to install skills from curated lists or GitHub paths.
 - [skill-creator/](./skill-creator/) - Guidance for building effective Codex skills with progressive disclosure.
+- [gptskin-theme](https://github.com/WendongAI/gptskin-skill) - Apply image-backed themes to the Codex desktop app: 6 free presets or any image as a full-window background, one-command apply and one-sentence restore (macOS + Windows). Install: `git clone https://github.com/WendongAI/gptskin-skill.git ~/.codex/skills/gptskin-theme && cd ~/.codex/skills/gptskin-theme && npm install`
 
 ## Using Skills in Codex
 


### PR DESCRIPTION
Adds [gptskin-theme](https://github.com/WendongAI/gptskin-skill) to **Meta & Utilities** (external-link format, as used in Development & Code Tools).

**What it does**: an open-source (MIT) Codex Skill that applies image-backed themes to the Codex desktop app — 6 free preset themes work with no account, and a paid pipeline turns any user image into a full-window background theme. Themes are injected over the local CDP (loopback only); the signed app is never modified, and the stock look is restored with one sentence. macOS + Windows.

**Trigger fit**: activates when users ask Codex to change its theme / background / appearance (`codex 换肤` included) — a customization utility for Codex itself, hence Meta & Utilities.

**Install** (documented in the repo README): `git clone https://github.com/WendongAI/gptskin-skill.git ~/.codex/skills/gptskin-theme && cd ~/.codex/skills/gptskin-theme && npm install`

Website/docs: https://gptskin.best