### PR TITLE
Add MiniMax video-generation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [slack-gif-creator/](./slack-gif-creator/) - Generate GIFs for Slack with captions and styling.
 - [theme-factory/](./theme-factory/) - Create reusable theme tokens and palettes.
 - [video-downloader/](./video-downloader/) - Download and prepare videos for offline review.
+- [minimax-video-generation/](./minimax-video-generation/) - Generate videos from a text prompt or a starting image with MiniMax, including async task polling and download.
 - [template-skill/](./template-skill/) - Starter template for building new skills.
 - [skill-installer/](./skill-installer/) - Helper scripts to install skills from curated lists or GitHub paths.
 - [skill-creator/](./skill-creator/) - Guidance for building effective Codex skills with progressive disclosure.

--- a/minimax-video-generation/SKILL.md
+++ b/minimax-video-generation/SKILL.md
@@ -21,20 +21,20 @@ script (`scripts/generate_video.py`) runs that full flow for you.
   ```bash
   export MINIMAX_API_KEY="your-api-key"
   ```
-- Python 3 (the script uses only the standard library — no extra packages required).
+- Python 3 (the script uses only the standard library; no extra packages required).
 
 ## Quick Start
 
 Text-to-video:
 
 ```bash
-python scripts/generate_video.py "A red fox running across a snowy field at sunrise"
+python scripts/generate_video.py "A red fox running across a snowy field at sunrise" --duration 6
 ```
 
 Image-to-video (animate a starting frame):
 
 ```bash
-python scripts/generate_video.py "The camera slowly zooms in" --first-frame-image ./frame.jpg
+python scripts/generate_video.py "The camera slowly zooms in" --first-frame-image ./frame.jpg --duration 6
 ```
 
 Both commands submit the task, poll until it completes, then download the finished MP4 to
@@ -44,28 +44,31 @@ Both commands submit the task, poll until it completes, then download the finish
 
 | Option | Description |
 |--------|-------------|
-| `prompt` (positional) | Text description of the video. Required for text-to-video; optional for image-to-video. |
-| `--first-frame-image PATH_OR_URL` | Local image path or public URL used as the first frame. Switches the request to image-to-video. |
-| `--model NAME` | Model to use (default `MiniMax-Hailuo-2.3`). |
+| `prompt` (positional) | Text description. Required for H3 and v1 text-to-video; optional only for v1 image-to-video. |
+| `--first-frame-image PATH_OR_URL` | Local image path, public URL, or data URI used as the first frame. H3 also accepts `mm_file://` references. |
+| `--model NAME` | Model to use (default `MiniMax-H3`). |
 | `--region {global_en,cn_zh}` | API region (default `global_en`). |
-| `--duration N` | Requested clip duration in seconds (model-dependent). |
-| `--resolution VALUE` | Requested output resolution (e.g. `768P`, `1080P`; model-dependent). |
-| `--prompt-optimizer / --no-prompt-optimizer` | Enable or disable prompt optimization (enabled by default). |
-| `--fast-pretreatment` | Enable fast pretreatment. |
-| `--callback-url URL` | Receive task status updates via callback instead of polling. |
+| `--duration N` | Requested clip duration. Required for H3 and must be an integer from 4 to 15. |
+| `--resolution VALUE` | Requested output resolution. H3 supports `2K`, which is used by default. |
+| `--ratio VALUE` | H3 aspect ratio: `adaptive`, `21:9`, `16:9`, `4:3`, `1:1`, `3:4`, or `9:16`. |
+| `--prompt-optimizer / --no-prompt-optimizer` | Enable or disable prompt optimization for v1 models. |
+| `--fast-pretreatment` | Enable fast pretreatment for v1 models. |
+| `--aigc-watermark / --no-aigc-watermark` | Configure the H3 watermark in the `cn_zh` region. |
+| `--callback-url URL` | Also request task status updates at a callback URL; the script continues polling. |
 | `--output DIR` / `-o DIR` | Output directory (default `/mnt/user-data/outputs/`). |
 | `--poll-interval SECONDS` | Seconds between status checks (default 10). |
 | `--timeout SECONDS` | Maximum time to wait for the task (default 600). |
 
 ## Models
 
-Default: `MiniMax-Hailuo-2.3`
+Default: `MiniMax-H3` (v2 API)
 
-Available: `MiniMax-Hailuo-2.3`, `MiniMax-Hailuo-2.3-Fast`, `MiniMax-Hailuo-02`,
+Also available through the v1 API: `MiniMax-Hailuo-2.3`, `MiniMax-Hailuo-2.3-Fast`, `MiniMax-Hailuo-02`,
 `T2V-01-Director`, `T2V-01`, `I2V-01-Director`, `I2V-01-live`, `I2V-01`.
 
-Use a `T2V-*` model for text-to-video and an `I2V-*` model when providing a first frame; the
-`MiniMax-Hailuo-*` models support both modes.
+H3 supports text-to-video and first-frame image-to-video. For older models, use a `T2V-*` model
+for text-to-video and an `I2V-*` model when providing a first frame; the `MiniMax-Hailuo-*`
+models support both modes.
 
 ## Regions
 
