### PR TITLE
Add codex-obsidian-workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 
 - [connect/](./connect/) - Connect Codex to 1000+ apps via the Composio CLI for real actions (Slack, GitHub, Notion, etc.).
 - [connect-apps/](./connect-apps/) - Wire up Composio CLI connections for Claude and kick off app workflows from the shell.
+- [codex-obsidian-workflow](https://github.com/white638/codex-obsidian-workflow) - Local-first Codex Agent Skill for incrementally ingesting, progressively retrieving, and auditing existing Obsidian vaults across Markdown, Bases, and JSON Canvas, with opt-in redacted Codex history. Install: `git clone https://github.com/white638/codex-obsidian-workflow.git "${CODEX_HOME:-$HOME/.codex}/skills/obsidian-knowledge"`
 - [issue-triage/](./issue-triage/) - Triage Linear or Jira backlogs and run bug sweeps from the terminal.
 - [linear/](./linear/) - Manage issues, projects, and team workflows in Linear.
 - [meeting-insights-analyzer/](./meeting-insights-analyzer/) - Analyze meeting transcripts for themes, risks, and follow-ups.


### PR DESCRIPTION
## Summary

Adds [codex-obsidian-workflow](https://github.com/white638/codex-obsidian-workflow) to Productivity & Collaboration as an external Codex Agent Skill.

## Why it fits

- Maintains existing Obsidian vaults with a local-first workflow
- Covers Markdown, Bases, JSON Canvas, incremental ingestion, progressive retrieval, and structural audit
- Keeps Codex history extraction opt-in and redacted
- Uses Python 3.8+ with no third-party runtime dependencies

## Verification

- Public MIT-licensed repository
- Published v0.1.0 release
- Green GitHub Actions validation on Python 3.8 and 3.13
- Entry includes a direct installation command targeting the installed skill name