### PR TITLE
docs: add Agent Legion Command skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [Agent Legion Command](https://github.com/skbylife/agent-legion-command) - Coordinate parallel Codex worktrees with frozen baselines, exclusive mutable scopes, source evidence, serialized integration, and independent candidate verification. Install: `npx skills add skbylife/agent-legion-command --skill agent-legion-command --agent codex --copy -y`
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
## Summary

Adds Agent Legion Command to Development & Code Tools as a narrow Codex skill for coordinating parallel Git worktrees.

## Why it fits

The skill provides frozen baselines, exclusive mutable scopes, source evidence, serialized integration, and independent candidate verification for multi-contributor coding campaigns.

## Validation

- `npx skills add skbylife/agent-legion-command --skill agent-legion-command --agent codex claude-code --copy -y` completed in a fresh Git repository.
- Codex CLI loaded the Skills CLI project install and returned its unique installed marker plus the first campaign action.
- The repository has a public `v0.1.0` release and standalone `SKILL.md` metadata.