@@ -76,36 +79,43 @@ Use a `T2V-*` model for text-to-video and an `I2V-*` model when providing a firs
 
 ## How It Works
 
-1. **Submit** — `POST /v1/video_generation` with the model plus a `prompt` (text-to-video) or a
-   `first_frame_image` (image-to-video). The response returns a `task_id`.
-2. **Poll** — `GET /v1/query/video_generation?task_id=...` until the task `status` reaches a
-   terminal state. On success the response includes a `file_id`.
-3. **Retrieve** — `GET /v1/files/retrieve?file_id=...` to obtain the download URL, then download
-   the rendered video to the output directory.
+For `MiniMax-H3`:
 
-All requests authenticate with `Authorization: Bearer $MINIMAX_API_KEY`, and every response is
-checked via `base_resp.status_code`.
+1. **Submit**: `POST /v2/video_generation` with `model`, a typed `content` array, `resolution`,
+   and `duration`. Text is always required; an image-to-video request adds an `image_url` item
+   with the `first_frame` role.
+2. **Poll**: `GET /v2/query/video_generation/{task_id}` until `task.status` is `succeeded` or
+   `failed`.
+3. **Download**: On success, download the direct URL from `task.content.url`.
+
+For v1 models, the script submits to `POST /v1/video_generation`, polls
+`GET /v1/query/video_generation?task_id=...`, and calls
+`GET /v1/files/retrieve?file_id=...` to obtain the download URL.
+
+All requests authenticate with `Authorization: Bearer $MINIMAX_API_KEY`. The v1 response path is
+also checked via `base_resp.status_code`.
 
 ## Examples
 
 1. Text-to-video with a specific model and duration:
    ```bash
-   python scripts/generate_video.py "Neon city skyline timelapse at night" --model MiniMax-Hailuo-02 --duration 6
+   python scripts/generate_video.py "Neon city skyline timelapse at night" --duration 6 --ratio 16:9
    ```
 
 2. Image-to-video from a local frame with a camera-motion prompt:
    ```bash
-   python scripts/generate_video.py "Pan left across the landscape" --first-frame-image ./landscape.png --model I2V-01
+   python scripts/generate_video.py "Pan left across the landscape" --first-frame-image ./landscape.png --duration 6
    ```
 
 3. Text-to-video in the `cn_zh` region saved to a custom directory:
    ```bash
-   python scripts/generate_video.py "A calm mountain landscape animation" --region cn_zh -o ./out
+   python scripts/generate_video.py "A calm mountain landscape animation" --duration 6 --region cn_zh -o ./out
    ```
 
 ## Notes
 
 - Generation is asynchronous and may take a few minutes; increase `--timeout` for longer clips.
+- H3 requires a non-empty text prompt for both text-to-video and image-to-video requests.
 - Download URLs returned by the API are time-limited, so the script downloads the file
   immediately after the task succeeds.
-- `--first-frame-image` accepts either a local file (encoded and sent inline) or a public URL.
+- Local first-frame images are encoded as data URIs before submission.

