### PR TITLE
Add skill: morluto/rea

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [REA](https://github.com/morluto/rea/tree/main/skills/reverse-engineer-anything) - Reverse-engineer native, managed, Electron/JavaScript, packaged, and browser applications with REA's local CLI and MCP tools.
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
## Summary

Adds [REA's reverse-engineer-anything skill](https://github.com/morluto/rea/tree/main/skills/reverse-engineer-anything) to Development & Code Tools.

The skill gives Codex a documented workflow for reverse engineering native binaries, managed applications, Electron/JavaScript packages, and browser runtimes with REA's local CLI and MCP tools. This PR links the existing public skill instead of copying its files into the list.

## Checks

- Confirmed the link resolves to the public skill directory.
- Checked the current README and GitHub issues/PRs for a duplicate REA entry.
- Kept the change to one README entry.