### PR TITLE
feat: Add Universal AI Clipboard Vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [Universal AI Clipboard Vision](https://github.com/1himanshu1804442/antigravity-clipboard-vision) - Zero-click Windows clipboard image inspection and multi-screenshot visual debugging for Codex, Claude Code, and Antigravity CLI sessions without manually saving files. Includes self-cleaning cache and universal installer.
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
### Summary
Adds **Universal AI Clipboard Vision** to the **Development & Code Tools** list.

### Description
Enables zero-click image inspection and multi-screenshot visual debugging directly from the native Windows system clipboard (Win + Shift + S) across Codex, Claude Code, and Antigravity CLI sessions without manually saving files. Includes an automated multi-AI installer and self-cleaning cache.