--- a/minimax-video-generation/SKILL.md
+++ b/minimax-video-generation/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: minimax-video-generation
+description: Generate videos with MiniMax from a text prompt (text-to-video) or a starting image (image-to-video). Use this skill when the user asks to create, render, or animate a video from a description or an image. Handles asynchronous task submission, task-status polling, and downloading the finished video.
+---
+
+# MiniMax Video Generation
+
+Create videos with MiniMax's video generation API. The API is asynchronous: you submit a
+generation task, poll the task until it finishes, then download the rendered file. The bundled
+script (`scripts/generate_video.py`) runs that full flow for you.
+
+## When to Use This Skill
+
+- Generate a video clip from a text prompt (text-to-video)
+- Animate a still image into a video (image-to-video)
+- Turn a storyboard or scene description into a short rendered clip
+
+## Prerequisites
+
+- A MiniMax API key. Set it in the `MINIMAX_API_KEY` environment variable:
+  ```bash
+  export MINIMAX_API_KEY="your-api-key"
+  ```
+- Python 3 (the script uses only the standard library — no extra packages required).
+
+## Quick Start
+
+Text-to-video:
+
+```bash
+python scripts/generate_video.py "A red fox running across a snowy field at sunrise"
+```
+
+Image-to-video (animate a starting frame):
+
+```bash
+python scripts/generate_video.py "The camera slowly zooms in" --first-frame-image ./frame.jpg
+```
+
+Both commands submit the task, poll until it completes, then download the finished MP4 to
+`/mnt/user-data/outputs/`.
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `prompt` (positional) | Text description of the video. Required for text-to-video; optional for image-to-video. |
+| `--first-frame-image PATH_OR_URL` | Local image path or public URL used as the first frame. Switches the request to image-to-video. |
+| `--model NAME` | Model to use (default `MiniMax-Hailuo-2.3`). |
+| `--region {global_en,cn_zh}` | API region (default `global_en`). |
+| `--duration N` | Requested clip duration in seconds (model-dependent). |
+| `--resolution VALUE` | Requested output resolution (e.g. `768P`, `1080P`; model-dependent). |
+| `--prompt-optimizer / --no-prompt-optimizer` | Enable or disable prompt optimization (enabled by default). |
+| `--fast-pretreatment` | Enable fast pretreatment. |
+| `--callback-url URL` | Receive task status updates via callback instead of polling. |
+| `--output DIR` / `-o DIR` | Output directory (default `/mnt/user-data/outputs/`). |
+| `--poll-interval SECONDS` | Seconds between status checks (default 10). |
+| `--timeout SECONDS` | Maximum time to wait for the task (default 600). |
+
+## Models
+
+Default: `MiniMax-Hailuo-2.3`
+
+Available: `MiniMax-Hailuo-2.3`, `MiniMax-Hailuo-2.3-Fast`, `MiniMax-Hailuo-02`,
+`T2V-01-Director`, `T2V-01`, `I2V-01-Director`, `I2V-01-live`, `I2V-01`.
+
+Use a `T2V-*` model for text-to-video and an `I2V-*` model when providing a first frame; the
+`MiniMax-Hailuo-*` models support both modes.
+
+## Regions
+
+| Region | API base |
+|--------|----------|
+| `global_en` (default) | `https://api.minimax.io` |
+| `cn_zh` | `https://api.minimaxi.com` |
+
+## How It Works
+
+1. **Submit** — `POST /v1/video_generation` with the model plus a `prompt` (text-to-video) or a
+   `first_frame_image` (image-to-video). The response returns a `task_id`.
+2. **Poll** — `GET /v1/query/video_generation?task_id=...` until the task `status` reaches a
+   terminal state. On success the response includes a `file_id`.
+3. **Retrieve** — `GET /v1/files/retrieve?file_id=...` to obtain the download URL, then download
+   the rendered video to the output directory.
+
+All requests authenticate with `Authorization: Bearer $MINIMAX_API_KEY`, and every response is
+checked via `base_resp.status_code`.
+
+## Examples
+
+1. Text-to-video with a specific model and duration:
+   ```bash
+   python scripts/generate_video.py "Neon city skyline timelapse at night" --model MiniMax-Hailuo-02 --duration 6
+   ```
+
+2. Image-to-video from a local frame with a camera-motion prompt:
+   ```bash
+   python scripts/generate_video.py "Pan left across the landscape" --first-frame-image ./landscape.png --model I2V-01
+   ```
+
+3. Text-to-video in the `cn_zh` region saved to a custom directory:
+   ```bash
+   python scripts/generate_video.py "A calm mountain landscape animation" --region cn_zh -o ./out
+   ```
+
+## Notes
+
+- Generation is asynchronous and may take a few minutes; increase `--timeout` for longer clips.
+- Download URLs returned by the API are time-limited, so the script downloads the file
+  immediately after the task succeeds.
+- `--first-frame-image` accepts either a local file (encoded and sent inline) or a public URL.

--- a/minimax-video-generation/SKILL.md
+++ b/minimax-video-generation/SKILL.md
@@ -85,7 +85,7 @@ For `MiniMax-H3`:
    and `duration`. Text is always required; an image-to-video request adds an `image_url` item
    with the `first_frame` role.
 2. **Poll**: `GET /v2/query/video_generation/{task_id}` until `task.status` is `succeeded` or
-   `failed`.
+   reaches a `failed` or `cancelled` terminal state.
 3. **Download**: On success, download the direct URL from `task.content.url`.
 
 For v1 models, the script submits to `POST /v1/video_generation`, polls

