### PR TITLE
Add xiaopixuan skills-public catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [template-skill/](./template-skill/) - Starter template for building new skills.
 - [skill-installer/](./skill-installer/) - Helper scripts to install skills from curated lists or GitHub paths.
 - [skill-creator/](./skill-creator/) - Guidance for building effective Codex skills with progressive disclosure.
+- [skills-public](https://github.com/xiaopixuan/skills-public) - Public Codex skills catalog with draw.io diagram generation, skill design review, example prompts, editable diagram sources, and skill review scorecards.
 
 ## Using Skills in Codex
 


### PR DESCRIPTION
## Summary\n\nAdds xiaopixuan/skills-public to the Meta & Utilities section.\n\nThe catalog includes public Codex skills for:\n- editable draw.io / diagrams.net diagram generation\n- skill design review and scoring\n- example prompts, editable diagram sources, and review scorecards\n\n## Link\n\nhttps://github.com/xiaopixuan/skills-public