### PR TITLE
docs: add missing composio-skills/ entry to Productivity & Collaboration section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 
 - [connect/](./connect/) - Connect Codex to 1000+ apps via the Composio CLI for real actions (Slack, GitHub, Notion, etc.).
 - [connect-apps/](./connect-apps/) - Wire up Composio CLI connections for Claude and kick off app workflows from the shell.
+- [composio-skills/](./composio-skills/) - Access 800+ app-specific automation skills for Composio integrations.
 - [issue-triage/](./issue-triage/) - Triage Linear or Jira backlogs and run bug sweeps from the terminal.
 - [linear/](./linear/) - Manage issues, projects, and team workflows in Linear.
 - [meeting-insights-analyzer/](./meeting-insights-analyzer/) - Analyze meeting transcripts for themes, risks, and follow-ups.


### PR DESCRIPTION
### What this PR does

Adds the missing \[composio-skills/](./composio-skills/)\ entry to the **Productivity & Collaboration** section of \README.md\.

The \composio-skills/\ directory exists in the repository root containing 800+ app-specific automation skills, but was previously unindexed in the README TOC.