### PR TITLE
docs(i18n): add Chinese (zh-CN) & Japanese (ja-JP) translations and update language switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 </div>
 
 <p align="center">
-  <b>Translations:</b> <a href="./README.md">🌐 English</a> • <a href="./i18n/README.vi.md">🇻🇳 Tiếng Việt</a>
+  <b>Translations:</b> <a href="./README.md">🌐 English</a> • <a href="./i18n/README.vi.md">🇻🇳 Tiếng Việt</a> • <a href="./i18n/README.zh-CN.md">🇨🇳 中文</a> • <a href="./i18n/README.ja-JP.md">🇯🇵 日本語</a>
 </p>
 
 A curated list of practical Codex skills for automating workflows across the Codex CLI and API.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 
 - [connect/](./connect/) - Connect Codex to 1000+ apps via the Composio CLI for real actions (Slack, GitHub, Notion, etc.).
 - [connect-apps/](./connect-apps/) - Wire up Composio CLI connections for Claude and kick off app workflows from the shell.
+- [composio-skills/](./composio-skills/) - Access 800+ app-specific automation skills for Composio integrations.
 - [issue-triage/](./issue-triage/) - Triage Linear or Jira backlogs and run bug sweeps from the terminal.
 - [linear/](./linear/) - Manage issues, projects, and team workflows in Linear.
 - [meeting-insights-analyzer/](./meeting-insights-analyzer/) - Analyze meeting transcripts for themes, risks, and follow-ups.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@
   </p>
 </div>
 
+<p align="center">
+  <b>Translations:</b> <a href="./README.md">🌐 English</a> • <a href="./i18n/README.vi.md">🇻🇳 Tiếng Việt</a>
+</p>
+
 A curated list of practical Codex skills for automating workflows across the Codex CLI and API.
 
 ## Give your skills real-world actions

