### PR TITLE
Add internalcot to Meta & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [template-skill/](./template-skill/) - Starter template for building new skills.
 - [skill-installer/](./skill-installer/) - Helper scripts to install skills from curated lists or GitHub paths.
 - [skill-creator/](./skill-creator/) - Guidance for building effective Codex skills with progressive disclosure.
+- [internalcot](https://github.com/morluto/internalcot) - Makes agent reasoning visible as persistent working notes throughout a Codex or Claude Code conversation using an opt-in skill and local CLI. Install: `npx internalcot@latest setup`.
 
 ## Using Skills in Codex
 


### PR DESCRIPTION
Adds [internalcot](https://github.com/morluto/internalcot) under **Meta & Utilities**.

internalcot is an opt-in skill plus local CLI that asks Codex or Claude Code to record persistent visible working notes throughout a conversation. The linked repository remains the canonical source and provides installation through `npx internalcot@latest setup`.

Validation:

- `git diff --check`
- Canonical repository link returns HTTP 200
- Confirmed there was no existing internalcot entry