### PR TITLE
Add engineering-loop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [create-plan/](./create-plan/) - Quickly draft concise execution plans for coding tasks.
 - [deploy-pipeline/](./deploy-pipeline/) - End-to-end Stripe → Supabase → Vercel release pipelines with verify and rollback.
 - [Emdash Skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS: CF Workers + Hono + Angular + D1 + Stripe. One-line prompts to deployed SaaS with 94 reference docs, 18 agents, and Codex-native `.agents/skills/` support.
+- [engineering-loop](https://github.com/Phelan164/codex-howto/tree/main/skills/engineering-loop) - Drive a software change through baseline, implementation, focused and required checks, findings-first review, verified fixes, and an evidence-based handoff. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo Phelan164/codex-howto --path skills/engineering-loop --name engineering-loop`
 - [gh-address-comments/](./gh-address-comments/) - Address review or issue comments on the open GitHub PR for the current branch using `gh`.
 - [gh-fix-ci/](./gh-fix-ci/) - Inspect failing GitHub Actions checks, summarize failures, and propose fixes.
 - [mcp-builder/](./mcp-builder/) - Build and evaluate MCP servers with best practices and an evaluation harness.


### PR DESCRIPTION
## Summary

Add the external `engineering-loop` skill to Development & Code Tools.

## Why this skill

The skill provides one lifecycle owner for a software change:

1. establish scope and a baseline or reproduction;
2. implement the smallest coherent change;
3. run focused and repository-required checks;
4. review the actual diff with findings first;
5. fix verified issues and report evidence and residual risk.

It uses progressive disclosure through a concise `SKILL.md` plus loop-contract
and hard-debugging references. The entry links to the original maintained skill
and its supported installer command instead of duplicating its files in this
repository.

The current model-adaptive version is published in
[Codex How To v0.3.0](https://github.com/Phelan164/codex-howto/releases/tag/v0.3.0).

## Verified installation

- catalog: https://skills.sh/phelan164/codex-howto/engineering-loop
- `npx skills add Phelan164/codex-howto --skill engineering-loop -g -a codex -y`
- isolated Codex installation smoke test: passed

## Validation

- official `skill-creator/scripts/quick_validate.py`: `Skill is valid!`
- repository validation and GitHub Actions pass on v0.3.0
- verified the current catalog has no `engineering-loop` entry
- `git diff --check`
