### PR TITLE
Add WeChat MP Downloader skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 
 ### Data & Analysis
 
+- [wechat-mp-downloader](https://github.com/KKK25843/wechat-mp-downloader-skill) - Archive 1-20 WeChat Official Accounts over a date range as Markdown with local images, title filters, resumable state, and no cookie export. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo KKK25843/wechat-mp-downloader-skill --path skills/wechat-mp-downloader --name wechat-mp-downloader`
 - [spreadsheet-formula-helper/](./spreadsheet-formula-helper/) - Write and debug spreadsheet formulas, pivots, and array formulas.
 - [competitive-ads-extractor/](./competitive-ads-extractor/) - Analyze competitor ads and extract structured insights.
 - [datadog-logs/](./datadog-logs/) - Filter Datadog logs from the shell via the Composio CLI, with JSON-friendly output and digest workflows.


### PR DESCRIPTION
## Summary

- add the external `wechat-mp-downloader` skill under Data & Analysis
- include a reproducible Codex Skill Installer command

## Why it is useful

The skill archives 1-20 WeChat Official Accounts over a shared date range as Markdown with local images. It supports manifest validation, title preview and keyword filtering, resumable state, and keeps authentication in the user's existing browser session without exporting cookies or automating CAPTCHA.

The project is MIT licensed and its offline compatibility suite covers macOS, Windows, and Linux on Python 3.10 and 3.13.

## Validation

- `git diff --check`
- verified that the documented Skill Installer accepts `--repo`, `--path`, and `--name`