--- a/minimax-video-generation/scripts/generate_video.py
+++ b/minimax-video-generation/scripts/generate_video.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Generate a video with MiniMax (text-to-video or image-to-video).
+
+The MiniMax video API is asynchronous. This script runs the full flow:
+
+  1. Submit a generation task   -> POST /v1/video_generation      (returns task_id)
+  2. Poll the task status       -> GET  /v1/query/video_generation (returns status, file_id)
+  3. Retrieve and download it   -> GET  /v1/files/retrieve          (returns download URL)
+
+Authentication uses the MINIMAX_API_KEY environment variable as a Bearer token.
+Only the Python standard library is required.
+"""
+
+import argparse
+import base64
+import json
+import mimetypes
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+DEFAULT_MODEL = "MiniMax-Hailuo-2.3"
+MODELS = [
+    "MiniMax-Hailuo-2.3",
+    "MiniMax-Hailuo-2.3-Fast",
+    "MiniMax-Hailuo-02",
+    "T2V-01-Director",
+    "T2V-01",
+    "I2V-01-Director",
+    "I2V-01-live",
+    "I2V-01",
+]
+
+# Regional API bases. The video endpoints live under /v1 on each host.
+REGION_BASES = {
+    "global_en": "https://api.minimax.io",
+    "cn_zh": "https://api.minimaxi.com",
+}
+
+SUBMIT_PATH = "/v1/video_generation"
+QUERY_PATH = "/v1/query/video_generation"
+RETRIEVE_PATH = "/v1/files/retrieve"
+
+# Terminal task statuses returned by the query endpoint.
+SUCCESS_STATES = {"Success"}
+FAILURE_STATES = {"Fail"}
+
+
+def _api_key():
+    key = os.environ.get("MINIMAX_API_KEY", "").strip()
+    if not key:
+        sys.exit("Error: set the MINIMAX_API_KEY environment variable to your MiniMax API key.")
+    return key
+
+
+def _check_base_resp(payload):
+    """Raise if the MiniMax base_resp reports a non-zero status code."""
+    base = payload.get("base_resp") or {}
+    code = base.get("status_code")
+    if code not in (None, 0):
+        msg = base.get("status_msg", "unknown error")
+        sys.exit("MiniMax API error (status_code={}): {}".format(code, msg))
+
+
+def _request(method, url, key, body=None):
+    data = None
+    headers = {"Authorization": "Bearer {}".format(key)}
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")
+        sys.exit("HTTP {} from {}: {}".format(exc.code, url, detail))
+    except urllib.error.URLError as exc:
+        sys.exit("Network error calling {}: {}".format(url, exc.reason))
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        sys.exit("Unexpected non-JSON response from {}: {}".format(url, raw[:200]))
+
+
+def _encode_first_frame(value):
+    """Return a value usable as first_frame_image: a URL or a base64 data URI."""
+    if value.startswith("http://") or value.startswith("https://") or value.startswith("data:"):
+        return value
+    if not os.path.isfile(value):
+        sys.exit("Error: first-frame image not found: {}".format(value))
+    mime = mimetypes.guess_type(value)[0] or "image/jpeg"
+    with open(value, "rb") as fh:
+        encoded = base64.b64encode(fh.read()).decode("ascii")
+    return "data:{};base64,{}".format(mime, encoded)
+
+
+def submit_task(base, key, args):
+    body = {"model": args.model}
+    if args.first_frame_image:
+        body["first_frame_image"] = _encode_first_frame(args.first_frame_image)
+        if args.prompt:
+            body["prompt"] = args.prompt
+    else:
+        if not args.prompt:
+            sys.exit("Error: a text prompt is required for text-to-video.")
+        body["prompt"] = args.prompt
+
+    if args.prompt_optimizer is not None:
+        body["prompt_optimizer"] = args.prompt_optimizer
+    if args.fast_pretreatment:
+        body["fast_pretreatment"] = True
+    if args.duration is not None:
+        body["duration"] = args.duration
+    if args.resolution:
+        body["resolution"] = args.resolution
+    if args.callback_url:
+        body["callback_url"] = args.callback_url
+
+    mode = "image-to-video" if args.first_frame_image else "text-to-video"
+    print("Submitting {} task (model={})...".format(mode, args.model))
+    payload = _request("POST", base + SUBMIT_PATH, key, body)
+    _check_base_resp(payload)
+    task_id = payload.get("task_id")
+    if not task_id:
+        sys.exit("No task_id returned by the API: {}".format(json.dumps(payload)[:300]))
+    print("Task submitted: task_id={}".format(task_id))
+    return task_id
+
+
+def poll_task(base, key, task_id, poll_interval, timeout):
+    query = base + QUERY_PATH + "?" + urllib.parse.urlencode({"task_id": task_id})
+    deadline = time.monotonic() + timeout
+    last_status = None
+    while True:
+        payload = _request("GET", query, key)
+        _check_base_resp(payload)
+        status = payload.get("status", "")
+        if status != last_status:
+            print("Task status: {}".format(status))
+            last_status = status
+        if status in SUCCESS_STATES:
+            file_id = payload.get("file_id")
+            if not file_id:
+                sys.exit("Task succeeded but no file_id was returned.")
+            return file_id
+        if status in FAILURE_STATES:
+            sys.exit("Task failed: {}".format(json.dumps(payload)[:300]))
+        if time.monotonic() >= deadline:
+            sys.exit("Timed out after {}s waiting for task {}.".format(timeout, task_id))
+        time.sleep(poll_interval)
+
+
+def retrieve_download_url(base, key, file_id):
+    query = base + RETRIEVE_PATH + "?" + urllib.parse.urlencode({"file_id": file_id})
+    payload = _request("GET", query, key)
+    _check_base_resp(payload)
+    file_info = payload.get("file") or {}
+    url = file_info.get("download_url") or file_info.get("backup_download_url")
+    if not url:
+        sys.exit("No download URL found for file_id={}: {}".format(file_id, json.dumps(payload)[:300]))
+    return url
+
+
+def download(url, out_dir, file_id):
+    os.makedirs(out_dir, exist_ok=True)
+    dest = os.path.join(out_dir, "minimax-video-{}.mp4".format(file_id))
+    print("Downloading video to {}...".format(dest))
+    try:
+        with urllib.request.urlopen(url, timeout=120) as resp, open(dest, "wb") as fh:
+            while True:
+                chunk = resp.read(65536)
+                if not chunk:
+                    break
+                fh.write(chunk)
+    except (urllib.error.URLError, OSError) as exc:
+        sys.exit("Failed to download video: {}".format(exc))
+    return dest
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description="Generate a video with MiniMax (text-to-video or image-to-video)."
+    )
+    parser.add_argument("prompt", nargs="?", help="Text description of the video.")
+    parser.add_argument("--first-frame-image", dest="first_frame_image",
+                        help="Local image path or URL to animate (image-to-video).")
+    parser.add_argument("--model", default=DEFAULT_MODEL, choices=MODELS,
+                        help="Model to use (default: %(default)s).")
+    parser.add_argument("--region", default="global_en", choices=sorted(REGION_BASES),
+                        help="API region (default: %(default)s).")
+    parser.add_argument("--duration", type=int, help="Requested clip duration in seconds.")
+    parser.add_argument("--resolution", help="Requested output resolution (e.g. 768P, 1080P).")
+    parser.add_argument("--prompt-optimizer", dest="prompt_optimizer",
+                        action="store_true", default=None, help="Enable prompt optimization.")
+    parser.add_argument("--no-prompt-optimizer", dest="prompt_optimizer",
+                        action="store_false", help="Disable prompt optimization.")
+    parser.add_argument("--fast-pretreatment", action="store_true",
+                        help="Enable fast pretreatment.")
+    parser.add_argument("--callback-url", dest="callback_url",
+                        help="Callback URL for task status updates.")
+    parser.add_argument("-o", "--output", default="/mnt/user-data/outputs/",
+                        help="Output directory (default: %(default)s).")
+    parser.add_argument("--poll-interval", type=float, default=10.0,
+                        help="Seconds between status checks (default: %(default)s).")
+    parser.add_argument("--timeout", type=float, default=600.0,
+                        help="Maximum seconds to wait for the task (default: %(default)s).")
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    if not args.prompt and not args.first_frame_image:
+        sys.exit("Error: provide a text prompt, a --first-frame-image, or both.")
+
+    key = _api_key()
+    base = REGION_BASES[args.region]
+
+    task_id = submit_task(base, key, args)
+    file_id = poll_task(base, key, task_id, args.poll_interval, args.timeout)
+    url = retrieve_download_url(base, key, file_id)
+    dest = download(url, args.output, file_id)
+    print("Done. Saved video to {}".format(dest))
+
+
+if __name__ == "__main__":
+    main()

--- a/minimax-video-generation/scripts/generate_video.py
+++ b/minimax-video-generation/scripts/generate_video.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 """Generate a video with MiniMax (text-to-video or image-to-video).
 
