### PR TITLE
Add Fact-Check-X to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [competitive-ads-extractor/](./competitive-ads-extractor/) - Analyze competitor ads and extract structured insights.
 - [datadog-logs/](./datadog-logs/) - Filter Datadog logs from the shell via the Composio CLI, with JSON-friendly output and digest workflows.
 - [developer-growth-analysis/](./developer-growth-analysis/) - Analyze Codex chat history for coding patterns and learning gaps.
+- [Fact-Check-X](https://github.com/ASI2030/Fact-Check-X/tree/main/skills/fact-check-x-complete) - Capture complete answers and citations from one or more AI platforms, compare atomic claims, verify them against authoritative evidence, and produce traceable stage reports. Install: `npx skills add ASI2030/Fact-Check-X --skill fact-check-x-complete`
 - [lead-research-assistant/](./lead-research-assistant/) - Research leads and enrich records with firmographic data.
 - [domain-name-brainstormer/](./domain-name-brainstormer/) - Brainstorm available domain names with criteria and checks.
 - [raffle-winner-picker/](./raffle-winner-picker/) - Randomly select winners with audit-friendly logs.


### PR DESCRIPTION
## Summary

Adds Fact-Check-X as a one-line external Agent Skill entry under **Data & Analysis**.

Fact-Check-X captures complete answers and citations from one or more AI platforms, decomposes disagreements into atomic claims, verifies each point against authoritative evidence, and generates traceable stage reports. It is designed for research, policy/compliance, and AI answer QA workflows where having a link is not enough: the source must actually support the claim.

## Codex compatibility and validation

- Public source: https://github.com/ASI2030/Fact-Check-X/tree/main/skills/fact-check-x-complete
- Apache-2.0, five Agent Skills, self-contained complete package
- 94-file complete directory with scripts, modules, references, browser runtime, tests, privacy notice, and manifest
- Validated with Codex and the public install command included in the README entry
- Current release: https://github.com/ASI2030/Fact-Check-X/releases/tag/v1.1.0

## Disclosure

Submitted from the project owner account, ASI2030. The PR only adds the maintained external source link; it does not copy the runtime into this catalog.