--- a/i18n/README.ja-JP.md
+++ b/i18n/README.ja-JP.md
@@ -1,0 +1,102 @@
+<h1 align="center">Awesome Codex Skills (日本語)</h1>
+
+<p align="center">
+<a href="https://dashboard.composio.dev/login?utm_source=Github&utm_medium=Youtube&utm_campaign=2025-11&utm_content=AwesomeCodexSkills">
+
+  <img width="1280" height="640" alt="Composio banner" src="../codex_cover_image.png">
+</a>
+</p>
+
+<p align="center">
+  <a href="https://awesome.re">
+    <img src="https://awesome.re/badge.svg" alt="Awesome" />
+  </a>
+  <a href="https://makeapullrequest.com">
+    <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square" alt="PRs Welcome" />
+  </a>
+</p>
+<div>
+<p align="center">
+  <a href="https://twitter.com/composio">
+    <img src="https://img.shields.io/badge/Follow on X-000000?style=for-the-badge&logo=x&logoColor=white" alt="Follow on X" />
+  </a>
+  <a href="https://www.linkedin.com/company/composiohq/">
+    <img src="https://img.shields.io/badge/Follow on LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" alt="Follow on LinkedIn" />
+  </a>
+  <a href="https://discord.com/invite/composio">
+    <img src="https://img.shields.io/badge/Join our Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Join our Discord" />
+  </a>
+  </p>
+</div>
+
+Codex CLIおよびAPI全体のワークフローを自動化するための実用的なCodex Skillの厳選リスト。
+
+---
+
+## ⚡ Skillに実 worldのアクションを提供
+
+SkillはAgentに**どのように**作業するかを指示します。MCP Gatewayは必要なツールへの安全なアクセスを提供します。
+
+Composio [MCP Gateway](https://composio.dev/mcp-gateway)は、1,000以上のアプリ統合に対して、認証、アクセス制御、監査ログを備えた単一のMCPエンドポイントを提供します。
+
+---
+
+## 🚀 クイックスタート: CodexにSkillを追加
+
+### Skill Installerでインストール（推奨）
+
+```bash
+git clone https://github.com/ComposioHQ/awesome-codex-skills.git
+cd awesome-codex-skills
+# 1つ以上のSkillを $CODEX_HOME/skills（デフォルト: ~/.codex/skills）にインストール
+python skill-installer/scripts/install-skill-from-github.py --repo ComposioHQ/awesome-codex-skills --path meeting-notes-and-actions
+```
+
+インストーラーがSkillを取得し、`$CODEX_HOME/skills/<skill-name>`に配置します。Codexを再起動して新しいSkillを読み込みます。
+
+---
+
+## 📚 目次
+
+- [Bernstein](https://github.com/chernistry/bernstein) - Codex CLIアダプター付きマルチエージェントオーケストレーター。
+- [Codex Skillsとは？](#codex-skillsとは)
+- [Skillsリスト](#skillsリスト)
+  - [開発 & コードツール](#開発--コードツール)
+  - [生産性 & コラボレーション](#生産性--コラボレーション)
+  - [コミュニケーション & 執筆](#コミュニケーション--執筆)
+  - [データ & 分析](#データ--分析)
+- [CodexでのSkillの使用](#codexでのskillの使用)
+- [コミュニティに参加](#コミュニティに参加)
+
+---
+
+## ❓ Codex Skillsとは？
+
+Codex Skillsは、Codexにタスクの実行手順を指示するモジュール式の手順パッケージです。各Skillは`SKILL.md`を含む独立したフォルダに保存されます。
+
+---
+
+## 🛠️ Skillsリスト
+
+### 開発 & コードツール
+
+- [codebase-migrate/](../codebase-migrate/) - CI検証付きで大規模なコードベースの移行を実行。
+- [codebase-recon](https://github.com/yujiachen-y/codebase-recon-skill) - git履歴を分析してコードベースの構造を把握。
+- [create-plan/](../create-plan/) - コーディングタスクの実行計画を迅速に作成。
+- [deploy-pipeline/](../deploy-pipeline/) - Stripe → Supabase → Vercel のエンドツーエンドデプロイ。
+- [gh-fix-ci/](../gh-fix-ci/) - 失敗したGitHub Actionsのログを解析して修正案を提示。
+- [mcp-builder/](../mcp-builder/) - ベストプラクティスに基づいてMCPサーバーを構築・評価。
+
+### 生産性 & コラボレーション
+
+- [connect/](../connect/) - Composio CLI経由でCodexを1000+のアプリに接続。
+- [connect-apps/](../connect-apps/) - シェルからComposioアプリの接続を設定。
+- [composio-skills/](../composio-skills/) - Composio統合用の800+の専用自動化Skillにアクセス。
+- [meeting-notes-and-actions/](../meeting-notes-and-actions/) - 会議の文字起こしを要約とアクションアイテムに変換。
+
+---
+
+## 💬 コミュニティに参加
+
+- [Discordに参加](https://discord.com/invite/composio) - 他のデベロッパーと交流。
+- [Xをフォロー](https://twitter.com/composio) - 最新の機能とSkillのアップデート。

--- a/i18n/README.vi.md
+++ b/i18n/README.vi.md
@@ -1,0 +1,136 @@
+<h1 align="center">Awesome Codex Skills (Tiếng Việt)</h1>
+
+<p align="center">
+<a href="https://dashboard.composio.dev/login?utm_source=Github&utm_medium=Youtube&utm_campaign=2025-11&utm_content=AwesomeCodexSkills">
+
+  <img width="1280" height="640" alt="Composio banner" src="../codex_cover_image.png">
+</a>
+</p>
+
+<p align="center">
+  <a href="https://awesome.re">
+    <img src="https://awesome.re/badge.svg" alt="Awesome" />
+  </a>
+  <a href="https://makeapullrequest.com">
+    <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square" alt="PRs Welcome" />
+  </a>
+</p>
+<div>
+<p align="center">
+  <a href="https://twitter.com/composio">
+    <img src="https://img.shields.io/badge/Follow on X-000000?style=for-the-badge&logo=x&logoColor=white" alt="Follow on X" />
+  </a>
+  <a href="https://www.linkedin.com/company/composiohq/">
+    <img src="https://img.shields.io/badge/Follow on LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" alt="Follow on LinkedIn" />
+  </a>
+  <a href="https://discord.com/invite/composio">
+    <img src="https://img.shields.io/badge/Join our Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Join our Discord" />
+  </a>
+  </p>
+</div>
+
+Danh sách tổng hợp các Codex Skills thực tế giúp tự động hóa quy trình làm việc trên Codex CLI và API.
+
+---
+
+## ⚡ Cung cấp khả năng hành động thực tế cho AI Agent của bạn
+
+Skill định nghĩa cho AI Agent biết **CÁCH** làm việc. Một MCP Gateway cung cấp cho nó quyền truy cập an toàn vào các công cụ cần thiết.
+
+Composio [MCP Gateway](https://composio.dev/mcp-gateway) cung cấp một endpoint MCP duy nhất cho 1.000+ tích hợp ứng dụng với tính năng xác thực tích hợp, phân quyền truy cập theo team, nhật ký kiểm toán (audit log) và độ tin cậy chuẩn production.
+
+---
+
+## 🚀 Hướng dẫn nhanh: Thêm Skills vào Codex
+
+### Cài đặt bằng Trình cài đặt Skill (Khuyên dùng)
+
+```bash
+git clone https://github.com/ComposioHQ/awesome-codex-skills.git
+cd awesome-codex-skills
+# Cài đặt một hoặc nhiều skill vào $CODEX_HOME/skills (mặc định là ~/.codex/skills)
+python skill-installer/scripts/install-skill-from-github.py --repo ComposioHQ/awesome-codex-skills --path meeting-notes-and-actions
+```
+
+Trình cài đặt sẽ tải skill về và đặt vào `$CODEX_HOME/skills/<skill-name>`. Khởi động lại Codex để nhận diện các skill mới.
+
+### Cài đặt thủ công
+
+1. Sao chép thư mục skill mong muốn (ví dụ: `./spreadsheet-formula-helper`) vào `$CODEX_HOME/skills/` (mặc định `~/.codex/skills/`).
+2. Khởi động lại Codex để tải metadata mới.
+3. Trong phiên làm việc tiếp theo, hãy mô tả tác vụ hoặc nhắc đến tên skill; Codex sẽ tự động kích hoạt các skill phù hợp dựa trên phần `description` ở frontmatter.
+
+---
+
+## 📚 Mục lục
+
+- [Bernstein](https://github.com/chernistry/bernstein) - Bộ điều phối đa agent với adapter cho Codex CLI. Chạy song song các Codex agent trong các git worktree độc lập có kiểm soát chất lượng.
+- [Codex Skills là gì?](#codex-skills-là-gì)
+- [Danh sách Skills](#danh-sách-skills)
+  - [Công cụ Lập trình & Dev](#công-cụ-lập-trình--dev)
+  - [Năng suất & Cộng tác](#năng-suất--cộng-tác)
+  - [Giao tiếp & Viết lách](#giao-tiếp--viết-lách)
+  - [Dữ liệu & Phân tích](#dữ-liệu--phân-tích)
+  - [Meta & Tiện ích](#meta--tiện-ích)
+- [Cách sử dụng Skills trong Codex](#cách-sử-dụng-skills-trong-codex)
+- [Cách tạo một Skill mới](#cách-tạo-một-skill-mới)
+- [Đóng góp](#đóng-góp)
+- [Tham gia Cộng đồng](#tham-gia-cộng-đồng)
+
+---
+
+## ❓ Codex Skills là gì?
+
+Codex Skills là các gói hướng dẫn mô-đun dạy Codex cách thực hiện một tác vụ theo đúng yêu cầu của bạn. Mỗi skill nằm trong thư mục riêng chứa file `SKILL.md` bao gồm metadata (tên + mô tả) và hướng dẫn thực hiện từng bước. Codex đọc metadata để quyết định khi nào kích hoạt skill và chỉ tải phần nội dung chi tiết sau khi được kích hoạt, giúp giữ cho cửa sổ ngữ cảnh (context window) gọn nhẹ.
+
+---
+
+## 🛠️ Danh sách Skills
+
+### Công cụ Lập trình & Dev
+
+- [brooks-lint](https://github.com/hyhmrright/brooks-lint) - AI code review dựa trên 6 cuốn sách kỹ thuật kinh điển.
+- [bringyour-migration-auditor](https://github.com/unitedideas/bringyour-mcp/tree/main/skills/bringyour-migration-auditor) - Kiểm tra chuyển đổi từ Claude Code sang Codex harness.
+- [codebase-migrate/](../codebase-migrate/) - Chạy refactor và chuyển đổi codebase lớn theo từng đợt có xác nhận CI.
+- [codebase-recon](https://github.com/yujiachen-y/codebase-recon-skill) - Phân tích lịch sử git để hiểu cấu trúc codebase.
+- [create-plan/](../create-plan/) - Nhanh chóng lập kế hoạch thực thi cho các tác vụ lập trình.
+- [deploy-pipeline/](../deploy-pipeline/) - Quy trình phát hành end-to-end từ Stripe → Supabase → Vercel.
+- [gh-address-comments/](../gh-address-comments/) - Xử lý các nhận xét/review trên Pull Request mở bằng `gh`.
+- [gh-fix-ci/](../gh-fix-ci/) - Kiểm tra các check lỗi trên GitHub Actions và đề xuất cách sửa.
+- [mcp-builder/](../mcp-builder/) - Xây dựng và đánh giá các server MCP theo chuẩn best practices.
+- [pr-review-ci-fix/](../pr-review-ci-fix/) - Tự động review PR và sửa lỗi CI qua Composio CLI.
+- [sentry-triage/](../sentry-triage/) - Chẩn đoán lỗi từ Sentry và trỏ trực tiếp đến source code local.
+- [webapp-testing/](../webapp-testing/) - Chạy test ứng dụng web targeted và tóm tắt kết quả.
+
+### Năng suất & Cộng tác
+
+- [connect/](../connect/) - Kết nối Codex với 1.000+ ứng dụng qua Composio CLI (Slack, GitHub, Notion...).
+- [connect-apps/](../connect-apps/) - Cấu hình kết nối ứng dụng Composio từ terminal.
+- [composio-skills/](../composio-skills/) - Truy cập 800+ skill tự động hóa ứng dụng chuyên biệt cho Composio.
+- [issue-triage/](../issue-triage/) - Phân loại backlog Linear/Jira và dọn lỗi từ terminal.
+- [linear/](../linear/) - Quản lý issue, dự án và quy trình làm việc trong Linear.
+- [meeting-notes-and-actions/](../meeting-notes-and-actions/) - Biến bản ghi cuộc họp thành tóm tắt và công việc cần làm.
+- [internal-comms/](../internal-comms/) - Soạn thảo thông báo nội bộ và cập nhật cho bên liên quan.
+- [invoice-organizer/](../invoice-organizer/) - Chuẩn hóa và trích xuất dữ liệu hóa đơn báo cáo.
+- [notion-knowledge-capture/](../notion-knowledge-capture/) - Chuyển đổi cuộc trò chuyện thành trang Notion có cấu trúc.
+- [file-organizer/](../file-organizer/) - Sắp xếp, đổi tên và làm sạch thư mục tập tin.
+
+### Giao tiếp & Viết lách
+
+- [email-draft-polish/](../email-draft-polish/) - Viết lại và chỉnh sửa email theo đúng văn phong.
+- [changelog-generator/](../changelog-generator/) - Tạo changelog rõ ràng từ commits.
+- [content-research-writer/](../content-research-writer/) - Nghiên cứu và soạn thảo nội dung có trích dẫn nguồn.
+- [tailored-resume-generator/](../tailored-resume-generator/) - Tùy chỉnh CV phù hợp với mô tả công việc (JD).
+
+---
+
+## 🤝 Đóng góp
+
+Rất hoan nghênh các Pull Request. Hãy đóng góp các skill thực tế có thể tái sử dụng, giữ mô tả chính xác và kèm theo các script/reference cần thiết.
+
+---
+
+## 💬 Tham gia Cộng đồng
+
+- [Tham gia Discord](https://discord.com/invite/composio) - Trò chuyện với các nhà phát triển khác.
+- [Theo dõi trên X](https://twitter.com/composio) - Cập nhật thông tin skill mới.

--- a/i18n/README.zh-CN.md
+++ b/i18n/README.zh-CN.md
@@ -1,0 +1,129 @@
+<h1 align="center">Awesome Codex Skills (简体中文)</h1>
+
+<p align="center">
+<a href="https://dashboard.composio.dev/login?utm_source=Github&utm_medium=Youtube&utm_campaign=2025-11&utm_content=AwesomeCodexSkills">
+
+  <img width="1280" height="640" alt="Composio banner" src="../codex_cover_image.png">
+</a>
+</p>
+
+<p align="center">
+  <a href="https://awesome.re">
+    <img src="https://awesome.re/badge.svg" alt="Awesome" />
+  </a>
+  <a href="https://makeapullrequest.com">
+    <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square" alt="PRs Welcome" />
+  </a>
+</p>
+<div>
+<p align="center">
+  <a href="https://twitter.com/composio">
+    <img src="https://img.shields.io/badge/Follow on X-000000?style=for-the-badge&logo=x&logoColor=white" alt="Follow on X" />
+  </a>
+  <a href="https://www.linkedin.com/company/composiohq/">
+    <img src="https://img.shields.io/badge/Follow on LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" alt="Follow on LinkedIn" />
+  </a>
+  <a href="https://discord.com/invite/composio">
+    <img src="https://img.shields.io/badge/Join our Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Join our Discord" />
+  </a>
+  </p>
+</div>
+
+精选实用 Codex Skills 列表，用于跨 Codex CLI 和 API 自动化工作流。
+
+---
+
+## ⚡ 赋予您的 Skill 真实世界的行动能力
+
+Skill 告诉您的 Agent **如何**工作。MCP Gateway 为其提供安全访问所需工具的权限。
+
+Composio [MCP Gateway](https://composio.dev/mcp-gateway) 为 1,000+ 应用集成提供单一 MCP 端点，具备内置身份验证、团队访问控制、审计日志和生产级可靠性。
+
+---
+
+## 🚀 快速开始：添加 Skills 到 Codex
+
+### 使用 Skill 安装器安装（推荐）
+
+```bash
+git clone https://github.com/ComposioHQ/awesome-codex-skills.git
+cd awesome-codex-skills
+# 安装一个或多个 skill 到 $CODEX_HOME/skills（默认为 ~/.codex/skills）
+python skill-installer/scripts/install-skill-from-github.py --repo ComposioHQ/awesome-codex-skills --path meeting-notes-and-actions
+```
+
+安装程序会拉取 skill 并放置在 `$CODEX_HOME/skills/<skill-name>`。重启 Codex 以加载新 skill。
+
+### 手动安装
+
+1. 将所需的 skill 文件夹（例如 `./spreadsheet-formula-helper`）复制到 `$CODEX_HOME/skills/`（默认为 `~/.codex/skills/`）。
+2. 重启 Codex 以加载新的元数据。
+3. 在下一次会话中，自然描述任务或提及 skill 名称；Codex 将根据其 `description` 元数据自动触发匹配的 skill。
+
+---
+
+## 📚 目录
+
+- [Bernstein](https://github.com/chernistry/bernstein) - 带 Codex CLI 适配器的多 Agent 编排器。在隔离的 git 工作树中并行运行 Codex agent，并附带质量把控。
+- [什么是 Codex Skills？](#什么是-codex-skills)
+- [Skills 列表](#skills-列表)
+  - [开发与代码工具](#开发与代码工具)
+  - [生产力与协作](#生产力与协作)
+  - [沟通与写作](#沟通与写作)
+  - [数据与分析](#数据与分析)
+  - [Meta 与实用工具](#meta-与实用工具)
+- [在 Codex 中使用 Skills](#在-codex-中使用-skills)
+- [创建 Skills](#创建-skills)
+- [贡献](#贡献)
+- [加入社区](#加入社区)
+
+---
+
+## ❓ 什么是 Codex Skills？
+
+Codex skills 是模块化的指令包，告诉 Codex 如何按照您期望的方式执行任务。每个 skill 存在于独立文件夹中，包含一个 `SKILL.md`（附带名称+描述元数据及逐步指导）。Codex 读取元数据以决定何时触发 skill，并仅在触发后加载主体内容，保持上下文高效简洁。
+
+---
+
+## 🛠️ Skills 列表
+
+### 开发与代码工具
+
+- [brooks-lint](https://github.com/hyhmrright/brooks-lint) - 基于 6 本经典工程书籍的 AI 代码审查。
+- [bringyour-migration-auditor](https://github.com/unitedideas/bringyour-mcp/tree/main/skills/bringyour-migration-auditor) - 审查从 Claude Code 到 Codex harness 的迁移。
+- [codebase-migrate/](../codebase-migrate/) - 带 CI 验证的大型代码库重构与迁移。
+- [codebase-recon](https://github.com/yujiachen-y/codebase-recon-skill) - 分析 git 历史以深入理解代码库结构。
+- [create-plan/](../create-plan/) - 快速草拟编码任务的简明执行计划。
+- [deploy-pipeline/](../deploy-pipeline/) - 从 Stripe → Supabase → Vercel 的端到端发布流水线。
+- [gh-address-comments/](../gh-address-comments/) - 使用 `gh` 处理 open PR 上的审查意见。
+- [gh-fix-ci/](../gh-fix-ci/) - 检查 GitHub Actions 失败项并提供修复建议。
+- [mcp-builder/](../mcp-builder/) - 构建与评估符合最佳实践的 MCP 服务器。
+- [pr-review-ci-fix/](../pr-review-ci-fix/) - 通过 Composio CLI 实现自动 PR 审查与 CI 自动修复循环。
+- [sentry-triage/](../sentry-triage/) - 诊断 Sentry 问题并映射至本地源码。
+- [webapp-testing/](../webapp-testing/) - 运行针对性的 Web 应用测试并总结结果。
+
+### 生产力与协作
+
+- [connect/](../connect/) - 通过 Composio CLI 将 Codex 连接至 1000+ 应用（Slack, GitHub, Notion 等）。
+- [connect-apps/](../connect-apps/) - 从终端配置 Composio 应用连接。
+- [composio-skills/](../composio-skills/) - 访问 800+ 针对 Composio 集成的应用自动化 skill。
+- [issue-triage/](../issue-triage/) - 分类 Linear/Jira 积压工作并在终端清理 bug。
+- [linear/](../linear/) - 在 Linear 中管理 Issue、项目和团队工作流。
+- [meeting-notes-and-actions/](../meeting-notes-and-actions/) - 将会议记录转为带行动项的总结。
+- [internal-comms/](../internal-comms/) - 撰写内部公告与干系人更新。
+- [invoice-organizer/](../invoice-organizer/) - 规范并提取发票数据用于跟踪与报告。
+- [notion-knowledge-capture/](../notion-knowledge-capture/) - 将对话或笔记转化为结构化的 Notion 页面。
+- [file-organizer/](../file-organizer/) - 整理、重命名并清理文件，保持工作区整洁。
+
+---
+
+## 🤝 贡献
+
+非常欢迎提交 PR。请添加真实、可复用的 skill，保持描述准确，并包含所需的脚本或参考资料。
+
+---
+
+## 💬 加入社区
+
+- [加入 Discord](https://discord.com/invite/composio) - 与其他构建 Codex skill 的开发者交流。
+- [在 X 上关注我们](https://twitter.com/composio) - 获取最新 skill 和功能更新。


### PR DESCRIPTION
### What this PR does

- Adds Chinese (\i18n/README.zh-CN.md\) and Japanese (\i18n/README.ja-JP.md\) documentation translations.
- Updates the language navigation switcher at the top of \README.md\ (\🌐 English\ • \🇻🇳 Tiếng Việt\ • \🇨🇳 中文\ • \🇯🇵 日本語\).