-The MiniMax video API is asynchronous. This script runs the full flow:
+MiniMax video generation is asynchronous. This script supports both API versions:
 
-  1. Submit a generation task   -> POST /v1/video_generation      (returns task_id)
-  2. Poll the task status       -> GET  /v1/query/video_generation (returns status, file_id)
-  3. Retrieve and download it   -> GET  /v1/files/retrieve          (returns download URL)
+  - MiniMax-H3 uses POST /v2/video_generation and polls
+    GET /v2/query/video_generation/{task_id} for a direct output URL.
+  - Earlier models use POST /v1/video_generation, poll
+    GET /v1/query/video_generation, and retrieve the output with
+    GET /v1/files/retrieve.
 
 Authentication uses the MINIMAX_API_KEY environment variable as a Bearer token.
 Only the Python standard library is required.
@@ -16,14 +18,16 @@ import base64
 import json
 import mimetypes
 import os
+import re
 import sys
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
 
-DEFAULT_MODEL = "MiniMax-Hailuo-2.3"
-MODELS = [
+DEFAULT_MODEL = "MiniMax-H3"
+V2_MODELS = {"MiniMax-H3"}
+V1_MODELS = [
     "MiniMax-Hailuo-2.3",
     "MiniMax-Hailuo-2.3-Fast",
     "MiniMax-Hailuo-02",
@@ -33,20 +37,25 @@ MODELS = [
     "I2V-01-live",
     "I2V-01",
 ]
+MODELS = [DEFAULT_MODEL] + V1_MODELS
+RATIOS = ["adaptive", "21:9", "16:9", "4:3", "1:1", "3:4", "9:16"]
 
-# Regional API bases. The video endpoints live under /v1 on each host.
 REGION_BASES = {
     "global_en": "https://api.minimax.io",
     "cn_zh": "https://api.minimaxi.com",
 }
 
-SUBMIT_PATH = "/v1/video_generation"
-QUERY_PATH = "/v1/query/video_generation"
-RETRIEVE_PATH = "/v1/files/retrieve"
+V2_SUBMIT_PATH = "/v2/video_generation"
+V2_QUERY_PATH = "/v2/query/video_generation/{task_id}"
+V1_SUBMIT_PATH = "/v1/video_generation"
+V1_QUERY_PATH = "/v1/query/video_generation"
+V1_RETRIEVE_PATH = "/v1/files/retrieve"
 
-# Terminal task statuses returned by the query endpoint.
-SUCCESS_STATES = {"Success"}
-FAILURE_STATES = {"Fail"}
+V2_SUCCESS_STATES = {"succeeded"}
+V2_FAILURE_STATES = {"failed"}
+V1_SUCCESS_STATES = {"Success"}
+V1_FAILURE_STATES = {"Fail"}
+V2_MAX_BODY_BYTES = 64 * 1024 * 1024
 
 
 def _api_key():
@@ -56,8 +65,12 @@ def _api_key():
     return key
 
 
+def _api_version(model):
+    return "v2" if model in V2_MODELS else "v1"
+
+
 def _check_base_resp(payload):
-    """Raise if the MiniMax base_resp reports a non-zero status code."""
+    """Raise if a v1 MiniMax response reports a non-zero status code."""
     base = payload.get("base_resp") or {}
     code = base.get("status_code")
     if code not in (None, 0):
@@ -87,8 +100,9 @@ def _request(method, url, key, body=None):
 
 
 def _encode_first_frame(value):
-    """Return a value usable as first_frame_image: a URL or a base64 data URI."""
-    if value.startswith("http://") or value.startswith("https://") or value.startswith("data:"):
+    """Return a supported image URL, file reference, or base64 data URI."""
+    supported_prefixes = ("http://", "https://", "data:", "mm_file://")
+    if value.startswith(supported_prefixes):
         return value
     if not os.path.isfile(value):
         sys.exit("Error: first-frame image not found: {}".format(value))
@@ -98,7 +112,54 @@ def _encode_first_frame(value):
     return "data:{};base64,{}".format(mime, encoded)
 
 
-def submit_task(base, key, args):
+def _build_v2_body(args):
+    if not args.prompt:
+        sys.exit("Error: MiniMax-H3 requires a text prompt for every generation mode.")
+    if len(args.prompt) > 7000:
+        sys.exit("Error: MiniMax-H3 prompts must not exceed 7000 characters.")
+    if args.duration is None or not 4 <= args.duration <= 15:
+        sys.exit("Error: MiniMax-H3 requires --duration as an integer from 4 to 15 seconds.")
+
+    resolution = args.resolution or "2K"
+    if resolution != "2K":
+        sys.exit("Error: MiniMax-H3 currently supports only --resolution 2K.")
+    if args.prompt_optimizer is not None or args.fast_pretreatment:
+        sys.exit("Error: prompt optimization and fast pretreatment are v1-only options.")
+    if args.aigc_watermark is not None and args.region != "cn_zh":
+        sys.exit("Error: --aigc-watermark is available only in the cn_zh region.")
+
+    content = [{"type": "text", "text": args.prompt}]
+    if args.first_frame_image:
+        content.append({
+            "type": "image_url",
+            "image_url": {"url": _encode_first_frame(args.first_frame_image)},
+            "role": "first_frame",
+        })
+
+    body = {
+        "model": args.model,
+        "content": content,
+        "resolution": resolution,
+        "duration": args.duration,
+    }
+    if args.ratio:
+        body["ratio"] = args.ratio
+    if args.callback_url:
+        body["callback_url"] = args.callback_url
+    if args.region == "cn_zh" and args.aigc_watermark is not None:
+        body["aigc_watermark"] = args.aigc_watermark
+
+    if len(json.dumps(body).encode("utf-8")) > V2_MAX_BODY_BYTES:
+        sys.exit("Error: MiniMax-H3 request bodies must not exceed 64 MB.")
+    return body
+
+
+def _build_v1_body(args):
+    if args.ratio:
+        sys.exit("Error: --ratio is available only with MiniMax-H3.")
+    if args.aigc_watermark is not None:
+        sys.exit("Error: --aigc-watermark is available only with MiniMax-H3 in cn_zh.")
+
     body = {"model": args.model}
     if args.first_frame_image:
         body["first_frame_image"] = _encode_first_frame(args.first_frame_image)
@@ -119,43 +180,76 @@ def submit_task(base, key, args):
         body["resolution"] = args.resolution
     if args.callback_url:
         body["callback_url"] = args.callback_url
+    return body
+
+
+def submit_task(base, key, args):
+    api_version = _api_version(args.model)
+    if api_version == "v2":
+        path = V2_SUBMIT_PATH
+        body = _build_v2_body(args)
+    else:
+        path = V1_SUBMIT_PATH
+        body = _build_v1_body(args)
 
     mode = "image-to-video" if args.first_frame_image else "text-to-video"
-    print("Submitting {} task (model={})...".format(mode, args.model))
-    payload = _request("POST", base + SUBMIT_PATH, key, body)
-    _check_base_resp(payload)
+    print("Submitting {} task (model={}, api={})...".format(mode, args.model, api_version))
+    payload = _request("POST", base + path, key, body)
+    if api_version == "v1":
+        _check_base_resp(payload)
     task_id = payload.get("task_id")
     if not task_id:
         sys.exit("No task_id returned by the API: {}".format(json.dumps(payload)[:300]))
     print("Task submitted: task_id={}".format(task_id))
-    return task_id
+    return api_version, str(task_id)
 
 
-def poll_task(base, key, task_id, poll_interval, timeout):
-    query = base + QUERY_PATH + "?" + urllib.parse.urlencode({"task_id": task_id})
+def poll_task(base, key, api_version, task_id, poll_interval, timeout):
+    if api_version == "v2":
+        quoted_task_id = urllib.parse.quote(task_id, safe="")
+        query = base + V2_QUERY_PATH.format(task_id=quoted_task_id)
+    else:
+        query = base + V1_QUERY_PATH + "?" + urllib.parse.urlencode({"task_id": task_id})
+
     deadline = time.monotonic() + timeout
     last_status = None
     while True:
         payload = _request("GET", query, key)
-        _check_base_resp(payload)
-        status = payload.get("status", "")
+        if api_version == "v2":
+            task = payload.get("task") or {}
+            status = str(task.get("status", "")).lower()
+            success_states = V2_SUCCESS_STATES
+            failure_states = V2_FAILURE_STATES
+        else:
+            _check_base_resp(payload)
+            task = payload
+            status = payload.get("status", "")
+            success_states = V1_SUCCESS_STATES
+            failure_states = V1_FAILURE_STATES
+
         if status != last_status:
             print("Task status: {}".format(status))
             last_status = status
-        if status in SUCCESS_STATES:
+        if status in success_states:
+            if api_version == "v2":
+                output = task.get("content") or {}
+                url = output.get("url")
+                if not url:
+                    sys.exit("Task succeeded but no task.content.url was returned.")
+                return {"download_url": url, "result_id": task.get("id") or task_id}
             file_id = payload.get("file_id")
             if not file_id:
                 sys.exit("Task succeeded but no file_id was returned.")
-            return file_id
-        if status in FAILURE_STATES:
-            sys.exit("Task failed: {}".format(json.dumps(payload)[:300]))
+            return {"file_id": str(file_id), "result_id": str(file_id)}
+        if status in failure_states:
+            sys.exit("Task failed: {}".format(json.dumps(task)[:300]))
         if time.monotonic() >= deadline:
             sys.exit("Timed out after {}s waiting for task {}.".format(timeout, task_id))
         time.sleep(poll_interval)
 
 
 def retrieve_download_url(base, key, file_id):
-    query = base + RETRIEVE_PATH + "?" + urllib.parse.urlencode({"file_id": file_id})
+    query = base + V1_RETRIEVE_PATH + "?" + urllib.parse.urlencode({"file_id": file_id})
     payload = _request("GET", query, key)
     _check_base_resp(payload)
     file_info = payload.get("file") or {}
@@ -165,9 +259,10 @@ def retrieve_download_url(base, key, file_id):
     return url
 
 
-def download(url, out_dir, file_id):
+def download(url, out_dir, result_id):
     os.makedirs(out_dir, exist_ok=True)
-    dest = os.path.join(out_dir, "minimax-video-{}.mp4".format(file_id))
+    safe_id = re.sub(r"[^A-Za-z0-9._-]+", "-", str(result_id)).strip("-") or "result"
+    dest = os.path.join(out_dir, "minimax-video-{}.mp4".format(safe_id))
     print("Downloading video to {}...".format(dest))
     try:
         with urllib.request.urlopen(url, timeout=120) as resp, open(dest, "wb") as fh:
@@ -186,28 +281,56 @@ def build_parser():
         description="Generate a video with MiniMax (text-to-video or image-to-video)."
     )
     parser.add_argument("prompt", nargs="?", help="Text description of the video.")
-    parser.add_argument("--first-frame-image", dest="first_frame_image",
-                        help="Local image path or URL to animate (image-to-video).")
-    parser.add_argument("--model", default=DEFAULT_MODEL, choices=MODELS,
-                        help="Model to use (default: %(default)s).")
-    parser.add_argument("--region", default="global_en", choices=sorted(REGION_BASES),
-                        help="API region (default: %(default)s).")
-    parser.add_argument("--duration", type=int, help="Requested clip duration in seconds.")
-    parser.add_argument("--resolution", help="Requested output resolution (e.g. 768P, 1080P).")
-    parser.add_argument("--prompt-optimizer", dest="prompt_optimizer",
-                        action="store_true", default=None, help="Enable prompt optimization.")
-    parser.add_argument("--no-prompt-optimizer", dest="prompt_optimizer",
-                        action="store_false", help="Disable prompt optimization.")
-    parser.add_argument("--fast-pretreatment", action="store_true",
-                        help="Enable fast pretreatment.")
-    parser.add_argument("--callback-url", dest="callback_url",
-                        help="Callback URL for task status updates.")
-    parser.add_argument("-o", "--output", default="/mnt/user-data/outputs/",
-                        help="Output directory (default: %(default)s).")
-    parser.add_argument("--poll-interval", type=float, default=10.0,
-                        help="Seconds between status checks (default: %(default)s).")
-    parser.add_argument("--timeout", type=float, default=600.0,
-                        help="Maximum seconds to wait for the task (default: %(default)s).")
+    parser.add_argument(
+        "--first-frame-image",
+        dest="first_frame_image",
+        help="Local image path, public URL, data URI, or mm_file:// reference.",
+    )
+    parser.add_argument(
+        "--model", default=DEFAULT_MODEL, choices=MODELS,
+        help="Model to use (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--region", default="global_en", choices=sorted(REGION_BASES),
+        help="API region (default: %(default)s).",
+    )
+    parser.add_argument("--duration", type=int, help="Clip duration in seconds; H3 requires 4-15.")
+    parser.add_argument("--resolution", help="Output resolution; H3 supports 2K only.")
+    parser.add_argument("--ratio", choices=RATIOS, help="H3 output aspect ratio.")
+    parser.add_argument(
+        "--prompt-optimizer", dest="prompt_optimizer", action="store_true", default=None,
+        help="Enable v1 prompt optimization.",
+    )
+    parser.add_argument(
+        "--no-prompt-optimizer", dest="prompt_optimizer", action="store_false",
+        help="Disable v1 prompt optimization.",
+    )
+    parser.add_argument(
+        "--fast-pretreatment", action="store_true", help="Enable v1 fast pretreatment.",
+    )
+    parser.add_argument(
+        "--aigc-watermark", dest="aigc_watermark", action="store_true", default=None,
+        help="Enable the H3 watermark in the cn_zh region.",
+    )
+    parser.add_argument(
+        "--no-aigc-watermark", dest="aigc_watermark", action="store_false",
+        help="Disable the H3 watermark in the cn_zh region.",
+    )
+    parser.add_argument(
+        "--callback-url", dest="callback_url", help="Callback URL for task status updates.",
+    )
+    parser.add_argument(
+        "-o", "--output", default="/mnt/user-data/outputs/",
+        help="Output directory (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--poll-interval", type=float, default=10.0,
+        help="Seconds between status checks (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--timeout", type=float, default=600.0,
+        help="Maximum seconds to wait for the task (default: %(default)s).",
+    )
     return parser
 
 
@@ -218,11 +341,12 @@ def main(argv=None):
 
     key = _api_key()
     base = REGION_BASES[args.region]
-
-    task_id = submit_task(base, key, args)
-    file_id = poll_task(base, key, task_id, args.poll_interval, args.timeout)
-    url = retrieve_download_url(base, key, file_id)
-    dest = download(url, args.output, file_id)
+    api_version, task_id = submit_task(base, key, args)
+    result = poll_task(base, key, api_version, task_id, args.poll_interval, args.timeout)
+    url = result.get("download_url")
+    if not url:
+        url = retrieve_download_url(base, key, result["file_id"])
+    dest = download(url, args.output, result["result_id"])
     print("Done. Saved video to {}".format(dest))
 
 

--- a/minimax-video-generation/scripts/generate_video.py
+++ b/minimax-video-generation/scripts/generate_video.py
@@ -52,7 +52,7 @@ V1_QUERY_PATH = "/v1/query/video_generation"
 V1_RETRIEVE_PATH = "/v1/files/retrieve"
 
 V2_SUCCESS_STATES = {"succeeded"}
-V2_FAILURE_STATES = {"failed"}
+V2_FAILURE_STATES = {"failed", "cancelled"}
 V1_SUCCESS_STATES = {"Success"}
 V1_FAILURE_STATES = {"Fail"}
 V2_MAX_BODY_BYTES = 64 * 1024 * 1024


### PR DESCRIPTION
Reason: The skill collection has Rube-backed video automation skills but no MiniMax skill, so this adds a MiniMax video-generation skill.

## What this adds

A new `minimax-video-generation/` skill that generates videos with MiniMax's asynchronous video API:

- **Text-to-video** — `POST /v1/video_generation` with a `model` and `prompt`.
- **Image-to-video** — the same endpoint with a `first_frame_image` (local file encoded inline, or a URL) plus an optional `prompt`.
- **Asynchronous task polling** — `GET /v1/query/video_generation?task_id=...` until the task reaches a terminal `status`.
- **Result retrieval** — `GET /v1/files/retrieve?file_id=...` to obtain the download URL, then downloads the finished MP4.

### Files

- `minimax-video-generation/SKILL.md` — skill metadata and usage, following the existing `SKILL.md` frontmatter convention.
- `minimax-video-generation/scripts/generate_video.py` — a standard-library-only Python 3 script that runs submit → poll → retrieve → download.
- `README.md` — lists the new skill under **Meta & Utilities**.

### Details

- Authentication uses the `MINIMAX_API_KEY` environment variable as a Bearer token; every response is checked via `base_resp.status_code`.
- Supports both the `global_en` (`https://api.minimax.io`) and `cn_zh` (`https://api.minimaxi.com`) regions via `--region`.
- Model choices default to `MiniMax-Hailuo-2.3` and cover the available text-to-video and image-to-video models.

## Checks

- `python3 -m py_compile minimax-video-generation/scripts/generate_video.py` — passes.
- Exercised the CLI: `--help`, missing-input error, missing-API-key error, and invalid-model rejection all behave as expected.
- Validated the `SKILL.md` frontmatter (`name` + `description`) parses correctly.
