### PR TITLE
Add review-ui-design to Meta & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [agent-deep-links/](./agent-deep-links/) - Build and validate deep links for Codex, Cursor, and VS Code with Slack-safe formatting and fallback guidance.
 - [canvas-design/](./canvas-design/) - Generate structured canvas layouts and design artifacts.
 - [image-enhancer/](./image-enhancer/) - Upscale and refine images with configurable presets.
+- [review-ui-design](https://github.com/guoxuyee-create/Review-ui-design) - Read-only, evidence-based reviews of Web, iOS, and Android screenshots or Figma nodes, with prioritized findings, annotated evidence, actionable fixes, and verification steps. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo guoxuyee-create/Review-ui-design --path . --name review-ui-design`
 - [slack-gif-creator/](./slack-gif-creator/) - Generate GIFs for Slack with captions and styling.
 - [theme-factory/](./theme-factory/) - Create reusable theme tokens and palettes.
 - [video-downloader/](./video-downloader/) - Download and prepare videos for offline review.


### PR DESCRIPTION
## Summary

Adds `review-ui-design` under **Skills → Meta & Utilities**.

`review-ui-design` is a read-only Codex skill for evidence-based UI reviews of Web, iOS, and Android screenshots and Figma nodes. It reports prioritized findings with traceable evidence, confidence levels, actionable fixes, and verification steps without modifying the source design.

Repository: https://github.com/guoxuyee-create/Review-ui-design  
Release: https://github.com/guoxuyee-create/Review-ui-design/releases/tag/v1.0.0

## Why it fits

- Public, reusable Codex skill with a root-level `SKILL.md`.
- Includes `name` and `description` frontmatter.
- Supports screenshot and Figma inputs across Web, iOS, and Android.
- Reviews existing interfaces instead of generating or modifying designs.
- Includes focused references and deterministic validation/rendering scripts.
- MIT licensed and released as `v1.0.0`.

## Validation

- [x] Repository and `SKILL.md` are publicly accessible.
- [x] Install command targets the repository root with `--path .`.
- [x] Entry follows the existing external-repository format.
- [x] Entry is placed under Meta & Utilities.
- [x] `git diff --check` passes.

Disclosure: first-party submission by the repository owner.
